### PR TITLE
Bug fix/pvs exclude autogenerated iql

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,6 +250,7 @@ if (USE_PVS_STUDIO)
     ANALYZE ${PVS_STUDIO_ANALYZE}
     MODE GA:1,2 OP
     LOG ${IResearch_TARGET_NAME}.err
+    CFG_TEXT "exclude-path=${CMAKE_CURRENT_BINARY_DIR}/core/iql"
   )
 
   pvs_studio_add_target(
@@ -258,6 +259,7 @@ if (USE_PVS_STUDIO)
     ANALYZE ${PVS_STUDIO_ANALYZE}
     MODE GA:1,2 OP
     LOG ${IResearch_TARGET_NAME}-html.err
+    CFG_TEXT "exclude-path=${CMAKE_CURRENT_BINARY_DIR}/core/iql"
   )
 
   pvs_studio_add_target(
@@ -266,6 +268,7 @@ if (USE_PVS_STUDIO)
     ANALYZE ${PVS_STUDIO_ANALYZE}
     MODE GA:1,2 OP
     LOG ${IResearch_TARGET_NAME}-xml.err
+    CFG_TEXT "exclude-path=${CMAKE_CURRENT_BINARY_DIR}/core/iql"
   )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,7 +250,7 @@ if (USE_PVS_STUDIO)
     ANALYZE ${PVS_STUDIO_ANALYZE}
     MODE GA:1,2 OP
     LOG ${IResearch_TARGET_NAME}.err
-    CFG_TEXT "exclude-path=${CMAKE_CURRENT_BINARY_DIR}/core/iql"
+    CONFIG "${CMAKE_SOURCE_DIR}/PVSIResearch.cfg"
   )
 
   pvs_studio_add_target(
@@ -259,7 +259,7 @@ if (USE_PVS_STUDIO)
     ANALYZE ${PVS_STUDIO_ANALYZE}
     MODE GA:1,2 OP
     LOG ${IResearch_TARGET_NAME}-html.err
-    CFG_TEXT "exclude-path=${CMAKE_CURRENT_BINARY_DIR}/core/iql"
+    CONFIG "${CMAKE_SOURCE_DIR}/PVSIResearch.cfg"
   )
 
   pvs_studio_add_target(
@@ -268,7 +268,7 @@ if (USE_PVS_STUDIO)
     ANALYZE ${PVS_STUDIO_ANALYZE}
     MODE GA:1,2 OP
     LOG ${IResearch_TARGET_NAME}-xml.err
-    CFG_TEXT "exclude-path=${CMAKE_CURRENT_BINARY_DIR}/core/iql"
+    CONFIG "${CMAKE_SOURCE_DIR}/PVSIResearch.cfg"
   )
 endif()
 

--- a/PVSIResearch.cfg
+++ b/PVSIResearch.cfg
@@ -1,0 +1,2 @@
+analysis-mode=31
+exclude-path=iql


### PR DESCRIPTION
Remove `build/iql` generated sources from PVS static analysis.