### PR TITLE
Feature add analyzer config to_string

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -361,12 +361,12 @@ add_dependencies(${IResearch_TARGET_NAME}-shared
 add_dependencies(${IResearch_TARGET_NAME}-static
   ${IResearch_TARGET_NAME}-build_identifier
   ${IResearch_TARGET_NAME}-build_version
-  ${IResearch_TARGET_NAME}-analyzer-delimited-static
+  ${IResearch_TARGET_NAME}-analyzer-delimiter-static
   ${IResearch_TARGET_NAME}-analyzer-ngram-static
   ${IResearch_TARGET_NAME}-analyzer-text-static
-  ${IResearch_TARGET_NAME}-analyzer-text-normalizing-static
-  ${IResearch_TARGET_NAME}-analyzer-text-stemming-static
-  ${IResearch_TARGET_NAME}-analyzer-token-masking-static
+  ${IResearch_TARGET_NAME}-analyzer-norm-static
+  ${IResearch_TARGET_NAME}-analyzer-stem-static
+  ${IResearch_TARGET_NAME}-analyzer-mask-static
   ${IResearch_TARGET_NAME}-format-1_0-static
   ${IResearch_TARGET_NAME}-scorer-tfidf-static
   ${IResearch_TARGET_NAME}-scorer-bm25-static
@@ -382,12 +382,12 @@ if(MSVC)
   add_dependencies(${IResearch_TARGET_NAME}-static-scrt
     ${IResearch_TARGET_NAME}-build_identifier
     ${IResearch_TARGET_NAME}-build_version
-    ${IResearch_TARGET_NAME}-analyzer-delimited-static-scrt
+    ${IResearch_TARGET_NAME}-analyzer-delimiter-static-scrt
     ${IResearch_TARGET_NAME}-analyzer-ngram-static-scrt
     ${IResearch_TARGET_NAME}-analyzer-text-static-scrt
-    ${IResearch_TARGET_NAME}-analyzer-text-normalizing-static-scrt
-    ${IResearch_TARGET_NAME}-analyzer-text-stemming-static-scrt
-    ${IResearch_TARGET_NAME}-analyzer-token-masking-static-scrt
+    ${IResearch_TARGET_NAME}-analyzer-norm-static-scrt
+    ${IResearch_TARGET_NAME}-analyzer-stem-static-scrt
+    ${IResearch_TARGET_NAME}-analyzer-mask-static-scrt
     ${IResearch_TARGET_NAME}-format-1_0-static-scrt
     ${IResearch_TARGET_NAME}-scorer-tfidf-static-scrt
     ${IResearch_TARGET_NAME}-scorer-bm25-static-scrt
@@ -503,12 +503,12 @@ target_link_libraries(${IResearch_TARGET_NAME}-shared
 )
 
 target_link_libraries(${IResearch_TARGET_NAME}-static
-  ${IResearch_TARGET_NAME}-analyzer-delimited-static
+  ${IResearch_TARGET_NAME}-analyzer-delimiter-static
   ${IResearch_TARGET_NAME}-analyzer-ngram-static
   ${IResearch_TARGET_NAME}-analyzer-text-static
-  ${IResearch_TARGET_NAME}-analyzer-text-normalizing-static
-  ${IResearch_TARGET_NAME}-analyzer-text-stemming-static
-  ${IResearch_TARGET_NAME}-analyzer-token-masking-static
+  ${IResearch_TARGET_NAME}-analyzer-norm-static
+  ${IResearch_TARGET_NAME}-analyzer-stem-static
+  ${IResearch_TARGET_NAME}-analyzer-mask-static
   ${IResearch_TARGET_NAME}-format-1_0-static
   ${IResearch_TARGET_NAME}-scorer-bm25-static
   ${IResearch_TARGET_NAME}-scorer-tfidf-static
@@ -537,12 +537,12 @@ if(MSVC)
   )
 
   target_link_libraries(${IResearch_TARGET_NAME}-static-scrt
-    ${IResearch_TARGET_NAME}-analyzer-delimited-static-scrt
+    ${IResearch_TARGET_NAME}-analyzer-delimiter-static-scrt
     ${IResearch_TARGET_NAME}-analyzer-ngram-static-scrt
     ${IResearch_TARGET_NAME}-analyzer-text-static-scrt
-    ${IResearch_TARGET_NAME}-analyzer-text-normalizing-static-scrt
-    ${IResearch_TARGET_NAME}-analyzer-text-stemming-static-scrt
-    ${IResearch_TARGET_NAME}-analyzer-token-masking-static-scrt
+    ${IResearch_TARGET_NAME}-analyzer-norm-static-scrt
+    ${IResearch_TARGET_NAME}-analyzer-stem-static-scrt
+    ${IResearch_TARGET_NAME}-analyzer-mask-static-scrt
     ${IResearch_TARGET_NAME}-format-1_0-static-scrt
     ${IResearch_TARGET_NAME}-scorer-bm25-static-scrt
     ${IResearch_TARGET_NAME}-scorer-tfidf-static-scrt
@@ -569,12 +569,12 @@ if (MSVC)
     "$<TARGET_FILE:icuuc-static>"   # must expand icu-static into components
     "$<TARGET_FILE:lz4_static>"
     "$<TARGET_FILE:stemmer-static>"
-    "$<TARGET_FILE:${IResearch_TARGET_NAME}-analyzer-delimited-static>"
+    "$<TARGET_FILE:${IResearch_TARGET_NAME}-analyzer-delimiter-static>"
     "$<TARGET_FILE:${IResearch_TARGET_NAME}-analyzer-ngram-static>"
     "$<TARGET_FILE:${IResearch_TARGET_NAME}-analyzer-text-static>"
-    "$<TARGET_FILE:${IResearch_TARGET_NAME}-analyzer-text-normalizing-static>"
-    "$<TARGET_FILE:${IResearch_TARGET_NAME}-analyzer-text-stemming-static>"
-    "$<TARGET_FILE:${IResearch_TARGET_NAME}-analyzer-token-masking-static>"
+    "$<TARGET_FILE:${IResearch_TARGET_NAME}-analyzer-norm-static>"
+    "$<TARGET_FILE:${IResearch_TARGET_NAME}-analyzer-stem-static>"
+    "$<TARGET_FILE:${IResearch_TARGET_NAME}-analyzer-mask-static>"
     "$<TARGET_FILE:${IResearch_TARGET_NAME}-format-1_0-static>"
     "$<TARGET_FILE:${IResearch_TARGET_NAME}-scorer-tfidf-static>"
     "$<TARGET_FILE:${IResearch_TARGET_NAME}-scorer-bm25-static>"
@@ -630,12 +630,12 @@ if (MSVC)
     "$<TARGET_FILE:icuuc-static>"   # must expand icu-static into components
     "$<TARGET_FILE:lz4_static>"
     "$<TARGET_FILE:stemmer-static>"
-    "$<TARGET_FILE:${IResearch_TARGET_NAME}-analyzer-delimited-static-scrt>"
+    "$<TARGET_FILE:${IResearch_TARGET_NAME}-analyzer-delimiter-static-scrt>"
     "$<TARGET_FILE:${IResearch_TARGET_NAME}-analyzer-ngram-static-scrt>"
     "$<TARGET_FILE:${IResearch_TARGET_NAME}-analyzer-text-static-scrt>"
-    "$<TARGET_FILE:${IResearch_TARGET_NAME}-analyzer-text-normalizing-static>"
-    "$<TARGET_FILE:${IResearch_TARGET_NAME}-analyzer-text-stemming-static>"
-    "$<TARGET_FILE:${IResearch_TARGET_NAME}-analyzer-token-masking-static>"
+    "$<TARGET_FILE:${IResearch_TARGET_NAME}-analyzer-norm-static>"
+    "$<TARGET_FILE:${IResearch_TARGET_NAME}-analyzer-stem-static>"
+    "$<TARGET_FILE:${IResearch_TARGET_NAME}-analyzer-mask-static>"
     "$<TARGET_FILE:${IResearch_TARGET_NAME}-format-1_0-static-scrt>"
     "$<TARGET_FILE:${IResearch_TARGET_NAME}-scorer-tfidf-static-scrt>"
     "$<TARGET_FILE:${IResearch_TARGET_NAME}-scorer-bm25-static-scrt>"
@@ -692,12 +692,12 @@ elseif (APPLE)
     "$<TARGET_FILE:icuuc-static>"   # must expand icu-static into components
     "$<TARGET_FILE:lz4_static>"
     "$<TARGET_FILE:stemmer-static>"
-    "$<TARGET_FILE:${IResearch_TARGET_NAME}-analyzer-delimited-static>"
+    "$<TARGET_FILE:${IResearch_TARGET_NAME}-analyzer-delimiter-static>"
     "$<TARGET_FILE:${IResearch_TARGET_NAME}-analyzer-ngram-static>"
     "$<TARGET_FILE:${IResearch_TARGET_NAME}-analyzer-text-static>"
-    "$<TARGET_FILE:${IResearch_TARGET_NAME}-analyzer-text-normalizing-static>"
-    "$<TARGET_FILE:${IResearch_TARGET_NAME}-analyzer-text-stemming-static>"
-    "$<TARGET_FILE:${IResearch_TARGET_NAME}-analyzer-token-masking-static>"
+    "$<TARGET_FILE:${IResearch_TARGET_NAME}-analyzer-norm-static>"
+    "$<TARGET_FILE:${IResearch_TARGET_NAME}-analyzer-stem-static>"
+    "$<TARGET_FILE:${IResearch_TARGET_NAME}-analyzer-mask-static>"
     "$<TARGET_FILE:${IResearch_TARGET_NAME}-format-1_0-static>"
     "$<TARGET_FILE:${IResearch_TARGET_NAME}-scorer-tfidf-static>"
     "$<TARGET_FILE:${IResearch_TARGET_NAME}-scorer-bm25-static>"
@@ -753,12 +753,12 @@ else()
     "$<TARGET_FILE:icuuc-static>"   # must expand icu-static into components
     "$<TARGET_FILE:lz4_static>"
     "$<TARGET_FILE:stemmer-static>"
-    "$<TARGET_FILE:${IResearch_TARGET_NAME}-analyzer-delimited-static>"
+    "$<TARGET_FILE:${IResearch_TARGET_NAME}-analyzer-delimiter-static>"
     "$<TARGET_FILE:${IResearch_TARGET_NAME}-analyzer-ngram-static>"
     "$<TARGET_FILE:${IResearch_TARGET_NAME}-analyzer-text-static>"
-    "$<TARGET_FILE:${IResearch_TARGET_NAME}-analyzer-text-normalizing-static>"
-    "$<TARGET_FILE:${IResearch_TARGET_NAME}-analyzer-text-stemming-static>"
-    "$<TARGET_FILE:${IResearch_TARGET_NAME}-analyzer-token-masking-static>"
+    "$<TARGET_FILE:${IResearch_TARGET_NAME}-analyzer-norm-static>"
+    "$<TARGET_FILE:${IResearch_TARGET_NAME}-analyzer-stem-static>"
+    "$<TARGET_FILE:${IResearch_TARGET_NAME}-analyzer-mask-static>"
     "$<TARGET_FILE:${IResearch_TARGET_NAME}-format-1_0-static>"
     "$<TARGET_FILE:${IResearch_TARGET_NAME}-scorer-tfidf-static>"
     "$<TARGET_FILE:${IResearch_TARGET_NAME}-scorer-bm25-static>"
@@ -803,28 +803,28 @@ else()
 endif()
 
 ################################################################################
-### analysis plugin : delimited
+### analysis plugin : delimiter
 ################################################################################
 
-add_library(${IResearch_TARGET_NAME}-analyzer-delimited-shared
+add_library(${IResearch_TARGET_NAME}-analyzer-delimiter-shared
   SHARED
   ./analysis/delimited_token_stream.cpp
   ./analysis/delimited_token_stream.hpp
 )
 
-add_library(${IResearch_TARGET_NAME}-analyzer-delimited-static
+add_library(${IResearch_TARGET_NAME}-analyzer-delimiter-static
   STATIC
   ./analysis/delimited_token_stream.cpp
 )
 
 # setup CRT
 if(MSVC)
-  add_library(${IResearch_TARGET_NAME}-analyzer-delimited-shared-scrt
+  add_library(${IResearch_TARGET_NAME}-analyzer-delimiter-shared-scrt
     SHARED
     ./analysis/delimited_token_stream.cpp
   )
 
-  add_library(${IResearch_TARGET_NAME}-analyzer-delimited-static-scrt
+  add_library(${IResearch_TARGET_NAME}-analyzer-delimiter-static-scrt
     STATIC
     ./analysis/delimited_token_stream.cpp
   )
@@ -832,76 +832,76 @@ endif()
 
 # setup CRT
 if(MSVC)
-  target_compile_options(${IResearch_TARGET_NAME}-analyzer-delimited-shared
+  target_compile_options(${IResearch_TARGET_NAME}-analyzer-delimiter-shared
     PRIVATE "$<$<CONFIG:Debug>:/MDd>$<$<NOT:$<CONFIG:Debug>>:/MD>"
   )
 
-  target_compile_options(${IResearch_TARGET_NAME}-analyzer-delimited-static
+  target_compile_options(${IResearch_TARGET_NAME}-analyzer-delimiter-static
     PRIVATE "$<$<CONFIG:Debug>:/MDd>$<$<NOT:$<CONFIG:Debug>>:/MD>"
   )
 
-  target_compile_options(${IResearch_TARGET_NAME}-analyzer-delimited-shared-scrt
+  target_compile_options(${IResearch_TARGET_NAME}-analyzer-delimiter-shared-scrt
     PRIVATE "$<$<CONFIG:Debug>:/MTd>$<$<NOT:$<CONFIG:Debug>>:/MT>"
   )
 
-  target_compile_options(${IResearch_TARGET_NAME}-analyzer-delimited-static-scrt
+  target_compile_options(${IResearch_TARGET_NAME}-analyzer-delimiter-static-scrt
     PRIVATE "$<$<CONFIG:Debug>:/MTd>$<$<NOT:$<CONFIG:Debug>>:/MT>"
   )
 endif()
 
-set_target_properties(${IResearch_TARGET_NAME}-analyzer-delimited-shared
+set_target_properties(${IResearch_TARGET_NAME}-analyzer-delimiter-shared
   PROPERTIES
   PREFIX lib
   IMPORT_PREFIX lib
-  OUTPUT_NAME analyzer-delimited
+  OUTPUT_NAME analyzer-delimiter
   DEBUG_POSTFIX "" # otherwise library names will not match expected dynamically loaded value
   COMPILE_DEFINITIONS "$<$<CONFIG:Debug>:IRESEARCH_DEBUG>;IRESEARCH_DLL;IRESEARCH_DLL_EXPORTS;IRESEARCH_DLL_PLUGIN"
   CXX_VISIBILITY_PRESET hidden
 )
 
-set_target_properties(${IResearch_TARGET_NAME}-analyzer-delimited-static
+set_target_properties(${IResearch_TARGET_NAME}-analyzer-delimiter-static
   PROPERTIES
   PREFIX lib
   IMPORT_PREFIX lib
-  OUTPUT_NAME analyzer-delimited-s
+  OUTPUT_NAME analyzer-delimiter-s
   COMPILE_DEFINITIONS "$<$<CONFIG:Debug>:IRESEARCH_DEBUG>"
 )
 
 # setup CRT
 if(MSVC)
-  set_target_properties(${IResearch_TARGET_NAME}-analyzer-delimited-shared-scrt
+  set_target_properties(${IResearch_TARGET_NAME}-analyzer-delimiter-shared-scrt
     PROPERTIES
     PREFIX lib
     IMPORT_PREFIX lib
-    OUTPUT_NAME analyzer-delimited-scrt
+    OUTPUT_NAME analyzer-delimiter-scrt
     COMPILE_DEFINITIONS "$<$<CONFIG:Debug>:IRESEARCH_DEBUG>;IRESEARCH_DLL;IRESEARCH_DLL_EXPORTS;IRESEARCH_DLL_PLUGIN"
     CXX_VISIBILITY_PRESET hidden
   )
 
-  set_target_properties(${IResearch_TARGET_NAME}-analyzer-delimited-static-scrt
+  set_target_properties(${IResearch_TARGET_NAME}-analyzer-delimiter-static-scrt
     PROPERTIES
     PREFIX lib
     IMPORT_PREFIX lib
-    OUTPUT_NAME analyzer-delimited-scrt-s
+    OUTPUT_NAME analyzer-delimiter-scrt-s
     COMPILE_DEFINITIONS "$<$<CONFIG:Debug>:IRESEARCH_DEBUG>"
   )
 endif()
 
-target_link_libraries(${IResearch_TARGET_NAME}-analyzer-delimited-shared
+target_link_libraries(${IResearch_TARGET_NAME}-analyzer-delimiter-shared
   ${IResearch_TARGET_NAME}-shared
 )
 
-target_link_libraries(${IResearch_TARGET_NAME}-analyzer-delimited-static
+target_link_libraries(${IResearch_TARGET_NAME}-analyzer-delimiter-static
   ${IResearch_TARGET_NAME}-static
 )
 
 # setup CRT
 if(MSVC)
-  target_link_libraries(${IResearch_TARGET_NAME}-analyzer-delimited-shared-scrt
+  target_link_libraries(${IResearch_TARGET_NAME}-analyzer-delimiter-shared-scrt
     ${IResearch_TARGET_NAME}-shared-scrt
   )
 
-  target_link_libraries(${IResearch_TARGET_NAME}-analyzer-delimited-static-scrt
+  target_link_libraries(${IResearch_TARGET_NAME}-analyzer-delimiter-static-scrt
     ${IResearch_TARGET_NAME}-static-scrt
   )
 endif()
@@ -1041,121 +1041,121 @@ endif()
 ### analysis plugin : text token normalizing
 ################################################################################
 
-add_library(${IResearch_TARGET_NAME}-analyzer-text-normalizing-shared
+add_library(${IResearch_TARGET_NAME}-analyzer-norm-shared
   SHARED
   ./analysis/text_token_normalizing_stream.cpp
   ./analysis/text_token_normalizing_stream.hpp
 )
 
-add_library(${IResearch_TARGET_NAME}-analyzer-text-normalizing-static
+add_library(${IResearch_TARGET_NAME}-analyzer-norm-static
   STATIC
   ./analysis/text_token_normalizing_stream.cpp
 )
 
 # setup CRT
 if(MSVC)
-  add_library(${IResearch_TARGET_NAME}-analyzer-text-normalizing-shared-scrt
+  add_library(${IResearch_TARGET_NAME}-analyzer-norm-shared-scrt
     SHARED
     ./analysis/text_token_normalizing_stream.cpp
   )
 
-  add_library(${IResearch_TARGET_NAME}-analyzer-text-normalizing-static-scrt
+  add_library(${IResearch_TARGET_NAME}-analyzer-norm-static-scrt
     STATIC
     ./analysis/text_token_normalizing_stream.cpp
   )
 endif()
 
-target_include_directories(${IResearch_TARGET_NAME}-analyzer-text-normalizing-shared
+target_include_directories(${IResearch_TARGET_NAME}-analyzer-norm-shared
   PRIVATE ${ICU_INCLUDE_DIR} # cmake on MSVC does not properly expand dependencies for linked libraries
 )
 
-target_include_directories(${IResearch_TARGET_NAME}-analyzer-text-normalizing-static
+target_include_directories(${IResearch_TARGET_NAME}-analyzer-norm-static
   PRIVATE ${ICU_INCLUDE_DIR} # cmake on MSVC does not properly expand dependencies for linked libraries
 )
 
 # setup CRT
 if(MSVC)
-  target_include_directories(${IResearch_TARGET_NAME}-analyzer-text-normalizing-shared-scrt
+  target_include_directories(${IResearch_TARGET_NAME}-analyzer-norm-shared-scrt
     PRIVATE ${ICU_INCLUDE_DIR} # cmake on MSVC does not properly expand dependencies for linked libraries
   )
 
-  target_include_directories(${IResearch_TARGET_NAME}-analyzer-text-normalizing-static-scrt
+  target_include_directories(${IResearch_TARGET_NAME}-analyzer-norm-static-scrt
     PRIVATE ${ICU_INCLUDE_DIR} # cmake on MSVC does not properly expand dependencies for linked libraries
   )
 endif()
 
 # setup CRT
 if(MSVC)
-  target_compile_options(${IResearch_TARGET_NAME}-analyzer-text-normalizing-shared
+  target_compile_options(${IResearch_TARGET_NAME}-analyzer-norm-shared
     PRIVATE "$<$<CONFIG:Debug>:/MDd>$<$<NOT:$<CONFIG:Debug>>:/MD>"
   )
 
-  target_compile_options(${IResearch_TARGET_NAME}-analyzer-text-normalizing-static
+  target_compile_options(${IResearch_TARGET_NAME}-analyzer-norm-static
     PRIVATE "$<$<CONFIG:Debug>:/MDd>$<$<NOT:$<CONFIG:Debug>>:/MD>"
   )
 
-  target_compile_options(${IResearch_TARGET_NAME}-analyzer-text-normalizing-shared-scrt
+  target_compile_options(${IResearch_TARGET_NAME}-analyzer-norm-shared-scrt
     PRIVATE "$<$<CONFIG:Debug>:/MTd>$<$<NOT:$<CONFIG:Debug>>:/MT>"
   )
 
-  target_compile_options(${IResearch_TARGET_NAME}-analyzer-text-normalizing-static-scrt
+  target_compile_options(${IResearch_TARGET_NAME}-analyzer-norm-static-scrt
     PRIVATE "$<$<CONFIG:Debug>:/MTd>$<$<NOT:$<CONFIG:Debug>>:/MT>"
   )
 endif()
 
-set_target_properties(${IResearch_TARGET_NAME}-analyzer-text-normalizing-shared
+set_target_properties(${IResearch_TARGET_NAME}-analyzer-norm-shared
   PROPERTIES
   PREFIX lib
   IMPORT_PREFIX lib
-  OUTPUT_NAME analyzer-text-token-normalize
+  OUTPUT_NAME analyzer-norm
   DEBUG_POSTFIX "" # otherwise library names will not match expected dynamically loaded value
   COMPILE_DEFINITIONS "$<$<CONFIG:Debug>:IRESEARCH_DEBUG>;IRESEARCH_DLL;IRESEARCH_DLL_EXPORTS;IRESEARCH_DLL_PLUGIN"
   CXX_VISIBILITY_PRESET hidden
 )
 
-set_target_properties(${IResearch_TARGET_NAME}-analyzer-text-normalizing-static
+set_target_properties(${IResearch_TARGET_NAME}-analyzer-norm-static
   PROPERTIES
   PREFIX lib
   IMPORT_PREFIX lib
-  OUTPUT_NAME analyzer-text-token-normalize-s
+  OUTPUT_NAME analyzer-norm-s
   COMPILE_DEFINITIONS "$<$<CONFIG:Debug>:IRESEARCH_DEBUG>"
 )
 
 # setup CRT
 if(MSVC)
-  set_target_properties(${IResearch_TARGET_NAME}-analyzer-text-normalizing-shared-scrt
+  set_target_properties(${IResearch_TARGET_NAME}-analyzer-norm-shared-scrt
     PROPERTIES
     PREFIX lib
     IMPORT_PREFIX lib
-    OUTPUT_NAME analyzer-text-token-normalize-scrt
+    OUTPUT_NAME analyzer-norm-scrt
     COMPILE_DEFINITIONS "$<$<CONFIG:Debug>:IRESEARCH_DEBUG>;IRESEARCH_DLL;IRESEARCH_DLL_EXPORTS;IRESEARCH_DLL_PLUGIN"
     CXX_VISIBILITY_PRESET hidden
   )
 
-  set_target_properties(${IResearch_TARGET_NAME}-analyzer-text-normalizing-static-scrt
+  set_target_properties(${IResearch_TARGET_NAME}-analyzer-norm-static-scrt
     PROPERTIES
     PREFIX lib
     IMPORT_PREFIX lib
-    OUTPUT_NAME analyzer-text-token-normalize-scrt-s
+    OUTPUT_NAME analyzer-norm-scrt-s
     COMPILE_DEFINITIONS "$<$<CONFIG:Debug>:IRESEARCH_DEBUG>"
   )
 endif()
 
-target_link_libraries(${IResearch_TARGET_NAME}-analyzer-text-normalizing-shared
+target_link_libraries(${IResearch_TARGET_NAME}-analyzer-norm-shared
   ${IResearch_TARGET_NAME}-shared
 )
 
-target_link_libraries(${IResearch_TARGET_NAME}-analyzer-text-normalizing-static
+target_link_libraries(${IResearch_TARGET_NAME}-analyzer-norm-static
   ${IResearch_TARGET_NAME}-static
 )
 
 # setup CRT
 if(MSVC)
-  target_link_libraries(${IResearch_TARGET_NAME}-analyzer-text-normalizing-shared-scrt
+  target_link_libraries(${IResearch_TARGET_NAME}-analyzer-norm-shared-scrt
     ${IResearch_TARGET_NAME}-shared-scrt
   )
 
-  target_link_libraries(${IResearch_TARGET_NAME}-analyzer-text-normalizing-static-scrt
+  target_link_libraries(${IResearch_TARGET_NAME}-analyzer-norm-static-scrt
     ${IResearch_TARGET_NAME}-static-scrt
   )
 endif()
@@ -1164,124 +1164,124 @@ endif()
 ### analysis plugin : text token stemming
 ################################################################################
 
-add_library(${IResearch_TARGET_NAME}-analyzer-text-stemming-shared
+add_library(${IResearch_TARGET_NAME}-analyzer-stem-shared
   SHARED
   ./analysis/text_token_stemming_stream.cpp
   ./analysis/text_token_stemming_stream.hpp
 )
 
-add_library(${IResearch_TARGET_NAME}-analyzer-text-stemming-static
+add_library(${IResearch_TARGET_NAME}-analyzer-stem-static
   STATIC
   ./analysis/text_token_stemming_stream.cpp
 )
 
 # setup CRT
 if(MSVC)
-  add_library(${IResearch_TARGET_NAME}-analyzer-text-stemming-shared-scrt
+  add_library(${IResearch_TARGET_NAME}-analyzer-stem-shared-scrt
     SHARED
     ./analysis/text_token_stemming_stream.cpp
   )
 
-  add_library(${IResearch_TARGET_NAME}-analyzer-text-stemming-static-scrt
+  add_library(${IResearch_TARGET_NAME}-analyzer-stem-static-scrt
     STATIC
     ./analysis/text_token_stemming_stream.cpp
   )
 endif()
 
-target_include_directories(${IResearch_TARGET_NAME}-analyzer-text-stemming-shared
+target_include_directories(${IResearch_TARGET_NAME}-analyzer-stem-shared
   PRIVATE ${Snowball_INCLUDE_DIR}
 )
 
-target_include_directories(${IResearch_TARGET_NAME}-analyzer-text-stemming-static
+target_include_directories(${IResearch_TARGET_NAME}-analyzer-stem-static
   PRIVATE ${Snowball_INCLUDE_DIR}
 )
 
 # setup CRT
 if(MSVC)
-  target_include_directories(${IResearch_TARGET_NAME}-analyzer-text-stemming-shared-scrt
+  target_include_directories(${IResearch_TARGET_NAME}-analyzer-stem-shared-scrt
     PRIVATE ${Snowball_INCLUDE_DIR}
   )
 
-  target_include_directories(${IResearch_TARGET_NAME}-analyzer-text-stemming-static-scrt
+  target_include_directories(${IResearch_TARGET_NAME}-analyzer-stem-static-scrt
     PRIVATE ${Snowball_INCLUDE_DIR}
   )
 endif()
 
 # setup CRT
 if(MSVC)
-  target_compile_options(${IResearch_TARGET_NAME}-analyzer-text-stemming-shared
+  target_compile_options(${IResearch_TARGET_NAME}-analyzer-stem-shared
     PRIVATE "$<$<CONFIG:Debug>:/MDd>$<$<NOT:$<CONFIG:Debug>>:/MD>"
   )
 
-  target_compile_options(${IResearch_TARGET_NAME}-analyzer-text-stemming-static
+  target_compile_options(${IResearch_TARGET_NAME}-analyzer-stem-static
     PRIVATE "$<$<CONFIG:Debug>:/MDd>$<$<NOT:$<CONFIG:Debug>>:/MD>"
   )
 
-  target_compile_options(${IResearch_TARGET_NAME}-analyzer-text-stemming-shared-scrt
+  target_compile_options(${IResearch_TARGET_NAME}-analyzer-stem-shared-scrt
     PRIVATE "$<$<CONFIG:Debug>:/MTd>$<$<NOT:$<CONFIG:Debug>>:/MT>"
   )
 
-  target_compile_options(${IResearch_TARGET_NAME}-analyzer-text-stemming-static-scrt
+  target_compile_options(${IResearch_TARGET_NAME}-analyzer-stem-static-scrt
     PRIVATE "$<$<CONFIG:Debug>:/MTd>$<$<NOT:$<CONFIG:Debug>>:/MT>"
   )
 endif()
 
-set_target_properties(${IResearch_TARGET_NAME}-analyzer-text-stemming-shared
+set_target_properties(${IResearch_TARGET_NAME}-analyzer-stem-shared
   PROPERTIES
   PREFIX lib
   IMPORT_PREFIX lib
-  OUTPUT_NAME analyzer-text-token-stem
+  OUTPUT_NAME analyzer-stem
   DEBUG_POSTFIX "" # otherwise library names will not match expected dynamically loaded value
   COMPILE_DEFINITIONS "$<$<CONFIG:Debug>:IRESEARCH_DEBUG>;IRESEARCH_DLL;IRESEARCH_DLL_EXPORTS;IRESEARCH_DLL_PLUGIN"
   CXX_VISIBILITY_PRESET hidden
 )
 
-set_target_properties(${IResearch_TARGET_NAME}-analyzer-text-stemming-static
+set_target_properties(${IResearch_TARGET_NAME}-analyzer-stem-static
   PROPERTIES
   PREFIX lib
   IMPORT_PREFIX lib
-  OUTPUT_NAME analyzer-text-token-stem-s
+  OUTPUT_NAME analyzer-stem-s
   COMPILE_DEFINITIONS "$<$<CONFIG:Debug>:IRESEARCH_DEBUG>"
 )
 
 # setup CRT
 if(MSVC)
-  set_target_properties(${IResearch_TARGET_NAME}-analyzer-text-stemming-shared-scrt
+  set_target_properties(${IResearch_TARGET_NAME}-analyzer-stem-shared-scrt
     PROPERTIES
     PREFIX lib
     IMPORT_PREFIX lib
-    OUTPUT_NAME analyzer-text-token-stem-scrt
+    OUTPUT_NAME analyzer-stem-scrt
     COMPILE_DEFINITIONS "$<$<CONFIG:Debug>:IRESEARCH_DEBUG>;IRESEARCH_DLL;IRESEARCH_DLL_EXPORTS;IRESEARCH_DLL_PLUGIN"
     CXX_VISIBILITY_PRESET hidden
   )
 
-  set_target_properties(${IResearch_TARGET_NAME}-analyzer-text-stemming-static-scrt
+  set_target_properties(${IResearch_TARGET_NAME}-analyzer-stem-static-scrt
     PROPERTIES
     PREFIX lib
     IMPORT_PREFIX lib
-    OUTPUT_NAME analyzer-text-token-stem-scrt-s
+    OUTPUT_NAME analyzer-stem-scrt-s
     COMPILE_DEFINITIONS "$<$<CONFIG:Debug>:IRESEARCH_DEBUG>"
   )
 endif()
 
-target_link_libraries(${IResearch_TARGET_NAME}-analyzer-text-stemming-shared
+target_link_libraries(${IResearch_TARGET_NAME}-analyzer-stem-shared
   ${IResearch_TARGET_NAME}-shared
   stemmer-shared
 )
 
-target_link_libraries(${IResearch_TARGET_NAME}-analyzer-text-stemming-static
+target_link_libraries(${IResearch_TARGET_NAME}-analyzer-stem-static
   ${IResearch_TARGET_NAME}-static
   stemmer-static
 )
 
 # setup CRT
 if(MSVC)
-  target_link_libraries(${IResearch_TARGET_NAME}-analyzer-text-stemming-shared-scrt
+  target_link_libraries(${IResearch_TARGET_NAME}-analyzer-stem-shared-scrt
     ${IResearch_TARGET_NAME}-shared-scrt
     stemmer-shared
   )
 
-  target_link_libraries(${IResearch_TARGET_NAME}-analyzer-text-stemming-static-scrt
+  target_link_libraries(${IResearch_TARGET_NAME}-analyzer-stem-static-scrt
     ${IResearch_TARGET_NAME}-static-scrt
     stemmer-static
   )
@@ -1291,25 +1291,25 @@ endif()
 ### analysis plugin : token masking
 ################################################################################
 
-add_library(${IResearch_TARGET_NAME}-analyzer-token-masking-shared
+add_library(${IResearch_TARGET_NAME}-analyzer-mask-shared
   SHARED
   ./analysis/token_masking_stream.cpp
   ./analysis/token_masking_stream.hpp
 )
 
-add_library(${IResearch_TARGET_NAME}-analyzer-token-masking-static
+add_library(${IResearch_TARGET_NAME}-analyzer-mask-static
   STATIC
   ./analysis/token_masking_stream.cpp
 )
 
 # setup CRT
 if(MSVC)
-  add_library(${IResearch_TARGET_NAME}-analyzer-token-masking-shared-scrt
+  add_library(${IResearch_TARGET_NAME}-analyzer-mask-shared-scrt
     SHARED
     ./analysis/token_masking_stream.cpp
   )
 
-  add_library(${IResearch_TARGET_NAME}-analyzer-token-masking-static-scrt
+  add_library(${IResearch_TARGET_NAME}-analyzer-mask-static-scrt
     STATIC
     ./analysis/token_masking_stream.cpp
   )
@@ -1317,76 +1317,76 @@ endif()
 
 # setup CRT
 if(MSVC)
-  target_compile_options(${IResearch_TARGET_NAME}-analyzer-token-masking-shared
+  target_compile_options(${IResearch_TARGET_NAME}-analyzer-mask-shared
     PRIVATE "$<$<CONFIG:Debug>:/MDd>$<$<NOT:$<CONFIG:Debug>>:/MD>"
   )
 
-  target_compile_options(${IResearch_TARGET_NAME}-analyzer-token-masking-static
+  target_compile_options(${IResearch_TARGET_NAME}-analyzer-mask-static
     PRIVATE "$<$<CONFIG:Debug>:/MDd>$<$<NOT:$<CONFIG:Debug>>:/MD>"
   )
 
-  target_compile_options(${IResearch_TARGET_NAME}-analyzer-token-masking-shared-scrt
+  target_compile_options(${IResearch_TARGET_NAME}-analyzer-mask-shared-scrt
     PRIVATE "$<$<CONFIG:Debug>:/MTd>$<$<NOT:$<CONFIG:Debug>>:/MT>"
   )
 
-  target_compile_options(${IResearch_TARGET_NAME}-analyzer-token-masking-static-scrt
+  target_compile_options(${IResearch_TARGET_NAME}-analyzer-mask-static-scrt
     PRIVATE "$<$<CONFIG:Debug>:/MTd>$<$<NOT:$<CONFIG:Debug>>:/MT>"
   )
 endif()
 
-set_target_properties(${IResearch_TARGET_NAME}-analyzer-token-masking-shared
+set_target_properties(${IResearch_TARGET_NAME}-analyzer-mask-shared
   PROPERTIES
   PREFIX lib
   IMPORT_PREFIX lib
-  OUTPUT_NAME analyzer-token-mask
+  OUTPUT_NAME analyzer-mask
   DEBUG_POSTFIX "" # otherwise library names will not match expected dynamically loaded value
   COMPILE_DEFINITIONS "$<$<CONFIG:Debug>:IRESEARCH_DEBUG>;IRESEARCH_DLL;IRESEARCH_DLL_EXPORTS;IRESEARCH_DLL_PLUGIN"
   CXX_VISIBILITY_PRESET hidden
 )
 
-set_target_properties(${IResearch_TARGET_NAME}-analyzer-token-masking-static
+set_target_properties(${IResearch_TARGET_NAME}-analyzer-mask-static
   PROPERTIES
   PREFIX lib
   IMPORT_PREFIX lib
-  OUTPUT_NAME analyzer-token-mask-s
+  OUTPUT_NAME analyzer-mask-s
   COMPILE_DEFINITIONS "$<$<CONFIG:Debug>:IRESEARCH_DEBUG>"
 )
 
 # setup CRT
 if(MSVC)
-  set_target_properties(${IResearch_TARGET_NAME}-analyzer-token-masking-shared-scrt
+  set_target_properties(${IResearch_TARGET_NAME}-analyzer-mask-shared-scrt
     PROPERTIES
     PREFIX lib
     IMPORT_PREFIX lib
-    OUTPUT_NAME analyzer-token-mask-scrt
+    OUTPUT_NAME analyzer-mask-scrt
     COMPILE_DEFINITIONS "$<$<CONFIG:Debug>:IRESEARCH_DEBUG>;IRESEARCH_DLL;IRESEARCH_DLL_EXPORTS;IRESEARCH_DLL_PLUGIN"
     CXX_VISIBILITY_PRESET hidden
   )
 
-  set_target_properties(${IResearch_TARGET_NAME}-analyzer-token-masking-static-scrt
+  set_target_properties(${IResearch_TARGET_NAME}-analyzer-mask-static-scrt
     PROPERTIES
     PREFIX lib
     IMPORT_PREFIX lib
-    OUTPUT_NAME analyzer-token-mask-scrt-s
+    OUTPUT_NAME analyzer-mask-scrt-s
     COMPILE_DEFINITIONS "$<$<CONFIG:Debug>:IRESEARCH_DEBUG>"
   )
 endif()
 
-target_link_libraries(${IResearch_TARGET_NAME}-analyzer-token-masking-shared
+target_link_libraries(${IResearch_TARGET_NAME}-analyzer-mask-shared
   ${IResearch_TARGET_NAME}-shared
 )
 
-target_link_libraries(${IResearch_TARGET_NAME}-analyzer-token-masking-static
+target_link_libraries(${IResearch_TARGET_NAME}-analyzer-mask-static
   ${IResearch_TARGET_NAME}-static
 )
 
 # setup CRT
 if(MSVC)
-  target_link_libraries(${IResearch_TARGET_NAME}-analyzer-token-masking-shared-scrt
+  target_link_libraries(${IResearch_TARGET_NAME}-analyzer-mask-shared-scrt
     ${IResearch_TARGET_NAME}-shared-scrt
   )
 
-  target_link_libraries(${IResearch_TARGET_NAME}-analyzer-token-masking-static-scrt
+  target_link_libraries(${IResearch_TARGET_NAME}-analyzer-mask-static-scrt
     ${IResearch_TARGET_NAME}-static-scrt
   )
 endif()

--- a/core/analysis/analyzer.hpp
+++ b/core/analysis/analyzer.hpp
@@ -54,20 +54,14 @@ class IRESEARCH_API analyzer: public token_stream {
 
   const type_id& type() const NOEXCEPT { return *type_; }
 
-  virtual bool to_string(
-    const ::irs::text_format::type_id& format,
-    std::string& definition) const  {
-    return to_string_impl(format, definition);
-  }
-
-protected:
-  virtual bool to_string_impl(
-    const ::irs::text_format::type_id& format,
-    std::string& definition) const {
-    UNUSED(format);
+  virtual bool to_string(const ::irs::text_format::type_id& /*format*/,
+                         std::string& definition) const {
     definition.clear();
     return false;
   }
+
+protected:
+ 
  private:
   const type_id* type_;
 };

--- a/core/analysis/analyzer.hpp
+++ b/core/analysis/analyzer.hpp
@@ -26,6 +26,7 @@
 
 #include "analysis/token_stream.hpp"
 #include "utils/type_id.hpp"
+#include "utils/text_format.hpp"
 
 NS_ROOT
 NS_BEGIN(analysis)
@@ -53,6 +54,19 @@ class IRESEARCH_API analyzer: public token_stream {
 
   const type_id& type() const NOEXCEPT { return *type_; }
 
+  virtual bool to_string(
+    const ::irs::text_format::type_id& format,
+    std::string& definition) const  {
+    return to_string_impl(format, definition);
+  }
+
+protected:
+  virtual bool to_string_impl(
+    const ::irs::text_format::type_id& format,
+    std::string& definition) const {
+
+    return to_string_impl(format, definition);
+  }
  private:
   const type_id* type_;
 };

--- a/core/analysis/analyzer.hpp
+++ b/core/analysis/analyzer.hpp
@@ -64,8 +64,9 @@ protected:
   virtual bool to_string_impl(
     const ::irs::text_format::type_id& format,
     std::string& definition) const {
-
-    return to_string_impl(format, definition);
+    UNUSED(format);
+    definition.clear();
+    return false;
   }
  private:
   const type_id* type_;

--- a/core/analysis/delimited_token_stream.cpp
+++ b/core/analysis/delimited_token_stream.cpp
@@ -117,7 +117,8 @@ irs::analysis::analyzer::ptr make_json(const irs::string_ref& args) {
    case rapidjson::kStringType:
     return irs::analysis::delimited_token_stream::make(json.GetString());
    case rapidjson::kObjectType:
-    if (json.HasMember(delimiterParamName.c_str()) && json[delimiterParamName.c_str()].IsString()) {
+    if (json.HasMember(delimiterParamName.c_str()) && 
+        json[delimiterParamName.c_str()].IsString()) {
       return irs::analysis::delimited_token_stream::make(json[delimiterParamName.c_str()].GetString());
     }
    default: {} // fall through
@@ -146,8 +147,11 @@ bool make_json_config(const irs::bstring& delimiter, std::string& definition) {
   // delimiter
   {
     auto delimiterStringRef = ::irs::ref_cast<char>(delimiter);
-    json.AddMember(rapidjson::Value::StringRefType(delimiterParamName.c_str(), static_cast<rapidjson::SizeType>(delimiterParamName.size())),
-      rapidjson::Value(rapidjson::StringRef(delimiterStringRef.c_str(), static_cast<rapidjson::SizeType>(delimiterStringRef.size()))), allocator);
+    json.AddMember(rapidjson::Value::StringRefType(delimiterParamName.c_str(),
+                       static_cast<rapidjson::SizeType>(delimiterParamName.size())),
+                   rapidjson::Value(rapidjson::StringRef(delimiterStringRef.c_str(), 
+                       static_cast<rapidjson::SizeType>(delimiterStringRef.size()))), 
+                   allocator);
   }
 
   //output json to string
@@ -250,14 +254,14 @@ bool delimited_token_stream::reset(const string_ref& data) {
   return true;
 }
 
-bool delimited_token_stream::to_string_impl(
+bool delimited_token_stream::to_string(
     const ::irs::text_format::type_id& format,
     std::string& definition) const {
-  if (::irs::text_format::json == format)
+  if (::irs::text_format::json == format) {
     return make_json_config(delim_buf_, definition);
-  else if (::irs::text_format::text == format)
+  } else if (::irs::text_format::text == format) {
     return make_text_config(delim_buf_, definition);
-
+  }
   return false;
 }
 

--- a/core/analysis/delimited_token_stream.cpp
+++ b/core/analysis/delimited_token_stream.cpp
@@ -21,7 +21,9 @@
 /// @author Vasiliy Nabatchikov
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <rapidjson/rapidjson/document.h> // for rapidjson::Document
+#include <rapidjson/rapidjson/document.h> // for rapidjson::Document, rapidjson::Value
+#include <rapidjson/rapidjson/writer.h> // for rapidjson::Writer
+#include <rapidjson/rapidjson/stringbuffer.h> // for rapidjson::StringBuffer
 
 #include "delimited_token_stream.hpp"
 
@@ -130,6 +132,33 @@ irs::analysis::analyzer::ptr make_json(const irs::string_ref& args) {
   return nullptr;
 }
 
+///////////////////////////////////////////////////////////////////////////////
+/// @brief builds analyzer config from internal options in json format
+/// @param delimiter reference to analyzer options storage
+/// @param definition string for storing json document with config 
+///////////////////////////////////////////////////////////////////////////////
+bool make_json_config(const irs::bstring& delimiter, std::string& definition) {
+  rapidjson::Document json;
+  json.SetObject();
+
+  rapidjson::Document::AllocatorType& allocator = json.GetAllocator();
+
+  // delimiter
+  {
+    auto delimiterStringRef = ::irs::ref_cast<char>(delimiter);
+    json.AddMember(rapidjson::Value::StringRefType(delimiterParamName.c_str(), static_cast<rapidjson::SizeType>(delimiterParamName.size())),
+      rapidjson::Value(rapidjson::StringRef(delimiterStringRef.c_str(), static_cast<rapidjson::SizeType>(delimiterStringRef.size()))), allocator);
+  }
+
+  //output json to string
+  rapidjson::StringBuffer buffer;
+  rapidjson::Writer< rapidjson::StringBuffer> writer(buffer);
+  json.Accept(writer);
+  definition = buffer.GetString();
+  return true;
+}
+
+
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief args is a delimiter to use for tokenization
 ////////////////////////////////////////////////////////////////////////////////
@@ -137,6 +166,14 @@ irs::analysis::analyzer::ptr make_text(const irs::string_ref& args) {
   return irs::memory::make_shared<irs::analysis::delimited_token_stream>(
     args
   );
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief build config string in 'text' format
+////////////////////////////////////////////////////////////////////////////////
+bool make_text_config(const irs::bstring& delimiter, std::string& definition) {
+  definition = irs::ref_cast<char>(delimiter);
+  return true;
 }
 
 REGISTER_ANALYZER_JSON(irs::analysis::delimited_token_stream, make_json);
@@ -212,6 +249,18 @@ bool delimited_token_stream::reset(const string_ref& data) {
 
   return true;
 }
+
+bool delimited_token_stream::to_string_impl(
+    const ::irs::text_format::type_id& format,
+    std::string& definition) const {
+  if (::irs::text_format::json == format)
+    return make_json_config(delim_buf_, definition);
+  else if (::irs::text_format::text == format)
+    return make_text_config(delim_buf_, definition);
+
+  return false;
+}
+
 
 NS_END // analysis
 NS_END // ROOT

--- a/core/analysis/delimited_token_stream.hpp
+++ b/core/analysis/delimited_token_stream.hpp
@@ -49,6 +49,11 @@ class delimited_token_stream: public analyzer, util::noncopyable {
   virtual bool next() override;
   virtual bool reset(const string_ref& data) override;
 
+protected:
+  virtual bool to_string_impl(
+    const ::irs::text_format::type_id& format,
+    std::string& definition) const override;
+
  private:
   class term_attribute final: public irs::term_attribute {
    public:

--- a/core/analysis/delimited_token_stream.hpp
+++ b/core/analysis/delimited_token_stream.hpp
@@ -48,11 +48,8 @@ class delimited_token_stream: public analyzer, util::noncopyable {
   static void init(); // for trigering registration in a static build
   virtual bool next() override;
   virtual bool reset(const string_ref& data) override;
-
-protected:
-  virtual bool to_string_impl(
-    const ::irs::text_format::type_id& format,
-    std::string& definition) const override;
+  virtual bool to_string(const ::irs::text_format::type_id& format,
+                         std::string& definition) const override;
 
  private:
   class term_attribute final: public irs::term_attribute {

--- a/core/analysis/ngram_token_stream.cpp
+++ b/core/analysis/ngram_token_stream.cpp
@@ -143,11 +143,11 @@ bool make_json_config(const irs::analysis::ngram_token_stream::options_t& option
 
   //min_gram
   json.AddMember(rapidjson::Value::StringRefType(minParamName.c_str(), static_cast<rapidjson::SizeType>(minParamName.size())),
-    rapidjson::Value(options.min_gram), allocator);
+    rapidjson::Value(static_cast<uint64_t>(options.min_gram)), allocator);
 
   //max_gram
   json.AddMember(rapidjson::Value::StringRefType(maxParamName.c_str(), static_cast<rapidjson::SizeType>(maxParamName.size())),
-    rapidjson::Value(options.max_gram), allocator);
+    rapidjson::Value(static_cast<uint64_t>(options.max_gram)), allocator);
 
   //preserve_original
   json.AddMember(rapidjson::Value::StringRefType(preserveOriginalParamName.c_str(), static_cast<rapidjson::SizeType>(preserveOriginalParamName.size())),

--- a/core/analysis/ngram_token_stream.cpp
+++ b/core/analysis/ngram_token_stream.cpp
@@ -135,23 +135,31 @@ irs::analysis::analyzer::ptr make_json(const irs::string_ref& args) {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief builds analyzer config from internal options in json format
 ///////////////////////////////////////////////////////////////////////////////
-bool make_json_config(const irs::analysis::ngram_token_stream::options_t& options, std::string& definition) {
+bool make_json_config(const irs::analysis::ngram_token_stream::options_t& options, 
+                      std::string& definition) {
   rapidjson::Document json;
   json.SetObject();
-
   rapidjson::Document::AllocatorType& allocator = json.GetAllocator();
-
+  
+  // ensure disambiguating casts below are safe. Casts required for clang compiler on Mac
+  static_assert(sizeof(uint64_t) >= sizeof(size_t), "sizeof(uint64_t) >= sizeof(size_t)");
   //min_gram
-  json.AddMember(rapidjson::Value::StringRefType(minParamName.c_str(), static_cast<rapidjson::SizeType>(minParamName.size())),
-    rapidjson::Value(static_cast<uint64_t>(options.min_gram)), allocator);
+  json.AddMember(rapidjson::Value::StringRefType(minParamName.c_str(), 
+                     static_cast<rapidjson::SizeType>(minParamName.size())),
+                 rapidjson::Value(static_cast<uint64_t>(options.min_gram)), 
+                 allocator);
 
   //max_gram
-  json.AddMember(rapidjson::Value::StringRefType(maxParamName.c_str(), static_cast<rapidjson::SizeType>(maxParamName.size())),
-    rapidjson::Value(static_cast<uint64_t>(options.max_gram)), allocator);
+  json.AddMember(rapidjson::Value::StringRefType(maxParamName.c_str(), 
+                     static_cast<rapidjson::SizeType>(maxParamName.size())),
+                 rapidjson::Value(static_cast<uint64_t>(options.max_gram)), 
+                 allocator);
 
   //preserve_original
-  json.AddMember(rapidjson::Value::StringRefType(preserveOriginalParamName.c_str(), static_cast<rapidjson::SizeType>(preserveOriginalParamName.size())),
-    rapidjson::Value(options.preserve_original), allocator);
+  json.AddMember(rapidjson::Value::StringRefType(preserveOriginalParamName.c_str(), 
+                     static_cast<rapidjson::SizeType>(preserveOriginalParamName.size())),
+                 rapidjson::Value(options.preserve_original), 
+                 allocator);
 
   //output json to string
   rapidjson::StringBuffer buffer;
@@ -254,12 +262,12 @@ bool ngram_token_stream::reset(const irs::string_ref& value) NOEXCEPT {
   return true;
 }
 
-bool ngram_token_stream::to_string_impl(
+bool ngram_token_stream::to_string(
     const ::irs::text_format::type_id& format,
     std::string& definition) const {
-  if (::irs::text_format::json == format)
+  if (::irs::text_format::json == format) {
     return make_json_config(options_, definition);
-
+  }
   return false;
 }
 

--- a/core/analysis/ngram_token_stream.cpp
+++ b/core/analysis/ngram_token_stream.cpp
@@ -249,7 +249,7 @@ bool ngram_token_stream::reset(const irs::string_ref& value) NOEXCEPT {
   begin_ = data_.begin()-1;
   length_ = 0;
   emit_original_ = data_.size() > options_.max_gram && options_.preserve_original;
-  assert(length_ < min_gram_);
+  assert(length_ < options_.min_gram);
 
   return true;
 }

--- a/core/analysis/ngram_token_stream.hpp
+++ b/core/analysis/ngram_token_stream.hpp
@@ -66,19 +66,12 @@ class ngram_token_stream: public analyzer, util::noncopyable {
   }
 
   virtual bool next() NOEXCEPT override;
-
   virtual bool reset(const string_ref& data) NOEXCEPT override;
-
+  virtual bool to_string(const ::irs::text_format::type_id& format,
+                         std::string& definition) const override;
   size_t min_gram() const NOEXCEPT { return options_.min_gram; }
-
   size_t max_gram() const NOEXCEPT { return options_.max_gram; }
-
   bool preserve_original() const NOEXCEPT { return options_.preserve_original; }
- 
- protected:
-  virtual bool to_string_impl(
-    const ::irs::text_format::type_id& format,
-    std::string& definition) const override;
 
  private:
   class term_attribute final: public irs::term_attribute {
@@ -94,7 +87,6 @@ class ngram_token_stream: public analyzer, util::noncopyable {
   term_attribute term_;
   const byte_type* begin_{};
   size_t length_{};
-
   bool emit_original_{ false };
 }; // ngram_token_stream
 

--- a/core/analysis/ngram_token_stream.hpp
+++ b/core/analysis/ngram_token_stream.hpp
@@ -37,17 +37,29 @@ NS_BEGIN(analysis)
 ////////////////////////////////////////////////////////////////////////////////
 class ngram_token_stream: public analyzer, util::noncopyable {
  public:
+  struct options_t {
+    options_t(size_t min, size_t max, bool original) {
+      min_gram = min;
+      max_gram = max;
+      preserve_original = original;
+    }
+
+    size_t min_gram;
+    size_t max_gram;
+    bool preserve_original; // emit input data as a token
+  };
+
   DECLARE_ANALYZER_TYPE();
 
-  DECLARE_FACTORY(size_t min_gram, size_t max_gram, bool preserve_original);
+  DECLARE_FACTORY(const options_t& options);
 
   static void init(); // for trigering registration in a static build
 
-  ngram_token_stream(size_t n, bool preserve_original)
-    : ngram_token_stream(n, n, preserve_original) {
-  }
+  //ngram_token_stream(size_t n, bool preserve_original)
+  //  : ngram_token_stream(n, n, preserve_original) {
+ //}
 
-  ngram_token_stream(size_t min_gram, size_t max_gram, bool preserve_original);
+  ngram_token_stream(const options_t& options);
 
   virtual const attribute_view& attributes() const NOEXCEPT override {
     return attrs_;
@@ -57,11 +69,11 @@ class ngram_token_stream: public analyzer, util::noncopyable {
 
   virtual bool reset(const string_ref& data) NOEXCEPT override;
 
-  size_t min_gram() const NOEXCEPT { return min_gram_; }
+  size_t min_gram() const NOEXCEPT { return options_.min_gram; }
 
-  size_t max_gram() const NOEXCEPT { return max_gram_; }
+  size_t max_gram() const NOEXCEPT { return options_.max_gram; }
 
-  bool preserve_original() const NOEXCEPT { return preserve_original_; }
+  bool preserve_original() const NOEXCEPT { return options_.preserve_original; }
  
  protected:
   virtual bool to_string_impl(
@@ -74,9 +86,8 @@ class ngram_token_stream: public analyzer, util::noncopyable {
     void value(const bytes_ref& value) { value_ = value; }
   };
 
+  options_t options_;
   attribute_view attrs_;
-  size_t min_gram_;
-  size_t max_gram_;
   bytes_ref data_; // data to process
   increment inc_;
   offset offset_;
@@ -84,7 +95,6 @@ class ngram_token_stream: public analyzer, util::noncopyable {
   const byte_type* begin_{};
   size_t length_{};
 
-  bool preserve_original_{ false }; // emit input data as a token
   bool emit_original_{ false };
 }; // ngram_token_stream
 

--- a/core/analysis/ngram_token_stream.hpp
+++ b/core/analysis/ngram_token_stream.hpp
@@ -62,6 +62,11 @@ class ngram_token_stream: public analyzer, util::noncopyable {
   size_t max_gram() const NOEXCEPT { return max_gram_; }
 
   bool preserve_original() const NOEXCEPT { return preserve_original_; }
+ 
+ protected:
+  virtual bool to_string_impl(
+    const ::irs::text_format::type_id& format,
+    std::string& definition) const override;
 
  private:
   class term_attribute final: public irs::term_attribute {

--- a/core/analysis/text_token_normalizing_stream.cpp
+++ b/core/analysis/text_token_normalizing_stream.cpp
@@ -85,7 +85,9 @@ const irs::string_ref caseConvertParamName = "caseConvert";
 const irs::string_ref noAccentParamName    = "noAccent";
 
 
-const std::unordered_map<std::string, irs::analysis::text_token_normalizing_stream::options_t::case_convert_t> case_convert_map = {
+const std::unordered_map<
+    std::string, 
+    irs::analysis::text_token_normalizing_stream::options_t::case_convert_t> case_convert_map = {
   { "lower", irs::analysis::text_token_normalizing_stream::options_t::case_convert_t::LOWER },
   { "none", irs::analysis::text_token_normalizing_stream::options_t::case_convert_t::NONE },
   { "upper", irs::analysis::text_token_normalizing_stream::options_t::case_convert_t::UPPER },
@@ -126,7 +128,9 @@ irs::analysis::analyzer::ptr make_json(const irs::string_ref& args) {
           auto& case_convert = json[caseConvertParamName.c_str()]; // optional string enum
 
           if (!case_convert.IsString()) {
-            IR_FRMT_WARN("Non-string value in '%s' while constructing text_token_normalizing_stream from jSON arguments: %s", caseConvertParamName.c_str(), args.c_str());
+            IR_FRMT_WARN(
+              "Non-string value in '%s' while constructing text_token_normalizing_stream from jSON arguments: %s", 
+              caseConvertParamName.c_str(), args.c_str());
 
             return nullptr;
           }
@@ -134,7 +138,9 @@ irs::analysis::analyzer::ptr make_json(const irs::string_ref& args) {
           auto itr = case_convert_map.find(case_convert.GetString());
 
           if (itr == case_convert_map.end()) {
-            IR_FRMT_WARN("Invalid value in '%s' while constructing text_token_normalizing_stream from jSON arguments: %s", caseConvertParamName.c_str(), args.c_str());
+            IR_FRMT_WARN(
+              "Invalid value in '%s' while constructing text_token_normalizing_stream from jSON arguments: %s", 
+              caseConvertParamName.c_str(), args.c_str());
 
             return nullptr;
           }
@@ -146,7 +152,9 @@ irs::analysis::analyzer::ptr make_json(const irs::string_ref& args) {
           auto& no_accent = json[noAccentParamName.c_str()]; // optional bool
 
           if (!no_accent.IsBool()) {
-            IR_FRMT_WARN("Non-boolean value in '%s' while constructing text_token_normalizing_stream from jSON arguments: %s", noAccentParamName.c_str(), args.c_str());
+            IR_FRMT_WARN(
+              "Non-boolean value in '%s' while constructing text_token_normalizing_stream from jSON arguments: %s", 
+              noAccentParamName.c_str(), args.c_str());
 
             return nullptr;
           }
@@ -191,29 +199,39 @@ bool make_json_config(
   rapidjson::Document::AllocatorType& allocator = json.GetAllocator();
 
   // locale
-  json.AddMember(rapidjson::Value::StringRefType(localeParamName.c_str(), static_cast<rapidjson::SizeType>(localeParamName.size())),
-    rapidjson::Value(options.locale.c_str(), static_cast<rapidjson::SizeType>(options.locale.length())), allocator);
+  json.AddMember(rapidjson::Value::StringRefType(localeParamName.c_str(), 
+                     static_cast<rapidjson::SizeType>(localeParamName.size())),
+                 rapidjson::Value(options.locale.c_str(), 
+                     static_cast<rapidjson::SizeType>(options.locale.length())), 
+                 allocator);
 
   // case convert
   {
     auto case_value = std::find_if(case_convert_map.begin(), case_convert_map.end(),
-      [&options](const decltype(case_convert_map)::value_type& v) { return v.second == options.case_convert; });
+      [&options](const decltype(case_convert_map)::value_type& v) { 
+          return v.second == options.case_convert; 
+      });
     if (case_value != case_convert_map.end()) {
-      json.AddMember(rapidjson::Value::StringRefType(caseConvertParamName.c_str(), static_cast<rapidjson::SizeType>(caseConvertParamName.size())),
-        rapidjson::Value(case_value->first.c_str(), static_cast<rapidjson::SizeType>(case_value->first.length())), allocator);
+      json.AddMember(rapidjson::Value::StringRefType(caseConvertParamName.c_str(),
+                         static_cast<rapidjson::SizeType>(caseConvertParamName.size())),
+                     rapidjson::Value(case_value->first.c_str(), 
+                         static_cast<rapidjson::SizeType>(case_value->first.length())), 
+                     allocator);
     }
     else {
       IR_FRMT_ERROR(
-        "Invalid case_convert value in text analyzer options: %d", static_cast<int>(options.case_convert));
+        "Invalid case_convert value in text analyzer options: %d", 
+        static_cast<int>(options.case_convert));
       return false;
     }
   }
 
   // noAccent
-  json.AddMember(rapidjson::Value::StringRefType(noAccentParamName.c_str(), static_cast<rapidjson::SizeType>(noAccentParamName.size())),
-    rapidjson::Value(options.no_accent), allocator);
+  json.AddMember(rapidjson::Value::StringRefType(noAccentParamName.c_str(), 
+                     static_cast<rapidjson::SizeType>(noAccentParamName.size())),
+                 rapidjson::Value(options.no_accent),
+                 allocator);
 
-  
   //output json to string
   rapidjson::StringBuffer buffer;
   rapidjson::Writer< rapidjson::StringBuffer> writer(buffer);
@@ -250,11 +268,12 @@ irs::analysis::analyzer::ptr make_text(const irs::string_ref& args) {
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief build config string in 'text' format
 ////////////////////////////////////////////////////////////////////////////////
-bool make_text_config(const irs::analysis::text_token_normalizing_stream::options_t& options, std::string& definition) {
+bool make_text_config(
+    const irs::analysis::text_token_normalizing_stream::options_t& options, 
+    std::string& definition) {
   definition = options.locale; // only locale available with text config (see make_text)
   return true;
 }
-
 
 REGISTER_ANALYZER_JSON(irs::analysis::text_token_normalizing_stream, make_json);
 REGISTER_ANALYZER_TEXT(irs::analysis::text_token_normalizing_stream, make_text);
@@ -284,8 +303,7 @@ text_token_normalizing_stream::text_token_normalizing_stream(
 }
 
 /*static*/ analyzer::ptr text_token_normalizing_stream::make(
-    const string_ref& locale
-) {
+    const string_ref& locale) {
   return make_text(locale);
 }
 
@@ -331,7 +349,8 @@ bool text_token_normalizing_stream::reset(const irs::string_ref& data) {
 
   if (state_->options.no_accent && !state_->transliterator) {
     // transliteration rule taken verbatim from: http://userguide.icu-project.org/transforms/general
-    icu::UnicodeString collationRule("NFD; [:Nonspacing Mark:] Remove; NFC"); // do not allocate statically since it causes memory leaks in ICU
+    // do not allocate statically since it causes memory leaks in ICU
+    icu::UnicodeString collationRule("NFD; [:Nonspacing Mark:] Remove; NFC"); 
 
     // reusable object owned by *this
     state_->transliterator.reset(icu::Transliterator::createInstance(
@@ -411,14 +430,14 @@ bool text_token_normalizing_stream::reset(const irs::string_ref& data) {
   return true;
 }
 
-bool text_token_normalizing_stream::to_string_impl(
+bool text_token_normalizing_stream::to_string(
     const ::irs::text_format::type_id& format,
     std::string& definition) const {
-  if (::irs::text_format::json == format)
+  if (::irs::text_format::json == format) {
     return make_json_config(state_->options, definition);
-  else if (::irs::text_format::text == format)
+  } else if (::irs::text_format::text == format) {
     return make_text_config(state_->options, definition);
-
+  }
   return false;
 }
 

--- a/core/analysis/text_token_normalizing_stream.hpp
+++ b/core/analysis/text_token_normalizing_stream.hpp
@@ -57,11 +57,8 @@ class text_token_normalizing_stream: public analyzer, util::noncopyable {
   static void init(); // for trigering registration in a static build
   virtual bool next() override;
   virtual bool reset(const irs::string_ref& data) override;
-
- protected:
-  virtual bool to_string_impl(
-    const ::irs::text_format::type_id& format,
-    std::string& definition) const override;
+  virtual bool to_string(const ::irs::text_format::type_id& format,
+                         std::string& definition) const override;
 
  private:
   class term_attribute final: public irs::term_attribute {

--- a/core/analysis/text_token_normalizing_stream.hpp
+++ b/core/analysis/text_token_normalizing_stream.hpp
@@ -58,6 +58,11 @@ class text_token_normalizing_stream: public analyzer, util::noncopyable {
   virtual bool next() override;
   virtual bool reset(const irs::string_ref& data) override;
 
+ protected:
+  virtual bool to_string_impl(
+    const ::irs::text_format::type_id& format,
+    std::string& definition) const override;
+
  private:
   class term_attribute final: public irs::term_attribute {
    public:

--- a/core/analysis/text_token_stemming_stream.cpp
+++ b/core/analysis/text_token_stemming_stream.cpp
@@ -91,8 +91,11 @@ bool make_json_config( const std::string& locale,  std::string& definition) {
   rapidjson::Document::AllocatorType& allocator = json.GetAllocator();
 
   // locale
-  json.AddMember(rapidjson::Value::StringRefType(localeParamName.c_str(), static_cast<rapidjson::SizeType>(localeParamName.size())),
-    rapidjson::Value(locale.c_str(), static_cast<rapidjson::SizeType>(locale.length())), allocator);
+  json.AddMember(rapidjson::Value::StringRefType(localeParamName.c_str(), 
+                     static_cast<rapidjson::SizeType>(localeParamName.size())),
+                 rapidjson::Value(locale.c_str(), 
+                     static_cast<rapidjson::SizeType>(locale.length())), 
+                 allocator);
 
   //output json to string
   rapidjson::StringBuffer buffer;
@@ -144,7 +147,6 @@ text_token_stemming_stream::text_token_stemming_stream(
 ): analyzer(text_token_stemming_stream::type()),
    attrs_(4), // increment + offset + payload + term
    locale_(irs::locale_utils::locale(locale, irs::string_ref::NIL, true)), // true == convert to unicode
-   locale_name_(locale),
    term_eof_(true) {
   attrs_.emplace(inc_);
   attrs_.emplace(offset_);
@@ -240,13 +242,14 @@ bool text_token_stemming_stream::reset(const irs::string_ref& data) {
   return true;
 }
 
-bool text_token_stemming_stream::to_string_impl(
+bool text_token_stemming_stream::to_string( 
     const ::irs::text_format::type_id& format,
     std::string& definition) const {
-  if (::irs::text_format::json == format)
-    return make_json_config(locale_name_, definition);
-  else if (::irs::text_format::text == format)
-    return make_text_config(locale_name_, definition);
+  if (::irs::text_format::json == format) {
+    return make_json_config(locale_utils::name(locale_), definition);
+  } else if (::irs::text_format::text == format) {
+    return make_text_config(locale_utils::name(locale_), definition);
+  }
 
   return false;
 }

--- a/core/analysis/text_token_stemming_stream.cpp
+++ b/core/analysis/text_token_stemming_stream.cpp
@@ -23,13 +23,15 @@
 
 #include "libstemmer.h"
 #include "rapidjson/rapidjson/document.h" // for rapidjson::Document
+#include <rapidjson/rapidjson/writer.h> // for rapidjson::Writer
+#include <rapidjson/rapidjson/stringbuffer.h> // for rapidjson::StringBuffer
 #include "utils/locale_utils.hpp"
 
 #include "text_token_stemming_stream.hpp"
 
 NS_LOCAL
 
-static const irs::string_ref localeParamName = "locale";
+const irs::string_ref localeParamName = "locale";
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief args is a jSON encoded object with the following attributes:
@@ -77,6 +79,29 @@ irs::analysis::analyzer::ptr make_json(const irs::string_ref& args) {
   return nullptr;
 }
 
+///////////////////////////////////////////////////////////////////////////////
+/// @brief builds analyzer config from internal options in json format
+/// @param locale reference to analyzer`s locale
+/// @param definition string for storing json document with config 
+///////////////////////////////////////////////////////////////////////////////
+bool make_json_config( const std::string& locale,  std::string& definition) {
+  rapidjson::Document json;
+  json.SetObject();
+
+  rapidjson::Document::AllocatorType& allocator = json.GetAllocator();
+
+  // locale
+  json.AddMember(rapidjson::Value::StringRefType(localeParamName.c_str(), static_cast<rapidjson::SizeType>(localeParamName.size())),
+    rapidjson::Value(locale.c_str(), static_cast<rapidjson::SizeType>(locale.length())), allocator);
+
+  //output json to string
+  rapidjson::StringBuffer buffer;
+  rapidjson::Writer< rapidjson::StringBuffer> writer(buffer);
+  json.Accept(writer);
+  definition = buffer.GetString();
+  return true;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief args is a language to use for stemming
 ////////////////////////////////////////////////////////////////////////////////
@@ -96,6 +121,14 @@ irs::analysis::analyzer::ptr make_text(const irs::string_ref& args) {
   return nullptr;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+/// @brief build config string in 'text' format
+////////////////////////////////////////////////////////////////////////////////
+bool make_text_config(const std::string& locale, std::string& definition) {
+  definition = locale; 
+  return true;
+}
+
 REGISTER_ANALYZER_JSON(irs::analysis::text_token_stemming_stream, make_json);
 REGISTER_ANALYZER_TEXT(irs::analysis::text_token_stemming_stream, make_text);
 
@@ -111,6 +144,7 @@ text_token_stemming_stream::text_token_stemming_stream(
 ): analyzer(text_token_stemming_stream::type()),
    attrs_(4), // increment + offset + payload + term
    locale_(irs::locale_utils::locale(locale, irs::string_ref::NIL, true)), // true == convert to unicode
+   locale_name_(locale),
    term_eof_(true) {
   attrs_.emplace(inc_);
   attrs_.emplace(offset_);
@@ -204,6 +238,17 @@ bool text_token_stemming_stream::reset(const irs::string_ref& data) {
   term_.value(irs::ref_cast<irs::byte_type>(term_buf_));
 
   return true;
+}
+
+bool text_token_stemming_stream::to_string_impl(
+    const ::irs::text_format::type_id& format,
+    std::string& definition) const {
+  if (::irs::text_format::json == format)
+    return make_json_config(locale_name_, definition);
+  else if (::irs::text_format::text == format)
+    return make_text_config(locale_name_, definition);
+
+  return false;
 }
 
 NS_END // analysis

--- a/core/analysis/text_token_stemming_stream.hpp
+++ b/core/analysis/text_token_stemming_stream.hpp
@@ -50,11 +50,8 @@ class text_token_stemming_stream: public analyzer, util::noncopyable {
   static void init(); // for trigering registration in a static build
   virtual bool next() override;
   virtual bool reset(const irs::string_ref& data) override;
-
-  protected:
-   virtual bool to_string_impl(
-    const ::irs::text_format::type_id& format,
-    std::string& definition) const override;
+  virtual bool to_string(const ::irs::text_format::type_id& format,
+                         std::string& definition) const override;
 
   private:
    class term_attribute final: public irs::term_attribute {
@@ -66,7 +63,6 @@ class text_token_stemming_stream: public analyzer, util::noncopyable {
    irs::attribute_view attrs_;
    irs::increment inc_;
    std::locale locale_;
-   std::string locale_name_;
    irs::offset offset_;
    irs::payload payload_; // raw token value
    std::shared_ptr<sb_stemmer> stemmer_;

--- a/core/analysis/text_token_stemming_stream.hpp
+++ b/core/analysis/text_token_stemming_stream.hpp
@@ -51,6 +51,11 @@ class text_token_stemming_stream: public analyzer, util::noncopyable {
   virtual bool next() override;
   virtual bool reset(const irs::string_ref& data) override;
 
+  protected:
+   virtual bool to_string_impl(
+    const ::irs::text_format::type_id& format,
+    std::string& definition) const override;
+
   private:
    class term_attribute final: public irs::term_attribute {
     public:
@@ -61,6 +66,7 @@ class text_token_stemming_stream: public analyzer, util::noncopyable {
    irs::attribute_view attrs_;
    irs::increment inc_;
    std::locale locale_;
+   std::string locale_name_;
    irs::offset offset_;
    irs::payload payload_; // raw token value
    std::shared_ptr<sb_stemmer> stemmer_;

--- a/core/analysis/text_token_stream.cpp
+++ b/core/analysis/text_token_stream.cpp
@@ -26,6 +26,8 @@
 #include <mutex>
 #include <unordered_map>
 #include <rapidjson/rapidjson/document.h> // for rapidjson::Document, rapidjson::Value
+#include <rapidjson/rapidjson/writer.h> // for rapidjson::Writer
+#include <rapidjson/rapidjson/stringbuffer.h> // for rapidjson::StringBuffer
 #include <unicode/brkiter.h> // for icu::BreakIterator
 
 #if defined(_MSC_VER)
@@ -74,12 +76,13 @@ struct text_token_stream::state_t {
   icu::UnicodeString data;
   icu::Locale icu_locale;
   std::locale locale;
+  const stopwords_t& stopwords;
   std::shared_ptr<const icu::Normalizer2> normalizer;
   const options_t& options;
   std::shared_ptr<sb_stemmer> stemmer;
   std::string tmp_buf; // used by processTerm(...)
   std::shared_ptr<icu::Transliterator> transliterator;
-  state_t(const options_t& opts): icu_locale("C"), options(opts) {
+  state_t(const options_t& opts, const stopwords_t& stopw) : icu_locale("C"), options(opts), stopwords(stopw) {
     // NOTE: use of the default constructor for Locale() or
     //       use of Locale::createFromName(nullptr)
     //       causes a memory leak with Boost 1.58, as detected by valgrind
@@ -95,17 +98,19 @@ NS_LOCAL
 // -----------------------------------------------------------------------------
 // --SECTION--                                                 private variables
 // -----------------------------------------------------------------------------
-
-struct options_t: public irs::analysis::text_token_stream::options_t {
+struct cached_options_t: public irs::analysis::text_token_stream::options_t {
   std::string key_;
+  irs::analysis::text_token_stream::stopwords_t stopwords_;
 
-  options_t(irs::analysis::text_token_stream::options_t &&options)
-    : irs::analysis::text_token_stream::options_t(std::move(options)) {
+  cached_options_t(irs::analysis::text_token_stream::options_t &&options, 
+    irs::analysis::text_token_stream::stopwords_t&& stopwords)
+    : irs::analysis::text_token_stream::options_t(std::move(options)),
+      stopwords_(std::move(stopwords)){
   };
 };
 
-typedef std::unordered_set<std::string> ignored_words_t;
-static std::unordered_map<irs::hashed_string_ref, options_t> cached_state_by_key;
+
+static std::unordered_map<irs::hashed_string_ref, cached_options_t> cached_state_by_key;
 static std::mutex mutex;
 static auto icu_cleanup = irs::make_finally([]()->void{
   // this call will release/free all memory used by ICU (for all users)
@@ -117,13 +122,14 @@ static auto icu_cleanup = irs::make_finally([]()->void{
 // --SECTION--                                                 private functions
 // -----------------------------------------------------------------------------
 
+
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief retrieves a set of ignored words from FS at the specified custom path
 ////////////////////////////////////////////////////////////////////////////////
-bool get_ignored_words(
-  ignored_words_t& buf,
-  const std::locale& locale,
-  const irs::string_ref& path = irs::string_ref::NIL
+bool get_stopwords(
+    irs::analysis::text_token_stream::stopwords_t& buf,
+    const std::locale& locale,
+    const irs::string_ref& path = irs::string_ref::NIL
 ) {
   auto language = irs::locale_utils::language(locale);
   irs::utf8_path stopword_path;
@@ -163,8 +169,8 @@ bool get_ignored_words(
       return false;
     }
 
-    ignored_words_t ignored_words;
-    auto visitor = [&ignored_words, &stopword_path](
+    irs::analysis::text_token_stream::stopwords_t stopwords;
+    auto visitor = [&stopwords, &stopword_path](
         const irs::utf8_path::native_char_t* name
     )->bool {
       auto path = stopword_path;
@@ -198,7 +204,7 @@ bool get_ignored_words(
 
         // skip lines starting with whitespace
         if (i > 0) {
-          ignored_words.insert(line.substr(0, i));
+          stopwords.insert(line.substr(0, i));
         }
       }
 
@@ -209,7 +215,7 @@ bool get_ignored_words(
       return false;
     }
 
-    buf.insert(ignored_words.begin(), ignored_words.end());
+    buf.insert(stopwords.begin(), stopwords.end());
 
     return true;
   } catch (...) {
@@ -221,15 +227,43 @@ bool get_ignored_words(
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// @brief builds a set of stopwords for options
+/// load rules:
+/// 'explicit_stopwords' + 'stopwordsPath' = load from both
+/// 'explicit_stopwords' only - load from 'explicit_stopwords'
+/// 'stopwordsPath' only - load from 'stopwordsPath'
+///  none (empty explicit_Stopwords  and flg explicit_stopwords_set not set) - load from default location
+////////////////////////////////////////////////////////////////////////////////
+bool build_stopwords(const irs::analysis::text_token_stream::options_t& options,
+  irs::analysis::text_token_stream::stopwords_t& buf) {
+  if (!options.explicit_stopwords.empty()) {
+    buf.insert(options.explicit_stopwords.begin(), options.explicit_stopwords.end()); // explicit stopwords always go
+  }
+
+  if (options.stopwordsPath.empty() || options.stopwordsPath[0] != 0) {// we have a custom path. let`s try loading
+    auto locale = irs::locale_utils::locale(options.locale);
+    return get_stopwords(buf, locale, options.stopwordsPath); // if we have stopwordsPath - do not  try default location. Nothing to do there anymore
+  }
+  else if (!options.explicit_stopwords_set && options.explicit_stopwords.empty()) { //  no stopwordsPath, explicit_stopwords empty and not marked as valid - load from defaults
+    auto locale = irs::locale_utils::locale(options.locale);
+    return get_stopwords(buf, locale);
+  }
+
+  return true;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
 /// @brief create an analyzer based on the supplied cache_key and options
 ////////////////////////////////////////////////////////////////////////////////
 irs::analysis::analyzer::ptr construct(
   const irs::string_ref& cache_key,
-  irs::analysis::text_token_stream::options_t&& options
+  irs::analysis::text_token_stream::options_t&& options,
+  irs::analysis::text_token_stream::stopwords_t&& stopwords
 ) {
   static auto generator = [](
       const irs::hashed_string_ref& key,
-      options_t& value
+      cached_options_t& value
   ) NOEXCEPT {
     if (key.null()) {
       return key;
@@ -240,7 +274,7 @@ irs::analysis::analyzer::ptr construct(
     // reuse hash but point ref at value
     return irs::hashed_string_ref(key.hash(), value.key_);
   };
-  irs::analysis::text_token_stream::options_t* options_ptr;
+  cached_options_t* options_ptr;
 
   {
     SCOPED_LOCK(mutex);
@@ -249,12 +283,14 @@ irs::analysis::analyzer::ptr construct(
       cached_state_by_key,
       generator,
       irs::make_hashed_ref(cache_key, std::hash<irs::string_ref>()),
-      std::move(options)
+      std::move(options),
+      std::move(stopwords)
     ).first->second);
   }
 
   return irs::memory::make_unique<irs::analysis::text_token_stream>(
-    *options_ptr
+    *options_ptr,
+    options_ptr->stopwords_
   );
 }
 
@@ -272,25 +308,24 @@ irs::analysis::analyzer::ptr construct(
 
     if (itr != cached_state_by_key.end()) {
       return irs::memory::make_unique<irs::analysis::text_token_stream>(
-        itr->second
+        itr->second,
+        itr->second.stopwords_
       );
     }
   }
 
   try {
     irs::analysis::text_token_stream::options_t options;
-
+    irs::analysis::text_token_stream::stopwords_t stopwords;
     options.locale = cache_key; // interpret the cache_key as a locale name
-
-    auto locale = irs::locale_utils::locale(options.locale);
-
-    if (!get_ignored_words(options.ignored_words, locale)) {
+    
+    if (!build_stopwords(options, stopwords)) {
       IR_FRMT_WARN("Failed to retrieve 'stopwords' while constructing text_token_stream with cache key: %s", cache_key.c_str());
 
       return nullptr;
     }
 
-    return construct(cache_key, std::move(options));
+    return construct(cache_key, std::move(options), std::move(stopwords));
   } catch (...) {
     IR_FRMT_ERROR("Caught error while constructing text_token_stream cache key: %s", cache_key.c_str());
     IR_LOG_EXCEPTION();
@@ -345,7 +380,7 @@ bool process_term(
   // ...........................................................................
   // skip ignored tokens
   // ...........................................................................
-  if (state.options.ignored_words.find(word_utf8) != state.options.ignored_words.end()) {
+  if (state.stopwords.find(word_utf8) != state.stopwords.end()) {
     return false;
   }
 
@@ -375,12 +410,85 @@ bool process_term(
   return true;
 }
 
-static const irs::string_ref localeParamName           = "locale";
-static const irs::string_ref caseConvertParamName      = "caseConvert";
-static const irs::string_ref stopwordsParamName        = "stopwords";
-static const irs::string_ref stopwordsPathParamName    = "stopwordsPath";
-static const irs::string_ref noAccentParamName         = "noAccent";
-static const irs::string_ref noStemParamName           = "noStem";
+const irs::string_ref localeParamName           = "locale";
+const irs::string_ref caseConvertParamName      = "caseConvert";
+const irs::string_ref stopwordsParamName        = "stopwords";
+const irs::string_ref stopwordsPathParamName    = "stopwordsPath";
+const irs::string_ref noAccentParamName         = "noAccent";
+const irs::string_ref noStemParamName           = "noStem";
+
+const std::unordered_map<std::string, irs::analysis::text_token_stream::options_t::case_convert_t> case_convert_map = {
+       { "lower", irs::analysis::text_token_stream::options_t::case_convert_t::LOWER },
+       { "none", irs::analysis::text_token_stream::options_t::case_convert_t::NONE },
+       { "upper", irs::analysis::text_token_stream::options_t::case_convert_t::UPPER },
+};
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief builds analyzer config from internal options in json format
+/// @param options reference to analyzer options storage
+/// @param definition string for storing json document with config 
+///////////////////////////////////////////////////////////////////////////////
+bool make_json_config(
+  const irs::analysis::text_token_stream::options_t& options,
+  std::string& definition) {
+
+  rapidjson::Document json;
+  json.SetObject();
+
+  rapidjson::Document::AllocatorType& allocator = json.GetAllocator();
+
+  // locale
+  json.AddMember(rapidjson::Value::StringRefType(localeParamName.c_str(), static_cast<rapidjson::SizeType>(localeParamName.size())), 
+                  rapidjson::Value(options.locale.c_str(), static_cast<rapidjson::SizeType>(options.locale.length())), allocator);
+
+  // case convert
+  {
+    auto case_value = std::find_if(case_convert_map.begin(), case_convert_map.end(),
+      [&options](const decltype(case_convert_map)::value_type& v) { return v.second == options.case_convert; });
+    if (case_value != case_convert_map.end()) {
+      json.AddMember(rapidjson::Value::StringRefType(caseConvertParamName.c_str(), static_cast<rapidjson::SizeType>(caseConvertParamName.size())),
+        rapidjson::Value(case_value->first.c_str(), static_cast<rapidjson::SizeType>(case_value->first.length())), allocator);
+    } else {
+      IR_FRMT_ERROR(
+        "Invalid case_convert value in text analyzer options: %d", static_cast<int>(options.case_convert));
+      return false;
+    }
+  }
+ 
+  // stopwords
+  if(!options.explicit_stopwords.empty() || options.explicit_stopwords_set) { // explicit_stopwords_set  marks that even empty stopwords list is valid
+    rapidjson::Value stopwordsArray(rapidjson::kArrayType);
+    for (const auto& stopword : options.explicit_stopwords) {
+      stopwordsArray.PushBack(rapidjson::StringRef(stopword.c_str(), static_cast<rapidjson::SizeType>(stopword.size())), allocator);
+    }
+    json.AddMember(rapidjson::Value::StringRefType(stopwordsParamName.c_str(), static_cast<rapidjson::SizeType>(stopwordsParamName.size())),
+      stopwordsArray.Move(), allocator);
+  }
+
+  // noAccent
+  json.AddMember(rapidjson::Value::StringRefType(noAccentParamName.c_str(), static_cast<rapidjson::SizeType>(noAccentParamName.size())),
+    rapidjson::Value(options.no_accent), allocator);
+
+  //noStem
+  json.AddMember(rapidjson::Value::StringRefType(noStemParamName.c_str(), static_cast<rapidjson::SizeType>(noStemParamName.size())),
+    rapidjson::Value(options.no_stem), allocator);
+
+
+  //stopwords path
+  if (options.stopwordsPath.empty() || options.stopwordsPath[0] != 0 ) { // if stopwordsPath is set  - output it (empty string is also valid value =  use of CWD)
+    json.AddMember(rapidjson::Value::StringRefType(stopwordsPathParamName.c_str(), static_cast<rapidjson::SizeType>(stopwordsPathParamName.size())),
+      rapidjson::Value(options.stopwordsPath.c_str(), static_cast<rapidjson::SizeType>(options.stopwordsPath.length())), allocator);
+  }
+
+  //output json to string
+  rapidjson::StringBuffer buffer;
+  rapidjson::Writer< rapidjson::StringBuffer> writer(buffer);
+  json.Accept(writer);
+  definition = buffer.GetString();
+  return true;
+}
+
+
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief args is a jSON encoded object with the following attributes:
@@ -432,11 +540,6 @@ irs::analysis::analyzer::ptr make_json(const irs::string_ref& args) {
         return nullptr;
       }
 
-      static const std::unordered_map<std::string, options_t::case_convert_t> case_convert_map = {
-        { "lower", options_t::case_convert_t::LOWER },
-        { "none", options_t::case_convert_t::NONE },
-        { "upper", options_t::case_convert_t::UPPER },
-      };
       auto itr = case_convert_map.find(case_convert.GetString());
 
       if (itr == case_convert_map.end()) {
@@ -448,13 +551,7 @@ irs::analysis::analyzer::ptr make_json(const irs::string_ref& args) {
       options.case_convert = itr->second;
     }
 
-    auto locale = irs::locale_utils::locale(options.locale);
-
-    // load stopwords
-    // 'stopwords' + 'stopwordsPath' = load from both
-    // 'stopwords' only - load from 'stopwords'
-    // 'stopwordsPath' only - load from 'stopwordsPath'
-    // none - load from default location
+    
     if (json.HasMember(stopwordsParamName.c_str())) {
       auto& stop_words = json[stopwordsParamName.c_str()]; // optional string array
 
@@ -463,7 +560,7 @@ irs::analysis::analyzer::ptr make_json(const irs::string_ref& args) {
 
         return nullptr;
       }
-
+      options.explicit_stopwords_set = true; // mark  - we have explicit list (even if it is empty)
       for (auto itr = stop_words.Begin(), end = stop_words.End();
            itr != end;
            ++itr) {
@@ -472,10 +569,8 @@ irs::analysis::analyzer::ptr make_json(const irs::string_ref& args) {
 
           return nullptr;
         }
-
-        options.ignored_words.emplace(itr->GetString());
+        options.explicit_stopwords.emplace(itr->GetString());
       }
-
       if (json.HasMember(stopwordsPathParamName.c_str())) {
         auto& ignored_words_path = json[stopwordsPathParamName.c_str()]; // optional string
 
@@ -484,12 +579,7 @@ irs::analysis::analyzer::ptr make_json(const irs::string_ref& args) {
 
           return nullptr;
         }
-
-        if (!get_ignored_words(options.ignored_words, locale, ignored_words_path.GetString())) {
-          IR_FRMT_WARN("Failed to retrieve 'stopwords' from path while constructing text_token_stream from jSON arguments: %s", args.c_str());
-
-          return nullptr;
-        }
+        options.stopwordsPath = ignored_words_path.GetString();
       }
     } else if (json.HasMember(stopwordsPathParamName.c_str())) {
       auto& ignored_words_path = json[stopwordsPathParamName.c_str()]; // optional string
@@ -499,19 +589,8 @@ irs::analysis::analyzer::ptr make_json(const irs::string_ref& args) {
 
         return nullptr;
       }
-
-      if (!get_ignored_words(options.ignored_words, locale, ignored_words_path.GetString())) {
-        IR_FRMT_WARN("Failed to retrieve 'stopwords' from path while constructing text_token_stream from jSON arguments: %s", args.c_str());
-
-        return nullptr;
-      }
-    } else {
-      if (!get_ignored_words(options.ignored_words, locale)) {
-        IR_FRMT_WARN("Failed to retrieve 'stopwords' while constructing text_token_stream from jSON arguments: %s", args.c_str());
-
-        return nullptr;
-      }
-    }
+      options.stopwordsPath = ignored_words_path.GetString();
+    } 
 
     if (json.HasMember(noAccentParamName.c_str())) {
       auto& no_accent = json[noAccentParamName.c_str()]; // optional bool
@@ -537,7 +616,14 @@ irs::analysis::analyzer::ptr make_json(const irs::string_ref& args) {
       options.no_stem = no_stem.GetBool();
     }
 
-    return construct(args, std::move(options));
+    irs::analysis::text_token_stream::stopwords_t stopwords;
+    if (!build_stopwords(options, stopwords)) {
+      IR_FRMT_WARN("Failed to retrieve 'stopwords' from path while constructing text_token_stream from jSON arguments: %s", args.c_str());
+
+      return nullptr;
+    }
+
+    return construct(args, std::move(options), std::move(stopwords));
   } catch (...) {
     IR_FRMT_ERROR("Caught error while constructing text_token_stream from jSON arguments: %s", args.c_str());
     IR_LOG_EXCEPTION();
@@ -546,11 +632,21 @@ irs::analysis::analyzer::ptr make_json(const irs::string_ref& args) {
   return nullptr;
 }
 
+
+
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief args is a locale name
 ////////////////////////////////////////////////////////////////////////////////
 irs::analysis::analyzer::ptr make_text(const irs::string_ref& args) {
   return construct(args);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief build config string in 'text' format
+////////////////////////////////////////////////////////////////////////////////
+bool make_text_config(const irs::analysis::text_token_stream::options_t& options, std::string& definition) {
+  definition = options.locale; // only locale available with text config (see make_text)
+  return true;
 }
 
 REGISTER_ANALYZER_JSON(irs::analysis::text_token_stream, make_json);
@@ -560,6 +656,8 @@ NS_END
 
 NS_ROOT
 NS_BEGIN(analysis)
+
+
 
 // -----------------------------------------------------------------------------
 // --SECTION--                                                  static variables
@@ -577,10 +675,10 @@ DEFINE_ANALYZER_TYPE_NAMED(text_token_stream, "text")
 // --SECTION--                                      constructors and destructors
 // -----------------------------------------------------------------------------
 
-text_token_stream::text_token_stream(const options_t& options)
+text_token_stream::text_token_stream(const options_t& options, const stopwords_t& stopwords)
   : analyzer(text_token_stream::type()),
     attrs_(3), // offset + bytes_term + increment
-    state_(memory::make_unique<state_t>(options)) {
+    state_(memory::make_unique<state_t>(options, stopwords)) {
   attrs_.emplace(offs_);
   attrs_.emplace(term_);
   attrs_.emplace(inc_);
@@ -719,6 +817,17 @@ bool text_token_stream::next() {
     offs_.end = end;
     return true;
   }
+
+  return false;
+}
+
+bool text_token_stream::to_string_impl(
+   const ::irs::text_format::type_id& format,
+   std::string& definition) const {
+  if (::irs::text_format::json == format)
+    return make_json_config(state_->options, definition);
+  else if (::irs::text_format::text == format)
+    return make_text_config(state_->options, definition);
 
   return false;
 }

--- a/core/analysis/text_token_stream.hpp
+++ b/core/analysis/text_token_stream.hpp
@@ -34,13 +34,16 @@ NS_BEGIN(analysis)
 
 class text_token_stream : public analyzer, util::noncopyable {
  public:
+  typedef std::unordered_set<std::string> stopwords_t;
   struct options_t {
     enum case_convert_t { LOWER, NONE, UPPER };
     case_convert_t case_convert{case_convert_t::LOWER}; // lowercase tokens, mach original implementation
-    std::unordered_set<std::string> ignored_words;
+    stopwords_t explicit_stopwords;
+    bool explicit_stopwords_set{ false }; // needed for mark empty explicit_stopwords as valid and prevent loading from defaults
     std::string locale;
     bool no_accent{true}; // remove accents from letters, mach original implementation
     bool no_stem{false}; // try to stem if possible, mach original implementation
+    std::string stopwordsPath{0}; // string with zero char indicates 'no value set'
   };
 
   struct state_t;
@@ -74,13 +77,18 @@ class text_token_stream : public analyzer, util::noncopyable {
   // for use with irs::order::add<T>() and default args (static build)
   DECLARE_FACTORY(const irs::string_ref& locale);
 
-  text_token_stream(const options_t& options);
+  text_token_stream(const options_t& options, const stopwords_t& stopwords);
   virtual const irs::attribute_view& attributes() const NOEXCEPT override {
     return attrs_;
   }
   static void init(); // for trigering registration in a static build
   virtual bool next() override;
   virtual bool reset(const string_ref& data) override;
+
+ protected:
+  virtual bool to_string_impl(
+    const ::irs::text_format::type_id& format,
+    std::string& definition) const override;
 
  private:
   irs::attribute_view attrs_;

--- a/core/analysis/text_token_stream.hpp
+++ b/core/analysis/text_token_stream.hpp
@@ -37,9 +37,11 @@ class text_token_stream : public analyzer, util::noncopyable {
   typedef std::unordered_set<std::string> stopwords_t;
   struct options_t {
     enum case_convert_t { LOWER, NONE, UPPER };
-    case_convert_t case_convert{case_convert_t::LOWER}; // lowercase tokens, mach original implementation
+    // lowercase tokens, mach original implementation
+    case_convert_t case_convert{case_convert_t::LOWER};
     stopwords_t explicit_stopwords;
-    bool explicit_stopwords_set{ false }; // needed for mark empty explicit_stopwords as valid and prevent loading from defaults
+    // needed for mark empty explicit_stopwords as valid and prevent loading from defaults
+    bool explicit_stopwords_set{ false }; 
     std::string locale;
     bool no_accent{true}; // remove accents from letters, mach original implementation
     bool no_stem{false}; // try to stem if possible, mach original implementation
@@ -84,11 +86,8 @@ class text_token_stream : public analyzer, util::noncopyable {
   static void init(); // for trigering registration in a static build
   virtual bool next() override;
   virtual bool reset(const string_ref& data) override;
-
- protected:
-  virtual bool to_string_impl(
-    const ::irs::text_format::type_id& format,
-    std::string& definition) const override;
+  virtual bool to_string(const ::irs::text_format::type_id& format,
+                         std::string& definition) const override;
 
  private:
   irs::attribute_view attrs_;

--- a/core/analysis/token_masking_stream.cpp
+++ b/core/analysis/token_masking_stream.cpp
@@ -192,7 +192,7 @@ NS_END
 NS_ROOT
 NS_BEGIN(analysis)
 
-DEFINE_ANALYZER_TYPE_NAMED(token_masking_stream, "token-mask")
+DEFINE_ANALYZER_TYPE_NAMED(token_masking_stream, "mask")
 
 token_masking_stream::token_masking_stream(
     std::unordered_set<irs::bstring>&& mask

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -161,24 +161,24 @@ add_executable(${IResearchTests_TARGET_NAME}-static
 add_sanitizers(${IResearchTests_TARGET_NAME}-static)
 
 add_dependencies(${IResearchTests_TARGET_NAME}-shared
-  ${IResearch_TARGET_NAME}-analyzer-delimited-shared
+  ${IResearch_TARGET_NAME}-analyzer-delimiter-shared
   ${IResearch_TARGET_NAME}-analyzer-ngram-shared
   ${IResearch_TARGET_NAME}-analyzer-text-shared
-  ${IResearch_TARGET_NAME}-analyzer-text-normalizing-shared
-  ${IResearch_TARGET_NAME}-analyzer-text-stemming-shared
-  ${IResearch_TARGET_NAME}-analyzer-token-masking-shared
+  ${IResearch_TARGET_NAME}-analyzer-norm-shared
+  ${IResearch_TARGET_NAME}-analyzer-stem-shared
+  ${IResearch_TARGET_NAME}-analyzer-mask-shared
   ${IResearch_TARGET_NAME}-format-1_0-shared
   ${IResearch_TARGET_NAME}-scorer-tfidf-shared
   ${IResearch_TARGET_NAME}-scorer-bm25-shared
 )
 
 add_dependencies(${IResearchTests_TARGET_NAME}-static
-  ${IResearch_TARGET_NAME}-analyzer-delimited-static
+  ${IResearch_TARGET_NAME}-analyzer-delimiter-static
   ${IResearch_TARGET_NAME}-analyzer-ngram-static
   ${IResearch_TARGET_NAME}-analyzer-text-static
-  ${IResearch_TARGET_NAME}-analyzer-text-normalizing-static
-  ${IResearch_TARGET_NAME}-analyzer-text-stemming-static
-  ${IResearch_TARGET_NAME}-analyzer-token-masking-static
+  ${IResearch_TARGET_NAME}-analyzer-norm-static
+  ${IResearch_TARGET_NAME}-analyzer-stem-static
+  ${IResearch_TARGET_NAME}-analyzer-mask-static
   ${IResearch_TARGET_NAME}-format-1_0-static
   ${IResearch_TARGET_NAME}-scorer-tfidf-static
   ${IResearch_TARGET_NAME}-scorer-bm25-static
@@ -217,12 +217,12 @@ set_target_properties(${IResearchTests_TARGET_NAME}-static
 target_link_libraries(${IResearchTests_TARGET_NAME}-shared
   ${GCOV_LIBRARY}
   ${IResearch_TARGET_NAME}-shared
-  ${IResearch_TARGET_NAME}-analyzer-delimited-shared
+  ${IResearch_TARGET_NAME}-analyzer-delimiter-shared
   ${IResearch_TARGET_NAME}-analyzer-ngram-shared
   ${IResearch_TARGET_NAME}-analyzer-text-shared
-  ${IResearch_TARGET_NAME}-analyzer-text-normalizing-shared
-  ${IResearch_TARGET_NAME}-analyzer-text-stemming-shared
-  ${IResearch_TARGET_NAME}-analyzer-token-masking-shared
+  ${IResearch_TARGET_NAME}-analyzer-norm-shared
+  ${IResearch_TARGET_NAME}-analyzer-stem-shared
+  ${IResearch_TARGET_NAME}-analyzer-mask-shared
   ${IResearch_TARGET_NAME}-format-1_0-shared
   ${GTEST_STATIC_LIBS}
   ${PTHREAD_LIBRARY}

--- a/tests/analysis/delimited_token_stream_tests.cpp
+++ b/tests/analysis/delimited_token_stream_tests.cpp
@@ -469,6 +469,39 @@ TEST_F(delimited_token_stream_tests, test_load) {
   }
 }
 
+TEST_F(delimited_token_stream_tests, test_make_config_json) {
+
+  //with unknown parameter
+  {
+    std::string config = "{\"delimiter\":\",\",\"invalid_parameter\":true}";
+    auto stream = irs::analysis::analyzers::get("delimiter", irs::text_format::json, config.c_str());
+    ASSERT_NE(nullptr, stream);
+
+    std::string actual;
+    ASSERT_TRUE(stream->to_string(::irs::text_format::json, actual));
+    ASSERT_EQ("{\"delimiter\":\",\"}", actual);
+  }
+}
+
+TEST_F(delimited_token_stream_tests, test_make_config_text) {
+  std::string config = ",";
+  auto stream = irs::analysis::analyzers::get("delimiter", irs::text_format::text, config.c_str());
+  ASSERT_NE(nullptr, stream);
+
+  std::string actual;
+  ASSERT_TRUE(stream->to_string(::irs::text_format::text, actual));
+  ASSERT_EQ(config, actual);
+}
+
+TEST_F(delimited_token_stream_tests, test_make_config_invalid_format) {
+  std::string config = ",";
+  auto stream = irs::analysis::analyzers::get("delimiter", irs::text_format::text, config.c_str());
+  ASSERT_NE(nullptr, stream);
+
+  std::string actual;
+  ASSERT_FALSE(stream->to_string(::irs::text_format::csv, actual));
+}
+
 // -----------------------------------------------------------------------------
 // --SECTION--                                                       END-OF-FILE
 // -----------------------------------------------------------------------------

--- a/tests/analysis/ngram_token_stream_test.cpp
+++ b/tests/analysis/ngram_token_stream_test.cpp
@@ -517,4 +517,42 @@ TEST(ngram_token_stream_test, next) {
   }
 }
 
+TEST(ngram_token_stream_test, test_make_config_json) {
+
+  //with unknown parameter
+  {
+    std::string config = "{\"min\":1,\"max\":5,\"preserveOriginal\":false,\"invalid_parameter\":true}";
+    auto stream = irs::analysis::analyzers::get("ngram", irs::text_format::json, config.c_str());
+    ASSERT_NE(nullptr, stream);
+
+    std::string actual;
+    ASSERT_TRUE(stream->to_string(::irs::text_format::json, actual));
+    ASSERT_EQ("{\"min\":1,\"max\":5,\"preserveOriginal\":false}", actual);
+  }
+
+  //with changed values
+  {
+    std::string config = "{\"min\":11,\"max\":22,\"preserveOriginal\":true}";
+    auto stream = irs::analysis::analyzers::get("ngram", irs::text_format::json, config.c_str());
+    ASSERT_NE(nullptr, stream);
+
+    std::string actual;
+    ASSERT_TRUE(stream->to_string(::irs::text_format::json, actual));
+    ASSERT_EQ("{\"min\":11,\"max\":22,\"preserveOriginal\":true}", actual);
+  }
+}
+
+//TEST_F(ngram_token_stream_test, test_make_config_text) {
+// No text builder for analyzer so far
+//}
+
+TEST(ngram_token_stream_test, test_make_config_invalid_format) {
+  std::string config = "{\"min\":11,\"max\":22,\"preserveOriginal\":true}";
+  auto stream = irs::analysis::analyzers::get("ngram", irs::text_format::json, config.c_str());
+  ASSERT_NE(nullptr, stream);
+
+  std::string actual;
+  ASSERT_FALSE(stream->to_string(::irs::text_format::csv, actual));
+}
+
 #endif // IRESEARCH_DLL

--- a/tests/analysis/ngram_token_stream_test.cpp
+++ b/tests/analysis/ngram_token_stream_test.cpp
@@ -63,7 +63,7 @@ TEST(ngram_token_stream_test, construct) {
 
   // 2-gram
   {
-    auto stream = irs::analysis::ngram_token_stream::make(2, 2, true);
+    auto stream = irs::analysis::ngram_token_stream::make(irs::analysis::ngram_token_stream::options_t(2, 2, true));
     ASSERT_NE(nullptr, stream);
     ASSERT_EQ(irs::analysis::ngram_token_stream::type(), stream->type());
 
@@ -91,7 +91,7 @@ TEST(ngram_token_stream_test, construct) {
 
   // 0 == min_gram
   {
-    auto stream = irs::analysis::ngram_token_stream::make(0, 2, true);
+    auto stream = irs::analysis::ngram_token_stream::make(irs::analysis::ngram_token_stream::options_t(0, 2, true));
     ASSERT_NE(nullptr, stream);
     ASSERT_EQ(irs::analysis::ngram_token_stream::type(), stream->type());
 
@@ -119,7 +119,7 @@ TEST(ngram_token_stream_test, construct) {
 
   // min_gram > max_gram
   {
-    auto stream = irs::analysis::ngram_token_stream::make(std::numeric_limits<size_t>::max(), 2, true);
+    auto stream = irs::analysis::ngram_token_stream::make(irs::analysis::ngram_token_stream::options_t(std::numeric_limits<size_t>::max(), 2, true));
     ASSERT_NE(nullptr, stream);
     ASSERT_EQ(irs::analysis::ngram_token_stream::type(), stream->type());
 
@@ -151,7 +151,7 @@ TEST(ngram_token_stream_test, construct) {
 
 
 TEST(ngram_token_stream_test, reset_too_big) {
-  irs::analysis::ngram_token_stream stream(1, 1, false);
+  irs::analysis::ngram_token_stream stream(irs::analysis::ngram_token_stream::options_t(1, 1, false));
 
   const irs::string_ref input(
     reinterpret_cast<const char*>(&stream),
@@ -211,7 +211,7 @@ TEST(ngram_token_stream_test, next) {
 
   // 1-gram
   {
-    irs::analysis::ngram_token_stream stream(1, 1, false);
+    irs::analysis::ngram_token_stream stream(irs::analysis::ngram_token_stream::options_t(1, 1, false));
 
     const std::vector<token> expected {
       { "q", 0, 1 },
@@ -226,7 +226,7 @@ TEST(ngram_token_stream_test, next) {
 
   // 1-gram, preserve original
   {
-    irs::analysis::ngram_token_stream stream(1, 1, true);
+    irs::analysis::ngram_token_stream stream(irs::analysis::ngram_token_stream::options_t(1, 1, true));
 
     const std::vector<token> expected {
       { "q", 0, 1 },
@@ -242,7 +242,7 @@ TEST(ngram_token_stream_test, next) {
 
   // 2-gram
   {
-    irs::analysis::ngram_token_stream stream(2, 2, false);
+    irs::analysis::ngram_token_stream stream(irs::analysis::ngram_token_stream::options_t(2, 2, false));
 
     const std::vector<token> expected {
       { "qu", 0, 2 },
@@ -256,7 +256,7 @@ TEST(ngram_token_stream_test, next) {
 
   // 2-gram, preserver original
   {
-    irs::analysis::ngram_token_stream stream(2, 2, true);
+    irs::analysis::ngram_token_stream stream(irs::analysis::ngram_token_stream::options_t(2, 2, true));
 
     const std::vector<token> expected {
       { "qu", 0, 2 },
@@ -271,7 +271,7 @@ TEST(ngram_token_stream_test, next) {
 
   // 1..2-gram
   {
-    irs::analysis::ngram_token_stream stream(1, 2, false);
+    irs::analysis::ngram_token_stream stream(irs::analysis::ngram_token_stream::options_t(1, 2, false));
 
     const std::vector<token> expected {
       { "qu", 0, 2 },
@@ -290,7 +290,7 @@ TEST(ngram_token_stream_test, next) {
 
   // 3-gram
   {
-    irs::analysis::ngram_token_stream stream(3, 3, false);
+    irs::analysis::ngram_token_stream stream(irs::analysis::ngram_token_stream::options_t(3, 3, false));
 
     const std::vector<token> expected {
       { "qui", 0, 3 },
@@ -303,7 +303,7 @@ TEST(ngram_token_stream_test, next) {
 
   // 1..3-gram
   {
-    irs::analysis::ngram_token_stream stream(1, 3, false);
+    irs::analysis::ngram_token_stream stream(irs::analysis::ngram_token_stream::options_t(1, 3, false));
 
     const std::vector<token> expected {
       { "qui", 0, 3 },
@@ -325,7 +325,7 @@ TEST(ngram_token_stream_test, next) {
 
   // 2..3-gram
   {
-    irs::analysis::ngram_token_stream stream(2, 3, false);
+    irs::analysis::ngram_token_stream stream(irs::analysis::ngram_token_stream::options_t(2, 3, false));
 
     const std::vector<token> expected {
       { "qui", 0, 3 },
@@ -342,7 +342,7 @@ TEST(ngram_token_stream_test, next) {
 
   // 2..3-gram, preserve origianl
   {
-    irs::analysis::ngram_token_stream stream(2, 3, true);
+    irs::analysis::ngram_token_stream stream(irs::analysis::ngram_token_stream::options_t(2, 3, true));
 
     const std::vector<token> expected {
       { "qui", 0, 3 },
@@ -360,7 +360,7 @@ TEST(ngram_token_stream_test, next) {
 
   // 4-gram
   {
-    irs::analysis::ngram_token_stream stream(4, 4, false);
+    irs::analysis::ngram_token_stream stream(irs::analysis::ngram_token_stream::options_t( 4, 4, false ));
 
     const std::vector<token> expected {
       { "quic", 0, 4 },
@@ -372,7 +372,7 @@ TEST(ngram_token_stream_test, next) {
 
   // 1..4-gram
   {
-    irs::analysis::ngram_token_stream stream(1, 4, false);
+    irs::analysis::ngram_token_stream stream(irs::analysis::ngram_token_stream::options_t(1, 4, false));
 
     const std::vector<token> expected {
       { "quic", 0, 4 },
@@ -396,7 +396,7 @@ TEST(ngram_token_stream_test, next) {
 
   // 5-gram
   {
-    irs::analysis::ngram_token_stream stream(5, 5, false);
+    irs::analysis::ngram_token_stream stream(irs::analysis::ngram_token_stream::options_t(5, 5, false));
 
     const std::vector<token> expected {
       { "quick", 0, 5 }
@@ -407,7 +407,7 @@ TEST(ngram_token_stream_test, next) {
 
   // 5-gram, preserve original
   {
-    irs::analysis::ngram_token_stream stream(5, 5, true);
+    irs::analysis::ngram_token_stream stream(irs::analysis::ngram_token_stream::options_t(5, 5, true));
 
     const std::vector<token> expected {
       { "quick", 0, 5 }
@@ -418,7 +418,7 @@ TEST(ngram_token_stream_test, next) {
 
   // 1..5-gram
   {
-    irs::analysis::ngram_token_stream stream(1, 5, false);
+    irs::analysis::ngram_token_stream stream(irs::analysis::ngram_token_stream::options_t(1, 5, false));
 
     const std::vector<token> expected {
       { "quick", 0, 5 },
@@ -443,7 +443,7 @@ TEST(ngram_token_stream_test, next) {
 
   // 3..5-gram
   {
-    irs::analysis::ngram_token_stream stream(3, 5, false);
+    irs::analysis::ngram_token_stream stream(irs::analysis::ngram_token_stream::options_t(3, 5, false));
 
     const std::vector<token> expected {
       { "quick", 0, 5 },
@@ -459,7 +459,7 @@ TEST(ngram_token_stream_test, next) {
 
   // 6-gram
   {
-    irs::analysis::ngram_token_stream stream(6, 6, false);
+    irs::analysis::ngram_token_stream stream(irs::analysis::ngram_token_stream::options_t(6, 6, false));
 
     const std::vector<token> expected { };
 
@@ -468,7 +468,7 @@ TEST(ngram_token_stream_test, next) {
 
   // 1..6-gram
   {
-    irs::analysis::ngram_token_stream stream(1, 6, false);
+    irs::analysis::ngram_token_stream stream(irs::analysis::ngram_token_stream::options_t(1, 6, false));
 
     const std::vector<token> expected {
       { "quick", 0, 5 },
@@ -493,7 +493,7 @@ TEST(ngram_token_stream_test, next) {
 
   // 1..6-gram, preserve original
   {
-    irs::analysis::ngram_token_stream stream(1, 6, true);
+    irs::analysis::ngram_token_stream stream(irs::analysis::ngram_token_stream::options_t(1, 6, true));
 
     const std::vector<token> expected {
       { "quick", 0, 5 },

--- a/tests/analysis/text_analyzer_tests.cpp
+++ b/tests/analysis/text_analyzer_tests.cpp
@@ -826,18 +826,18 @@ TEST_F(TextAnalyzerParserTestSuite, test_make_config_json) {
 }
 
 TEST_F(TextAnalyzerParserTestSuite, test_make_config_text) {
-  std::string config = "ru_RU.UTF-8";
-  auto stream = irs::analysis::analyzers::get("text", irs::text_format::text, config.c_str());
+  std::string config = "{\"locale\":\"ru_RU.UTF-8\",\"caseConvert\":\"lower\",\"stopwords\":[],\"noAccent\":false}";
+  auto stream = irs::analysis::analyzers::get("text", irs::text_format::json, config.c_str());
   ASSERT_NE(nullptr, stream);
 
   std::string actual;
   ASSERT_TRUE(stream->to_string(::irs::text_format::text, actual));
-  ASSERT_EQ(config, actual);
+  ASSERT_EQ("ru_RU.UTF-8", actual);
 }
 
 TEST_F(TextAnalyzerParserTestSuite, test_make_config_invalid_format) {
-  std::string config = "ru_RU.UTF-8";
-  auto stream = irs::analysis::analyzers::get("text", irs::text_format::text, config.c_str());
+  std::string config = "{\"locale\":\"ru_RU.UTF-8\",\"caseConvert\":\"lower\",\"stopwords\":[],\"noAccent\":false}";
+  auto stream = irs::analysis::analyzers::get("text", irs::text_format::json, config.c_str());
   ASSERT_NE(nullptr, stream);
 
   std::string actual;

--- a/tests/analysis/text_analyzer_tests.cpp
+++ b/tests/analysis/text_analyzer_tests.cpp
@@ -29,6 +29,9 @@
 #include "analysis/token_stream.hpp"
 #include "utils/locale_utils.hpp"
 #include "utils/runtime_utils.hpp"
+#include "utils/utf8_path.hpp"
+
+#include <rapidjson/document.h> // for rapidjson::Document, rapidjson::Value
 
 NS_LOCAL
 
@@ -75,7 +78,7 @@ TEST_F(TextAnalyzerParserTestSuite, test_nbsp_whitespace) {
   auto locale = irs::locale_utils::locale(irs::string_ref::NIL, "utf8", true); // utf8 internal and external
   std::string data;
   ASSERT_TRUE(irs::locale_utils::append_external<wchar_t>(data, sDataUCS2, locale));
-  irs::analysis::text_token_stream stream(options);
+  irs::analysis::text_token_stream stream(options, options.explicit_stopwords);
 
   ASSERT_TRUE(stream.reset(data));
 
@@ -105,7 +108,7 @@ TEST_F(TextAnalyzerParserTestSuite, test_text_analyzer) {
     options.locale = "en_US.UTF-8";
 
     std::string data = " A  hErd of   quIck brown  foXes ran    and Jumped over  a     runninG dog";
-    irs::analysis::text_token_stream stream(options);
+    irs::analysis::text_token_stream stream(options, options.explicit_stopwords);
 
     auto testFunc = [](const irs::string_ref& data, analyzer* pStream) {
       ASSERT_TRUE(pStream->reset(data));
@@ -146,7 +149,7 @@ TEST_F(TextAnalyzerParserTestSuite, test_text_analyzer) {
     {
       irs::analysis::text_token_stream::options_t options;
       options.locale = "en_US.UTF-8";
-      irs::analysis::text_token_stream stream(options);
+      irs::analysis::text_token_stream stream(options, options.explicit_stopwords);
       testFunc(data, &stream);
     }
     {
@@ -183,7 +186,7 @@ TEST_F(TextAnalyzerParserTestSuite, test_text_analyzer) {
       irs::analysis::text_token_stream::options_t options;
       options.case_convert = irs::analysis::text_token_stream::options_t::case_convert_t::LOWER;
       options.locale = "en_US.UTF-8";
-      irs::analysis::text_token_stream stream(options);
+      irs::analysis::text_token_stream stream(options, options.explicit_stopwords);
       testFunc(data, &stream);
     }
     {
@@ -218,7 +221,7 @@ TEST_F(TextAnalyzerParserTestSuite, test_text_analyzer) {
       irs::analysis::text_token_stream::options_t options;
       options.case_convert = irs::analysis::text_token_stream::options_t::case_convert_t::UPPER;
       options.locale = "en_US.UTF-8";
-      irs::analysis::text_token_stream stream(options);
+      irs::analysis::text_token_stream stream(options, options.explicit_stopwords);
       testFunc(data, &stream);
     }
     {
@@ -254,7 +257,7 @@ TEST_F(TextAnalyzerParserTestSuite, test_text_analyzer) {
       irs::analysis::text_token_stream::options_t options;
       options.case_convert = irs::analysis::text_token_stream::options_t::case_convert_t::NONE;
       options.locale = "en_US.UTF-8";
-      irs::analysis::text_token_stream stream(options);
+      irs::analysis::text_token_stream stream(options, options.explicit_stopwords);
       testFunc(data, &stream);
     }
     {
@@ -291,9 +294,9 @@ TEST_F(TextAnalyzerParserTestSuite, test_text_analyzer) {
 
     {
       irs::analysis::text_token_stream::options_t options;
-      options.ignored_words = std::unordered_set<std::string>({ "a", "of", "and" });
+      options.explicit_stopwords = std::unordered_set<std::string>({ "a", "of", "and" });
       options.locale = "en_US.UTF-8";
-      irs::analysis::text_token_stream stream(options);
+      irs::analysis::text_token_stream stream(options, options.explicit_stopwords);
       testFunc(data, &stream);
     }
     {
@@ -343,7 +346,7 @@ TEST_F(TextAnalyzerParserTestSuite, test_text_analyzer) {
     {
       irs::analysis::text_token_stream::options_t options;
       options.locale = "ru_RU.UTF-8";
-      irs::analysis::text_token_stream stream(options);
+      irs::analysis::text_token_stream stream(options, options.explicit_stopwords);
       testFunc(data, &stream);
     }
     {
@@ -392,7 +395,7 @@ TEST_F(TextAnalyzerParserTestSuite, test_text_analyzer) {
 
       options.locale = "ru_RU.UTF-8";
       options.no_accent = false;
-      irs::analysis::text_token_stream stream(options);
+      irs::analysis::text_token_stream stream(options, options.explicit_stopwords);
       testFunc(data, &stream);
     }
     {
@@ -439,7 +442,7 @@ TEST_F(TextAnalyzerParserTestSuite, test_text_analyzer) {
       irs::analysis::text_token_stream::options_t options;
       options.locale = "ru_RU.UTF-8";
       options.no_stem = true;
-      irs::analysis::text_token_stream stream(options);
+      irs::analysis::text_token_stream stream(options, options.explicit_stopwords);
       testFunc(data, &stream);
     }
     {
@@ -475,7 +478,7 @@ TEST_F(TextAnalyzerParserTestSuite, test_text_analyzer) {
     {
       irs::analysis::text_token_stream::options_t options;
       options.locale = "tr-TR.UTF-8";
-      irs::analysis::text_token_stream stream(options);
+      irs::analysis::text_token_stream stream(options, options.explicit_stopwords);
       testFunc(data, &stream);
     }
     {
@@ -520,7 +523,7 @@ TEST_F(TextAnalyzerParserTestSuite, test_text_analyzer) {
     {
       irs::analysis::text_token_stream::options_t options;
       options.locale = "zh_CN.UTF-8";
-      irs::analysis::text_token_stream stream(options);
+      irs::analysis::text_token_stream stream(options, options.explicit_stopwords);
       testFunc(data, &stream);
     }
     {
@@ -540,7 +543,7 @@ TEST_F(TextAnalyzerParserTestSuite, test_text_analyzer) {
       // ICU locale will fail initialization for an invalid std:locale
       irs::analysis::text_token_stream::options_t options;
       options.locale = "invalid12345.UTF-8";
-      irs::analysis::text_token_stream stream(options);
+      irs::analysis::text_token_stream stream(options, options.explicit_stopwords);
       ASSERT_FALSE(stream.reset(data));
     }
     {
@@ -647,6 +650,198 @@ TEST_F(TextAnalyzerParserTestSuite, test_load_stopwords_path_override) {
   auto stream = irs::analysis::analyzers::get("text", irs::text_format::json, "{\"locale\":\"en_US.UTF-8\", \"stopwordsPath\":\"" IResearch_test_resource_dir "\"}");
   ASSERT_NE(nullptr, stream);
   testFunc(sDataASCII, stream);
+}
+
+TEST_F(TextAnalyzerParserTestSuite, test_load_stopwords_path_override_emptypath) {
+  // no stopwords, but empty stopwords path (we need to shift CWD to our test resources, to be able to load stopwords)
+  auto oldCWD = irs::utf8_path(true);
+  auto newCWD = irs::utf8_path(IResearch_test_resource_dir);
+  newCWD.chdir();
+  auto reset_stopword_path = irs::make_finally([oldCWD]()->void {
+    oldCWD.chdir();
+  });
+
+  std::string config = "{\"locale\":\"en_US.UTF-8\",\"caseConvert\":\"lower\",\"noAccent\":true,\"noStem\":false,\"stopwordsPath\":\"\"}";
+  auto stream = irs::analysis::analyzers::get("text", irs::text_format::json, config);
+  ASSERT_NE(nullptr, stream);
+
+  // Checking that default stowords are loaded
+  std::string sDataASCII = "A E I O U";
+  ASSERT_TRUE(stream->reset(sDataASCII));
+  auto& pOffset = stream->attributes().get<iresearch::offset>();
+  auto& pPayload = stream->attributes().get<iresearch::payload>();
+  auto& pValue = stream->attributes().get<iresearch::term_attribute>();
+
+  ASSERT_TRUE(stream->next());
+  ASSERT_EQ("e", std::string((char*)(pValue->value().c_str()), pValue->value().size()));
+  ASSERT_TRUE(stream->next());
+  ASSERT_EQ("u", std::string((char*)(pValue->value().c_str()), pValue->value().size()));
+  ASSERT_FALSE(stream->next());
+}
+
+TEST_F(TextAnalyzerParserTestSuite, test_make_config_json) {
+  
+  //with unknown parameter
+  {
+    std::string config = "{\"locale\":\"ru_RU.UTF-8\",\"caseConvert\":\"lower\",\"invalid_parameter\":true,\"stopwords\":[],\"noAccent\":false,\"noStem\":true}";
+    auto stream = irs::analysis::analyzers::get("text", irs::text_format::json, config.c_str());
+    ASSERT_NE(nullptr, stream);
+
+    std::string actual;
+    ASSERT_TRUE(stream->to_string(::irs::text_format::json, actual));
+    ASSERT_EQ("{\"locale\":\"ru_RU.UTF-8\",\"caseConvert\":\"lower\",\"stopwords\":[],\"noAccent\":false,\"noStem\":true}", actual);
+  }
+
+  // no case convert in creation. Default value shown
+  {
+    std::string config = "{\"locale\":\"ru_RU.UTF-8\",\"stopwords\":[],\"noAccent\":false,\"noStem\":true}";
+    auto stream = irs::analysis::analyzers::get("text", irs::text_format::json, config);
+    ASSERT_NE(nullptr, stream);
+
+    std::string actual;
+    ASSERT_TRUE(stream->to_string(::irs::text_format::json, actual));
+    ASSERT_EQ("{\"locale\":\"ru_RU.UTF-8\",\"caseConvert\":\"lower\",\"stopwords\":[],\"noAccent\":false,\"noStem\":true}" , actual);
+  }
+
+  // no accent in creation. Default value shown
+  {
+    std::string config = "{\"locale\":\"ru_RU.UTF-8\",\"caseConvert\":\"lower\",\"stopwords\":[],\"noStem\":true}";
+    auto stream = irs::analysis::analyzers::get("text", irs::text_format::json, config);
+    ASSERT_NE(nullptr, stream);
+
+    std::string actual;
+    ASSERT_TRUE(stream->to_string(::irs::text_format::json, actual));
+    ASSERT_EQ("{\"locale\":\"ru_RU.UTF-8\",\"caseConvert\":\"lower\",\"stopwords\":[],\"noAccent\":true,\"noStem\":true}", actual);
+  }
+
+  // no stem in creation. Default value shown
+  {
+    std::string config = "{\"locale\":\"ru_RU.UTF-8\",\"caseConvert\":\"lower\",\"stopwords\":[],\"noAccent\":false}";
+    auto stream = irs::analysis::analyzers::get("text", irs::text_format::json, config);
+    ASSERT_NE(nullptr, stream);
+
+    std::string actual;
+    ASSERT_TRUE(stream->to_string(::irs::text_format::json, actual));
+    ASSERT_EQ("{\"locale\":\"ru_RU.UTF-8\",\"caseConvert\":\"lower\",\"stopwords\":[],\"noAccent\":false,\"noStem\":false}", actual);
+  }
+
+  // non default values for stem, accent and case
+  {
+    std::string config = "{\"locale\":\"ru_RU.UTF-8\",\"caseConvert\":\"upper\",\"stopwords\":[],\"noAccent\":false,\"noStem\":true}";
+    auto stream = irs::analysis::analyzers::get("text", irs::text_format::json, config);
+    ASSERT_NE(nullptr, stream);
+
+    std::string actual;
+    ASSERT_TRUE(stream->to_string(::irs::text_format::json, actual));
+    ASSERT_EQ(config, actual);
+  }
+
+  // no stopwords no stopwords path
+  {
+    const char* czOldStopwordPath = iresearch::getenv(text_token_stream::STOPWORD_PATH_ENV_VARIABLE);
+    std::string sOldStopwordPath = czOldStopwordPath == nullptr ? "" : czOldStopwordPath;
+    auto reset_stopword_path = irs::make_finally([czOldStopwordPath, sOldStopwordPath]()->void {
+      if (czOldStopwordPath) {
+        irs::setenv(text_token_stream::STOPWORD_PATH_ENV_VARIABLE, sOldStopwordPath.c_str(), true);
+      }
+    });
+
+    iresearch::setenv(text_token_stream::STOPWORD_PATH_ENV_VARIABLE, IResearch_test_resource_dir, true);
+
+    std::string config = "{\"locale\":\"en_US.UTF-8\",\"caseConvert\":\"lower\",\"noAccent\":true,\"noStem\":false}";
+    auto stream = irs::analysis::analyzers::get("text", irs::text_format::json, config);
+    ASSERT_NE(nullptr, stream);
+
+    std::string actual;
+    ASSERT_TRUE(stream->to_string(::irs::text_format::json, actual));
+    ASSERT_EQ(config, actual);
+  }
+  
+  // empty stopwords, but stopwords path
+  {
+    std::string config = "{\"locale\":\"en_US.UTF-8\",\"caseConvert\":\"upper\",\"stopwords\":[],\"noAccent\":true,\"noStem\":false,\"stopwordsPath\":\"" IResearch_test_resource_dir "\"}";
+    auto stream = irs::analysis::analyzers::get("text", irs::text_format::json, config);
+    ASSERT_NE(nullptr, stream);
+
+    std::string actual;
+    ASSERT_TRUE(stream->to_string(::irs::text_format::json, actual));
+    ASSERT_EQ(config, actual);
+  }
+
+  // no stopwords, but stopwords path
+  {
+    std::string config = "{\"locale\":\"en_US.UTF-8\",\"caseConvert\":\"upper\",\"noAccent\":true,\"noStem\":false,\"stopwordsPath\":\"" IResearch_test_resource_dir "\"}";
+    auto stream = irs::analysis::analyzers::get("text", irs::text_format::json, config);
+    ASSERT_NE(nullptr, stream);
+
+    std::string actual;
+    ASSERT_TRUE(stream->to_string(::irs::text_format::json, actual));
+    ASSERT_EQ(config, actual);
+  }
+
+  // no stopwords, but empty stopwords path (we need to shift CWD to our test resources, to be able to load stopwords)
+  {
+    auto oldCWD = irs::utf8_path(true);
+    auto newCWD = irs::utf8_path(IResearch_test_resource_dir);
+    newCWD.chdir();
+    auto reset_stopword_path = irs::make_finally([oldCWD]()->void {
+      oldCWD.chdir();
+    });
+
+    std::string config = "{\"locale\":\"en_US.UTF-8\",\"caseConvert\":\"lower\",\"noAccent\":true,\"noStem\":false,\"stopwordsPath\":\"\"}";
+    auto stream = irs::analysis::analyzers::get("text", irs::text_format::json, config);
+    ASSERT_NE(nullptr, stream);
+
+    std::string actual;
+    ASSERT_TRUE(stream->to_string(::irs::text_format::json, actual));
+    ASSERT_EQ(config, actual);
+  }
+
+
+  // non-empty stopwords with duplicates
+  {
+    std::string config = "{\"locale\":\"en_US.UTF-8\",\"caseConvert\":\"upper\",\"stopwords\":[\"z\",\"a\",\"b\",\"a\"],\"noAccent\":true,\"noStem\":false,\"stopwordsPath\":\"" IResearch_test_resource_dir "\"}";
+    auto stream = irs::analysis::analyzers::get("text", irs::text_format::json, config);
+    ASSERT_NE(nullptr, stream);
+
+    std::string actual;
+    ASSERT_TRUE(stream->to_string(::irs::text_format::json, actual));
+
+    // stopwords order is not guaranteed. Need to deep check json
+    rapidjson::Document json;
+    ASSERT_FALSE(json.Parse(actual.c_str(), actual.size()).HasParseError());
+    ASSERT_TRUE(json.HasMember("stopwords"));
+    auto& stopwords = json["stopwords"]; 
+    ASSERT_TRUE(stopwords.IsArray());
+
+    std::unordered_set<std::string> expected_stopwords = { "z","a","b" };
+    for (auto itr = stopwords.Begin(), end = stopwords.End();
+      itr != end;
+      ++itr) {
+      ASSERT_TRUE(itr->IsString());
+      expected_stopwords.erase(itr->GetString());
+    }
+    ASSERT_TRUE(expected_stopwords.empty());
+  }
+}
+
+TEST_F(TextAnalyzerParserTestSuite, test_make_config_text) {
+  std::string config = "ru_RU.UTF-8";
+  auto stream = irs::analysis::analyzers::get("text", irs::text_format::text, config.c_str());
+  ASSERT_NE(nullptr, stream);
+
+  std::string actual;
+  ASSERT_TRUE(stream->to_string(::irs::text_format::text, actual));
+  ASSERT_EQ(config, actual);
+}
+
+TEST_F(TextAnalyzerParserTestSuite, test_make_config_invalid_format) {
+  std::string config = "ru_RU.UTF-8";
+  auto stream = irs::analysis::analyzers::get("text", irs::text_format::text, config.c_str());
+  ASSERT_NE(nullptr, stream);
+
+  std::string actual;
+  ASSERT_FALSE(stream->to_string(::irs::text_format::csv, actual));
 }
 // -----------------------------------------------------------------------------
 // --SECTION--                                                       END-OF-FILE

--- a/tests/analysis/text_token_normalizing_stream_tests.cpp
+++ b/tests/analysis/text_token_normalizing_stream_tests.cpp
@@ -311,6 +311,74 @@ TEST_F(text_token_normalizing_stream_tests, test_load) {
   }
 }
 
+TEST_F(text_token_normalizing_stream_tests, test_make_config_json) {
+
+  //with unknown parameter
+  {
+    std::string config = "{\"locale\":\"ru_RU.UTF-8\",\"caseConvert\":\"lower\",\"invalid_parameter\":true,\"noAccent\":false}";
+    auto stream = irs::analysis::analyzers::get("norm", irs::text_format::json, config.c_str());
+    ASSERT_NE(nullptr, stream);
+
+    std::string actual;
+    ASSERT_TRUE(stream->to_string(::irs::text_format::json, actual));
+    ASSERT_EQ("{\"locale\":\"ru_RU.UTF-8\",\"caseConvert\":\"lower\",\"noAccent\":false}", actual);
+  }
+
+  // no case convert in creation. Default value shown
+  {
+    std::string config = "{\"locale\":\"ru_RU.UTF-8\",\"noAccent\":false}";
+    auto stream = irs::analysis::analyzers::get("norm", irs::text_format::json, config);
+    ASSERT_NE(nullptr, stream);
+
+    std::string actual;
+    ASSERT_TRUE(stream->to_string(::irs::text_format::json, actual));
+    ASSERT_EQ("{\"locale\":\"ru_RU.UTF-8\",\"caseConvert\":\"none\",\"noAccent\":false}", actual);
+  }
+
+  // no accent in creation. Default value shown
+  {
+    std::string config = "{\"locale\":\"ru_RU.UTF-8\",\"caseConvert\":\"lower\"}";
+    auto stream = irs::analysis::analyzers::get("norm", irs::text_format::json, config);
+    ASSERT_NE(nullptr, stream);
+
+    std::string actual;
+    ASSERT_TRUE(stream->to_string(::irs::text_format::json, actual));
+    ASSERT_EQ("{\"locale\":\"ru_RU.UTF-8\",\"caseConvert\":\"lower\",\"noAccent\":false}", actual);
+  }
+
+  
+  // non default values for accent and case
+  {
+    std::string config = "{\"locale\":\"ru_RU.UTF-8\",\"caseConvert\":\"upper\",\"noAccent\":false}";
+    auto stream = irs::analysis::analyzers::get("norm", irs::text_format::json, config);
+    ASSERT_NE(nullptr, stream);
+
+    std::string actual;
+    ASSERT_TRUE(stream->to_string(::irs::text_format::json, actual));
+    ASSERT_EQ(config, actual);
+  }
+
+}
+
+TEST_F(text_token_normalizing_stream_tests, test_make_config_text) {
+  std::string config = "ru_RU.UTF-8";
+  auto stream = irs::analysis::analyzers::get("norm", irs::text_format::text, config.c_str());
+  ASSERT_NE(nullptr, stream);
+
+  std::string actual;
+  ASSERT_TRUE(stream->to_string(::irs::text_format::text, actual));
+  ASSERT_EQ(config, actual);
+}
+
+TEST_F(text_token_normalizing_stream_tests, test_make_config_invalid_format) {
+  std::string config = "ru_RU.UTF-8";
+  auto stream = irs::analysis::analyzers::get("norm", irs::text_format::text, config.c_str());
+  ASSERT_NE(nullptr, stream);
+
+  std::string actual;
+  ASSERT_FALSE(stream->to_string(::irs::text_format::csv, actual));
+}
+
 // -----------------------------------------------------------------------------
 // --SECTION--                                                       END-OF-FILE
 // -----------------------------------------------------------------------------

--- a/tests/analysis/text_token_stemming_stream_tests.cpp
+++ b/tests/analysis/text_token_stemming_stream_tests.cpp
@@ -189,13 +189,13 @@ TEST_F(text_token_stemming_stream_tests, test_make_config_json) {
 
     std::string actual;
     ASSERT_TRUE(stream->to_string(::irs::text_format::json, actual));
-    ASSERT_EQ("{\"locale\":\"ru_RU.UTF-8\"}", actual);
+    ASSERT_EQ("{\"locale\":\"ru_RU.utf-8\"}", actual);
   }
 
 }
 
 TEST_F(text_token_stemming_stream_tests, test_make_config_text) {
-  std::string config = "ru_RU.UTF-8";
+  std::string config = "ru_RU.utf-8";
   auto stream = irs::analysis::analyzers::get("stem", irs::text_format::text, config.c_str());
   ASSERT_NE(nullptr, stream);
 
@@ -205,7 +205,7 @@ TEST_F(text_token_stemming_stream_tests, test_make_config_text) {
 }
 
 TEST_F(text_token_stemming_stream_tests, test_make_config_invalid_format) {
-  std::string config = "ru_RU.UTF-8";
+  std::string config = "ru_RU.utfF-8";
   auto stream = irs::analysis::analyzers::get("stem", irs::text_format::text, config.c_str());
   ASSERT_NE(nullptr, stream);
 

--- a/tests/analysis/text_token_stemming_stream_tests.cpp
+++ b/tests/analysis/text_token_stemming_stream_tests.cpp
@@ -178,6 +178,41 @@ TEST_F(text_token_stemming_stream_tests, test_load) {
   }
 }
 
+
+TEST_F(text_token_stemming_stream_tests, test_make_config_json) {
+
+  //with unknown parameter
+  {
+    std::string config = "{\"locale\":\"ru_RU.UTF-8\",\"invalid_parameter\":true}";
+    auto stream = irs::analysis::analyzers::get("stem", irs::text_format::json, config.c_str());
+    ASSERT_NE(nullptr, stream);
+
+    std::string actual;
+    ASSERT_TRUE(stream->to_string(::irs::text_format::json, actual));
+    ASSERT_EQ("{\"locale\":\"ru_RU.UTF-8\"}", actual);
+  }
+
+}
+
+TEST_F(text_token_stemming_stream_tests, test_make_config_text) {
+  std::string config = "ru_RU.UTF-8";
+  auto stream = irs::analysis::analyzers::get("stem", irs::text_format::text, config.c_str());
+  ASSERT_NE(nullptr, stream);
+
+  std::string actual;
+  ASSERT_TRUE(stream->to_string(::irs::text_format::text, actual));
+  ASSERT_EQ(config, actual);
+}
+
+TEST_F(text_token_stemming_stream_tests, test_make_config_invalid_format) {
+  std::string config = "ru_RU.UTF-8";
+  auto stream = irs::analysis::analyzers::get("stem", irs::text_format::text, config.c_str());
+  ASSERT_NE(nullptr, stream);
+
+  std::string actual;
+  ASSERT_FALSE(stream->to_string(::irs::text_format::csv, actual));
+}
+
 // -----------------------------------------------------------------------------
 // --SECTION--                                                       END-OF-FILE
 // -----------------------------------------------------------------------------

--- a/tests/analysis/token_masking_stream_tests.cpp
+++ b/tests/analysis/token_masking_stream_tests.cpp
@@ -122,10 +122,10 @@ TEST_F(token_masking_stream_tests, test_load) {
       ASSERT_EQ("ghi", irs::ref_cast<char>(term->value()));
       ASSERT_FALSE(stream->next());
     };
-    auto stream = irs::analysis::analyzers::get("token-mask", irs::text_format::json, "[ \"abc\", \"646566\", \"6D6e6F\" ]");
+    auto stream = irs::analysis::analyzers::get("mask", irs::text_format::json, "[ \"abc\", \"646566\", \"6D6e6F\" ]");
     testFunc(data0, data1, stream);
 
-    auto streamFromJsonObjest = irs::analysis::analyzers::get("token-mask", irs::text_format::json, "{\"mask\":[ \"abc\", \"646566\", \"6D6e6F\" ]}");
+    auto streamFromJsonObjest = irs::analysis::analyzers::get("mask", irs::text_format::json, "{\"mask\":[ \"abc\", \"646566\", \"6D6e6F\" ]}");
     testFunc(data0, data1, streamFromJsonObjest);
 
   }
@@ -154,29 +154,29 @@ TEST_F(token_masking_stream_tests, test_load) {
       ASSERT_FALSE(stream->next());
     };
 
-    auto stream = irs::analysis::analyzers::get("token-mask", irs::text_format::json, "[ \"abc\", \"646566\", \"6D6e6F\" ]");
+    auto stream = irs::analysis::analyzers::get("mask", irs::text_format::json, "[ \"abc\", \"646566\", \"6D6e6F\" ]");
     testFunc(data0, data1, stream);
 
 
-    auto streamFromJsonObjest = irs::analysis::analyzers::get("token-mask", irs::text_format::json, "{\"mask\":[ \"abc\", \"646566\", \"6D6e6F\" ]}");
+    auto streamFromJsonObjest = irs::analysis::analyzers::get("mask", irs::text_format::json, "{\"mask\":[ \"abc\", \"646566\", \"6D6e6F\" ]}");
     testFunc(data0, data1, streamFromJsonObjest);
 
   }
 
   // load jSON invalid
   {
-    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("token-mask", irs::text_format::json, irs::string_ref::NIL));
-    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("token-mask", irs::text_format::json, "1"));
-    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("token-mask", irs::text_format::json, "\"abc\""));
-    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("token-mask", irs::text_format::json, "{}"));
-    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("token-mask", irs::text_format::json, "{\"mask\":1}"));
+    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("mask", irs::text_format::json, irs::string_ref::NIL));
+    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("mask", irs::text_format::json, "1"));
+    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("mask", irs::text_format::json, "\"abc\""));
+    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("mask", irs::text_format::json, "{}"));
+    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("mask", irs::text_format::json, "{\"mask\":1}"));
   }
 
   // load text (mask hex)
   {
     irs::string_ref data0("ghi");
     irs::string_ref data1("mno");
-    auto stream = irs::analysis::analyzers::get("token-mask", irs::text_format::text, "abc \n646566\t6D6e6F");
+    auto stream = irs::analysis::analyzers::get("mask", irs::text_format::text, "abc \n646566\t6D6e6F");
 
     ASSERT_NE(nullptr, stream);
     ASSERT_TRUE(stream->reset(data0));
@@ -200,7 +200,7 @@ TEST_F(token_masking_stream_tests, test_load) {
   {
     irs::string_ref data0("ghi");
     irs::string_ref data1("mno");
-    auto stream = irs::analysis::analyzers::get("token-mask", irs::text_format::text, irs::string_ref::NIL);
+    auto stream = irs::analysis::analyzers::get("mask", irs::text_format::text, irs::string_ref::NIL);
 
     ASSERT_NE(nullptr, stream);
     ASSERT_TRUE(stream->reset(data0));
@@ -225,6 +225,52 @@ TEST_F(token_masking_stream_tests, test_load) {
     ASSERT_FALSE(stream->next());
   }
 }
+
+// commented out due to lack
+//TEST_F(token_masking_stream_tests, test_make_config_json) {
+//
+//  //with unknown parameter
+//  {
+//    std::string config = "{\"mask\":[\"abc\",\"646566\",\"6D6e6F\"],\"invalid_parameter\":true}";
+//    auto stream = irs::analysis::analyzers::get("mask", irs::text_format::json, config.c_str());
+//    ASSERT_NE(nullptr, stream);
+//
+//    std::string actual;
+//    ASSERT_TRUE(stream->to_string(::irs::text_format::json, actual));
+//    ASSERT_EQ("{\"mask\":[\"abc\",\"646566\",\"6D6e6F\"]}", actual);
+//  }
+//  //with dublicates  removed
+//  {
+//    std::string config = "{\"mask\":[\"abc\",\"646566\",\"6D6e6F\",\"abc\"],\"invalid_parameter\":true}";
+//    auto stream = irs::analysis::analyzers::get("mask", irs::text_format::json, config.c_str());
+//    ASSERT_NE(nullptr, stream);
+//
+//    std::string actual;
+//    ASSERT_TRUE(stream->to_string(::irs::text_format::json, actual));
+//    ASSERT_EQ("{\"mask\":[\"abc\",\"646566\",\"6D6e6F\"]}", actual);
+//  }
+//
+//
+//}
+//
+//TEST_F(token_masking_stream_tests, test_make_config_text) {
+//  std::string config = "abc \n646566\t6D6e6F";
+//  auto stream = irs::analysis::analyzers::get("mask", irs::text_format::text, config.c_str());
+//  ASSERT_NE(nullptr, stream);
+//
+//  std::string actual;
+//  ASSERT_TRUE(stream->to_string(::irs::text_format::text, actual));
+//  ASSERT_EQ(config, actual);
+//}
+//
+//TEST_F(token_masking_stream_tests, test_make_config_invalid_format) {
+//  std::string config = "abc \n646566\t6D6e6F";
+//  auto stream = irs::analysis::analyzers::get("mask", irs::text_format::text, config.c_str());
+//  ASSERT_NE(nullptr, stream);
+//
+//  std::string actual;
+//  ASSERT_FALSE(stream->to_string(::irs::text_format::csv, actual));
+//}
 
 // -----------------------------------------------------------------------------
 // --SECTION--                                                       END-OF-FILE


### PR DESCRIPTION
Changed CMakeLists.txt to fix shared lib tests
Added to_string method to analyzers
Renamed token-mask analyzer to mask
Moved ngram analyzer properties into separate structure for convenience in serializing properties to string

PR run is pending....