### PR TITLE
Bug fix/docs mask for merged segment with deletes

### DIFF
--- a/core/index/index_writer.cpp
+++ b/core/index/index_writer.cpp
@@ -2043,6 +2043,11 @@ index_writer::pending_context_t index_writer::flush_all(const before_commit_f& b
       // pending consolidation request
       pending_candidates_count += candidates.size();
     } else {
+      // during consolidation doc_mask could be already populated even for just merged segment
+      if (pending_segment.segment.meta.docs_count != pending_segment.segment.meta.live_docs_count) {
+        index_utils::read_document_mask(docs_mask, dir, pending_segment.segment.meta);
+      }
+      bool docs_mask_modified = false;
       // pending already imported/consolidated segment, apply deletes
       // mask documents matching filters from segment_contexts (i.e. from new operations)
       for (auto& modifications: ctx->pending_segment_contexts_) {
@@ -2057,13 +2062,18 @@ index_writer::pending_context_t index_writer::flush_all(const before_commit_f& b
           modifications_end - modifications_begin
         );
 
-        add_document_mask_modified_records(
+        docs_mask_modified |= add_document_mask_modified_records(
           modification_queries,
           docs_mask,
           cached_readers_, // reader cache for segments
           pending_segment.segment.meta,
           pending_segment.generation
         );
+      }
+
+      // if mask left untouched, reset it, to prevent unnecessary writes
+      if (!docs_mask_modified) {
+        docs_mask.clear();
       }
     }
 

--- a/tests/index/index_tests.cpp
+++ b/tests/index/index_tests.cpp
@@ -17911,7 +17911,7 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
       writer->commit();
     };
     
-    ASSERT_TRUE(writer->consolidate(do_commit_and_consolidate_count)); // consolidate
+    ASSERT_TRUE(writer->consolidate(do_commit_and_consolidate_count)); 
 
     // check consolidating segments
     expected_consolidating_segments = { 0, 1 };

--- a/tests/index/index_tests.cpp
+++ b/tests/index/index_tests.cpp
@@ -17280,6 +17280,7 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
 
     auto reader = iresearch::directory_reader::open(dir(), codec());
     ASSERT_EQ(1, reader.size());
+    ASSERT_EQ(2, reader.live_docs_count());
 
     // assume 0 is merged segment
     {
@@ -17386,6 +17387,7 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
 
     auto reader = iresearch::directory_reader::open(dir(), codec());
     ASSERT_EQ(2, reader.size());
+    ASSERT_EQ(4, reader.live_docs_count());
 
     // assume 0 is the existing segment
     {
@@ -17530,6 +17532,7 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
     auto reader = iresearch::directory_reader::open(dir(), codec());
     ASSERT_TRUE(reader);
     ASSERT_EQ(3, reader.size());
+    ASSERT_EQ(6, reader.live_docs_count());
 
     // assume 0 is the existing segment
     {
@@ -17676,6 +17679,7 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
     auto reader = iresearch::directory_reader::open(dir(), codec());
     ASSERT_TRUE(reader);
     ASSERT_EQ(1, reader.size());
+    ASSERT_EQ(2, reader.live_docs_count());
 
     // assume 0 is merged segment
     {
@@ -17805,6 +17809,139 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
     auto reader = iresearch::directory_reader::open(dir(), codec());
     ASSERT_TRUE(reader);
     ASSERT_EQ(1, reader.size());
+    ASSERT_EQ(2, reader.live_docs_count());
+
+    // assume 0 is merged segment
+    {
+      auto& segment = reader[0];
+      const auto* column = segment.column_reader("name");
+      ASSERT_NE(nullptr, column);
+      auto values = column->values();
+      ASSERT_EQ(4, segment.docs_count()); // total count of documents
+      ASSERT_EQ(2, segment.live_docs_count()); // total count of live documents
+      auto terms = segment.field("same");
+      ASSERT_NE(nullptr, terms);
+      auto termItr = terms->iterator();
+      ASSERT_TRUE(termItr->next());
+
+      // with deleted docs
+      {
+        auto docsItr = termItr->postings(iresearch::flags());
+        ASSERT_TRUE(docsItr->next());
+        ASSERT_TRUE(values(docsItr->value(), actual_value));
+        ASSERT_EQ("A", irs::to_string<irs::string_ref>(actual_value.c_str())); // 'name' value in doc3
+        ASSERT_TRUE(docsItr->next());
+        ASSERT_TRUE(values(docsItr->value(), actual_value));
+        ASSERT_EQ("B", irs::to_string<irs::string_ref>(actual_value.c_str())); // 'name' value in doc3
+        ASSERT_TRUE(docsItr->next());
+        ASSERT_TRUE(values(docsItr->value(), actual_value));
+        ASSERT_EQ("C", irs::to_string<irs::string_ref>(actual_value.c_str())); // 'name' value in doc4
+        ASSERT_TRUE(docsItr->next());
+        ASSERT_TRUE(values(docsItr->value(), actual_value));
+        ASSERT_EQ("D", irs::to_string<irs::string_ref>(actual_value.c_str())); // 'name' value in doc4
+        ASSERT_FALSE(docsItr->next());
+      }
+
+      // without deleted docs
+      {
+        auto docsItr = segment.mask(termItr->postings(iresearch::flags()));
+        ASSERT_TRUE(docsItr->next());
+        ASSERT_TRUE(values(docsItr->value(), actual_value));
+        ASSERT_EQ("B", irs::to_string<irs::string_ref>(actual_value.c_str())); // 'name' value in doc3
+        ASSERT_TRUE(docsItr->next());
+        ASSERT_TRUE(values(docsItr->value(), actual_value));
+        ASSERT_EQ("C", irs::to_string<irs::string_ref>(actual_value.c_str())); // 'name' value in doc4
+        ASSERT_FALSE(docsItr->next());
+      }
+    }
+  }
+
+  // consolidate with delete committed and pending
+  {
+    SetUp();
+    auto query_doc1 = iresearch::iql::query_builder().build("name==A", std::locale::classic());
+    auto query_doc4 = iresearch::iql::query_builder().build("name==D", std::locale::classic());
+    auto writer = open_writer();
+    ASSERT_NE(nullptr, writer);
+
+    // segment 1
+    ASSERT_TRUE(insert(*writer,
+      doc1->indexed.begin(), doc1->indexed.end(),
+      doc1->stored.begin(), doc1->stored.end()
+    ));
+    ASSERT_TRUE(insert(*writer,
+      doc2->indexed.begin(), doc2->indexed.end(),
+      doc2->stored.begin(), doc2->stored.end()
+    ));
+    writer->commit();
+    ASSERT_EQ(0, irs::directory_cleaner::clean(dir()));
+
+    // segment 2
+    ASSERT_TRUE(insert(*writer,
+      doc3->indexed.begin(), doc3->indexed.end(),
+      doc3->stored.begin(), doc3->stored.end()
+    ));
+    ASSERT_TRUE(insert(*writer,
+      doc4->indexed.begin(), doc4->indexed.end(),
+      doc4->stored.begin(), doc4->stored.end()
+    ));
+    writer->commit();
+    ASSERT_EQ(1, irs::directory_cleaner::clean(dir())); // segments_1
+
+    // count number of files in segments
+    count = 0;
+    ASSERT_TRUE(dir().visit(get_number_of_files_in_segments));
+
+    ASSERT_EQ(0, irs::directory_cleaner::clean(dir()));
+    writer->documents().remove(*query_doc1.filter);
+    ASSERT_TRUE(writer->begin()); // begin transaction
+    ASSERT_EQ(0, irs::directory_cleaner::clean(dir()));
+
+    // check consolidating segments
+    expected_consolidating_segments = { };
+    ASSERT_TRUE(writer->consolidate(check_consolidating_segments));
+
+    auto do_commit_and_consolidate_count = [&writer](
+      std::set<const irs::segment_meta*>& candidates,
+      const irs::index_meta& meta,
+      const irs::index_writer::consolidating_segments_t& consolidating_segments
+      ) {
+      auto sub_policy = irs::index_utils::consolidation_policy(irs::index_utils::consolidate_count());
+      sub_policy(candidates, meta, consolidating_segments);
+      writer->commit();
+    };
+    
+    ASSERT_TRUE(writer->consolidate(do_commit_and_consolidate_count)); // consolidate
+
+    // check consolidating segments
+    expected_consolidating_segments = { 0, 1 };
+    ASSERT_TRUE(writer->consolidate(check_consolidating_segments));
+
+    // can't consolidate segments that are already marked for consolidation
+    ASSERT_FALSE(writer->consolidate(irs::index_utils::consolidation_policy(irs::index_utils::consolidate_count())));
+    
+    writer->documents().remove(*query_doc4.filter);
+ 
+    writer->commit(); // commit pending merge + delete
+    ASSERT_EQ(count+8, irs::directory_cleaner::clean(dir())); 
+
+    // check consolidating segments
+    expected_consolidating_segments = { };
+    ASSERT_TRUE(writer->consolidate(check_consolidating_segments));
+
+    // validate structure (doesn't take removals into account)
+    tests::index_t expected;
+    expected.emplace_back();
+    expected.back().add(doc1->indexed.begin(), doc1->indexed.end());
+    expected.back().add(doc2->indexed.begin(), doc2->indexed.end());
+    expected.back().add(doc3->indexed.begin(), doc3->indexed.end());
+    expected.back().add(doc4->indexed.begin(), doc4->indexed.end());
+    tests::assert_index(dir(), codec(), expected, all_features);
+
+    auto reader = iresearch::directory_reader::open(dir(), codec());
+    ASSERT_TRUE(reader);
+    ASSERT_EQ(1, reader.size());
+    ASSERT_EQ(2, reader.live_docs_count());
 
     // assume 0 is merged segment
     {
@@ -17943,6 +18080,7 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
     auto reader = iresearch::directory_reader::open(dir(), codec());
     ASSERT_TRUE(reader);
     ASSERT_EQ(2, reader.size());
+    ASSERT_EQ(3, reader.live_docs_count());
 
     // assume 0 is merged segment
     {
@@ -18100,6 +18238,7 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
     auto reader = iresearch::directory_reader::open(dir(), codec());
     ASSERT_TRUE(reader);
     ASSERT_EQ(2, reader.size());
+    ASSERT_EQ(3, reader.live_docs_count());
 
     // assume 1 is the recently added segment
     {
@@ -18277,6 +18416,7 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
     auto reader = iresearch::directory_reader::open(dir(), codec());
     ASSERT_TRUE(reader);
     ASSERT_EQ(2, reader.size());
+    ASSERT_EQ(3, reader.live_docs_count());
 
     // assume 0 is first segment
     {


### PR DESCRIPTION
On consolidation step after lock-free merge additional check is done for  commited  removes. These removes are applied to newly created segment (this is correct) and docs_mask for this segment is populated (also correct). However flush procedure always expected empty docs_mask for consolidated segments. This PR fixes that - for fresh-merged segment docs count is checked and current docs_mask is loded/updated when needed.
Fix is verified by GTEST  