### PR TITLE
renamed normalizing, stem and delimiter analyzers

### DIFF
--- a/core/analysis/delimited_token_stream.cpp
+++ b/core/analysis/delimited_token_stream.cpp
@@ -147,7 +147,7 @@ NS_END
 NS_ROOT
 NS_BEGIN(analysis)
 
-DEFINE_ANALYZER_TYPE_NAMED(delimited_token_stream, "delimited")
+DEFINE_ANALYZER_TYPE_NAMED(delimited_token_stream, "delimiter")
 
 delimited_token_stream::delimited_token_stream(const string_ref& delimiter)
   : analyzer(delimited_token_stream::type()),

--- a/core/analysis/text_token_normalizing_stream.cpp
+++ b/core/analysis/text_token_normalizing_stream.cpp
@@ -204,7 +204,7 @@ NS_END
 NS_ROOT
 NS_BEGIN(analysis)
 
-DEFINE_ANALYZER_TYPE_NAMED(text_token_normalizing_stream, "text-token-normalize")
+DEFINE_ANALYZER_TYPE_NAMED(text_token_normalizing_stream, "norm")
 
 text_token_normalizing_stream::text_token_normalizing_stream(
     const options_t& options

--- a/core/analysis/text_token_stemming_stream.cpp
+++ b/core/analysis/text_token_stemming_stream.cpp
@@ -104,7 +104,7 @@ NS_END
 NS_ROOT
 NS_BEGIN(analysis)
 
-DEFINE_ANALYZER_TYPE_NAMED(text_token_stemming_stream, "text-token-stem")
+DEFINE_ANALYZER_TYPE_NAMED(text_token_stemming_stream, "stem")
 
 text_token_stemming_stream::text_token_stemming_stream(
     const irs::string_ref& locale

--- a/tests/analysis/delimited_token_stream_tests.cpp
+++ b/tests/analysis/delimited_token_stream_tests.cpp
@@ -244,7 +244,7 @@ TEST_F(delimited_token_stream_tests, test_quote) {
       testFunc(data, &stream);
     }
     {
-      auto stream = irs::analysis::analyzers::get("delimited", irs::text_format::json, "{\"delimiter\":\",\"}");
+      auto stream = irs::analysis::analyzers::get("delimiter", irs::text_format::json, "{\"delimiter\":\",\"}");
       testFunc(data, stream.get());
     }
   }
@@ -372,7 +372,7 @@ TEST_F(delimited_token_stream_tests, test_load) {
   // load jSON string
   {
     irs::string_ref data("abc,def,ghi"); // quoted terms should be honoured
-    auto stream = irs::analysis::analyzers::get("delimited", irs::text_format::json, "\",\"");
+    auto stream = irs::analysis::analyzers::get("delimiter", irs::text_format::json, "\",\"");
 
     ASSERT_NE(nullptr, stream);
     ASSERT_TRUE(stream->reset(data));
@@ -402,7 +402,7 @@ TEST_F(delimited_token_stream_tests, test_load) {
   // load jSON object
   {
     irs::string_ref data("abc,def,ghi"); // quoted terms should be honoured
-    auto stream = irs::analysis::analyzers::get("delimited", irs::text_format::json, "{\"delimiter\":\",\"}");
+    auto stream = irs::analysis::analyzers::get("delimiter", irs::text_format::json, "{\"delimiter\":\",\"}");
 
     ASSERT_NE(nullptr, stream);
     ASSERT_TRUE(stream->reset(data));
@@ -431,17 +431,17 @@ TEST_F(delimited_token_stream_tests, test_load) {
 
   // load jSON invalid
   {
-    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("delimited", irs::text_format::json, irs::string_ref::NIL));
-    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("delimited", irs::text_format::json, "1"));
-    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("delimited", irs::text_format::json, "[]"));
-    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("delimited", irs::text_format::json, "{}"));
-    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("delimited", irs::text_format::json, "{\"delimiter\":1}"));
+    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("delimiter", irs::text_format::json, irs::string_ref::NIL));
+    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("delimiter", irs::text_format::json, "1"));
+    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("delimiter", irs::text_format::json, "[]"));
+    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("delimiter", irs::text_format::json, "{}"));
+    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("delimiter", irs::text_format::json, "{\"delimiter\":1}"));
   }
 
   // load text
   {
     irs::string_ref data("abc,def,ghi"); // quoted terms should be honoured
-    auto stream = irs::analysis::analyzers::get("delimited", irs::text_format::text, ",");
+    auto stream = irs::analysis::analyzers::get("delimiter", irs::text_format::text, ",");
 
     ASSERT_NE(nullptr, stream);
     ASSERT_TRUE(stream->reset(data));

--- a/tests/analysis/text_token_normalizing_stream_tests.cpp
+++ b/tests/analysis/text_token_normalizing_stream_tests.cpp
@@ -153,7 +153,7 @@ TEST_F(text_token_normalizing_stream_tests, test_load) {
   // load jSON string
   {
     irs::string_ref data("running");
-    auto stream = irs::analysis::analyzers::get("text-token-normalize", irs::text_format::json, "\"en\"");
+    auto stream = irs::analysis::analyzers::get("norm", irs::text_format::json, "\"en\"");
 
     ASSERT_NE(nullptr, stream);
     ASSERT_TRUE(stream->reset(data));
@@ -173,7 +173,7 @@ TEST_F(text_token_normalizing_stream_tests, test_load) {
   // load jSON object
   {
     irs::string_ref data("running");
-    auto stream = irs::analysis::analyzers::get("text-token-normalize", irs::text_format::json, "{\"locale\":\"en\"}");
+    auto stream = irs::analysis::analyzers::get("norm", irs::text_format::json, "{\"locale\":\"en\"}");
 
     ASSERT_NE(nullptr, stream);
     ASSERT_TRUE(stream->reset(data));
@@ -193,7 +193,7 @@ TEST_F(text_token_normalizing_stream_tests, test_load) {
   // with UPPER case 
   {
     irs::string_ref data("ruNNing");
-    auto stream = irs::analysis::analyzers::get("text-token-normalize", irs::text_format::json, "{\"locale\":\"en\", \"caseConvert\":\"upper\"}");
+    auto stream = irs::analysis::analyzers::get("norm", irs::text_format::json, "{\"locale\":\"en\", \"caseConvert\":\"upper\"}");
 
     ASSERT_NE(nullptr, stream);
     ASSERT_TRUE(stream->reset(data));
@@ -213,7 +213,7 @@ TEST_F(text_token_normalizing_stream_tests, test_load) {
   // with LOWER case 
   {
     irs::string_ref data("ruNNing");
-    auto stream = irs::analysis::analyzers::get("text-token-normalize", irs::text_format::json, "{\"locale\":\"en\", \"caseConvert\":\"lower\"}");
+    auto stream = irs::analysis::analyzers::get("norm", irs::text_format::json, "{\"locale\":\"en\", \"caseConvert\":\"lower\"}");
 
     ASSERT_NE(nullptr, stream);
     ASSERT_TRUE(stream->reset(data));
@@ -233,7 +233,7 @@ TEST_F(text_token_normalizing_stream_tests, test_load) {
   // with NONE case 
   {
     irs::string_ref data("ruNNing");
-    auto stream = irs::analysis::analyzers::get("text-token-normalize", irs::text_format::json, "{\"locale\":\"en\", \"caseConvert\":\"none\"}");
+    auto stream = irs::analysis::analyzers::get("norm", irs::text_format::json, "{\"locale\":\"en\", \"caseConvert\":\"none\"}");
 
     ASSERT_NE(nullptr, stream);
     ASSERT_TRUE(stream->reset(data));
@@ -258,7 +258,7 @@ TEST_F(text_token_normalizing_stream_tests, test_load) {
     auto locale = irs::locale_utils::locale(irs::string_ref::NIL, "utf8", true); 
     ASSERT_TRUE(irs::locale_utils::append_external<wchar_t>(data, unicodeData, locale));
     
-    auto stream = irs::analysis::analyzers::get("text-token-normalize", irs::text_format::json, "{\"locale\":\"de_DE.UTF8\", \"caseConvert\":\"lower\", \"noAccent\":true}");
+    auto stream = irs::analysis::analyzers::get("norm", irs::text_format::json, "{\"locale\":\"de_DE.UTF8\", \"caseConvert\":\"lower\", \"noAccent\":true}");
    
     ASSERT_NE(nullptr, stream);
     ASSERT_TRUE(stream->reset(data));
@@ -281,19 +281,19 @@ TEST_F(text_token_normalizing_stream_tests, test_load) {
 
   // load jSON invalid
   {
-    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("text-token-normalize", irs::text_format::json, irs::string_ref::NIL));
-    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("text-token-normalize", irs::text_format::json, "1"));
-    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("text-token-normalize", irs::text_format::json, "[]"));
-    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("text-token-normalize", irs::text_format::json, "{}"));
-    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("text-token-normalize", irs::text_format::json, "{\"locale\":1}"));
-    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("text-token-normalize", irs::text_format::json, "{\"locale\":\"en\", \"caseConvert\":42}"));
-    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("text-token-normalize", irs::text_format::json, "{\"locale\":\"en\", \"noAccent\":42}"));
+    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("norm", irs::text_format::json, irs::string_ref::NIL));
+    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("norm", irs::text_format::json, "1"));
+    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("norm", irs::text_format::json, "[]"));
+    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("norm", irs::text_format::json, "{}"));
+    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("norm", irs::text_format::json, "{\"locale\":1}"));
+    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("norm", irs::text_format::json, "{\"locale\":\"en\", \"caseConvert\":42}"));
+    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("norm", irs::text_format::json, "{\"locale\":\"en\", \"noAccent\":42}"));
   }
 
   // load text
   {
     irs::string_ref data("running");
-    auto stream = irs::analysis::analyzers::get("text-token-normalize", irs::text_format::text, "en");
+    auto stream = irs::analysis::analyzers::get("norm", irs::text_format::text, "en");
 
     ASSERT_NE(nullptr, stream);
     ASSERT_TRUE(stream->reset(data));

--- a/tests/analysis/text_token_stemming_stream_tests.cpp
+++ b/tests/analysis/text_token_stemming_stream_tests.cpp
@@ -111,7 +111,7 @@ TEST_F(text_token_stemming_stream_tests, test_load) {
   // load jSON string
   {
     irs::string_ref data("running");
-    auto stream = irs::analysis::analyzers::get("text-token-stem", irs::text_format::json, "\"en\"");
+    auto stream = irs::analysis::analyzers::get("stem", irs::text_format::json, "\"en\"");
 
     ASSERT_NE(nullptr, stream);
     ASSERT_TRUE(stream->reset(data));
@@ -131,7 +131,7 @@ TEST_F(text_token_stemming_stream_tests, test_load) {
   // load jSON object
   {
     irs::string_ref data("running");
-    auto stream = irs::analysis::analyzers::get("text-token-stem", irs::text_format::json, "{\"locale\":\"en\"}");
+    auto stream = irs::analysis::analyzers::get("stem", irs::text_format::json, "{\"locale\":\"en\"}");
 
     ASSERT_NE(nullptr, stream);
     ASSERT_TRUE(stream->reset(data));
@@ -150,17 +150,17 @@ TEST_F(text_token_stemming_stream_tests, test_load) {
 
   // load jSON invalid
   {
-    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("text-token-stem", irs::text_format::json, irs::string_ref::NIL));
-    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("text-token-stem", irs::text_format::json, "1"));
-    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("text-token-stem", irs::text_format::json, "[]"));
-    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("text-token-stem", irs::text_format::json, "{}"));
-    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("text-token-stem", irs::text_format::json, "{\"locale\":1}"));
+    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("stem", irs::text_format::json, irs::string_ref::NIL));
+    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("stem", irs::text_format::json, "1"));
+    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("stem", irs::text_format::json, "[]"));
+    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("stem", irs::text_format::json, "{}"));
+    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("stem", irs::text_format::json, "{\"locale\":1}"));
   }
 
   // load text
   {
     irs::string_ref data("running");
-    auto stream = irs::analysis::analyzers::get("text-token-stem", irs::text_format::text, "en");
+    auto stream = irs::analysis::analyzers::get("stem", irs::text_format::text, "en");
 
     ASSERT_NE(nullptr, stream);
     ASSERT_TRUE(stream->reset(data));

--- a/tests/index/doc_generator.cpp
+++ b/tests/index/doc_generator.cpp
@@ -313,7 +313,7 @@ csv_doc_generator::csv_doc_generator(
     const irs::utf8_path& file, doc_template& doc
 ): doc_(doc),
    ifs_(file.native(), std::ifstream::in | std::ifstream::binary),
-   stream_(irs::analysis::analyzers::get("delimited", irs::text_format::text, ",")) {
+   stream_(irs::analysis::analyzers::get("delimiter", irs::text_format::text, ",")) {
   doc_.init();
   doc_.reset();
 }


### PR DESCRIPTION
"text-token-stem"->"stem"
"text-token-normalize"->"norm"
"delimited"->"delimiter"

https://jenkins01.arangodb.biz/view/PR/job/iresearch_s-pr/13/