### PR TITLE
Bug fix/removing dangling cached readers

### DIFF
--- a/core/index/index_writer.cpp
+++ b/core/index/index_writer.cpp
@@ -2085,6 +2085,11 @@ index_writer::pending_context_t index_writer::flush_all(const before_commit_f& b
 
     // write non-empty document mask
     if (!docs_mask.empty()) {
+      if (!pending_consolidation) { // if this is pending consolidation this segment is already in the mask (see assert below)
+        //new version will be created created. Remove old version from cache!
+        ctx->segment_mask_.emplace(pending_segment.segment.meta);
+      }
+      assert(ctx->segment_mask_.find(pending_segment.segment.meta) != ctx->segment_mask_.end()); // this segment should be deleted from cache!
       write_document_mask(dir, pending_segment.segment.meta, docs_mask, !pending_consolidation);
       pending_consolidation = true; // force write new segment meta
     }

--- a/core/index/index_writer.cpp
+++ b/core/index/index_writer.cpp
@@ -2086,7 +2086,7 @@ index_writer::pending_context_t index_writer::flush_all(const before_commit_f& b
     // write non-empty document mask
     if (!docs_mask.empty()) {
       if (!pending_consolidation) { // if this is pending consolidation this segment is already in the mask (see assert below)
-        //new version will be created created. Remove old version from cache!
+        //new version will be created. Remove old version from cache!
         ctx->segment_mask_.emplace(pending_segment.segment.meta);
       }
       assert(ctx->segment_mask_.find(pending_segment.segment.meta) != ctx->segment_mask_.end()); // this segment should be deleted from cache!

--- a/core/index/index_writer.cpp
+++ b/core/index/index_writer.cpp
@@ -2088,7 +2088,7 @@ index_writer::pending_context_t index_writer::flush_all(const before_commit_f& b
       if (!pending_consolidation) { 
         // if this is pending consolidation, 
         // this segment is already in the mask (see assert below)
-        //new version will be created. Remove old version from cache!
+        // new version will be created. Remove old version from cache!
         ctx->segment_mask_.emplace(pending_segment.segment.meta);
       }
       assert(ctx->segment_mask_.find(pending_segment.segment.meta) != ctx->segment_mask_.end()); // this segment should be deleted from cache!

--- a/core/index/index_writer.cpp
+++ b/core/index/index_writer.cpp
@@ -2085,7 +2085,9 @@ index_writer::pending_context_t index_writer::flush_all(const before_commit_f& b
 
     // write non-empty document mask
     if (!docs_mask.empty()) {
-      if (!pending_consolidation) { // if this is pending consolidation this segment is already in the mask (see assert below)
+      if (!pending_consolidation) { 
+        // if this is pending consolidation, 
+        // this segment is already in the mask (see assert below)
         //new version will be created. Remove old version from cache!
         ctx->segment_mask_.emplace(pending_segment.segment.meta);
       }

--- a/tests/index/index_tests.cpp
+++ b/tests/index/index_tests.cpp
@@ -9225,6 +9225,7 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
     }
 
     // check for dangling old segment versions in writers cache 
+    // first create new segment
     // segment 5
     ASSERT_TRUE(insert(*writer,
         doc5->indexed.begin(), doc5->indexed.end(),
@@ -9236,20 +9237,18 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
     ));
     writer->commit();
 
+    // remove one doc from new and old segment to make conolidation do something
     auto query_doc3 = iresearch::iql::query_builder().build("name==C", std::locale::classic());
     auto query_doc5 = iresearch::iql::query_builder().build("name==E", std::locale::classic());
     writer->documents().remove(*query_doc3.filter);
     writer->documents().remove(*query_doc5.filter);
     writer->commit();
 
-
-    // segment 6 should be created
     ASSERT_TRUE(writer->consolidate(irs::index_utils::consolidation_policy(irs::index_utils::consolidate_count())));
     writer->commit();
 
-    // segments 
+    // check all old segments are deleted (no old version of segments is left in cache and blocking )
     ASSERT_EQ(23, irs::directory_cleaner::clean(dir())); 
-
   }
 
   // consolidate with deletes + inserts

--- a/tests/index/index_tests.cpp
+++ b/tests/index/index_tests.cpp
@@ -9174,55 +9174,82 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
     expected.back().add(doc3->indexed.begin(), doc3->indexed.end());
     expected.back().add(doc4->indexed.begin(), doc4->indexed.end());
     tests::assert_index(dir(), codec(), expected, all_features);
-
-    auto reader = iresearch::directory_reader::open(dir(), codec());
-    ASSERT_TRUE(reader);
-    ASSERT_EQ(1, reader.size());
-    ASSERT_EQ(2, reader.live_docs_count());
-
-    // assume 0 is merged segment
     {
-      auto& segment = reader[0];
-      const auto* column = segment.column_reader("name");
-      ASSERT_NE(nullptr, column);
-      auto values = column->values();
-      ASSERT_EQ(4, segment.docs_count()); // total count of documents
-      ASSERT_EQ(2, segment.live_docs_count()); // total count of live documents
-      auto terms = segment.field("same");
-      ASSERT_NE(nullptr, terms);
-      auto termItr = terms->iterator();
-      ASSERT_TRUE(termItr->next());
-
-      // with deleted docs
+      auto reader = iresearch::directory_reader::open(dir(), codec());
+      ASSERT_TRUE(reader);
+      ASSERT_EQ(1, reader.size());
+      ASSERT_EQ(2, reader.live_docs_count());
+      // assume 0 is merged segment
       {
-        auto docsItr = termItr->postings(iresearch::flags());
-        ASSERT_TRUE(docsItr->next());
-        ASSERT_TRUE(values(docsItr->value(), actual_value));
-        ASSERT_EQ("A", irs::to_string<irs::string_ref>(actual_value.c_str())); // 'name' value in doc3
-        ASSERT_TRUE(docsItr->next());
-        ASSERT_TRUE(values(docsItr->value(), actual_value));
-        ASSERT_EQ("B", irs::to_string<irs::string_ref>(actual_value.c_str())); // 'name' value in doc3
-        ASSERT_TRUE(docsItr->next());
-        ASSERT_TRUE(values(docsItr->value(), actual_value));
-        ASSERT_EQ("C", irs::to_string<irs::string_ref>(actual_value.c_str())); // 'name' value in doc4
-        ASSERT_TRUE(docsItr->next());
-        ASSERT_TRUE(values(docsItr->value(), actual_value));
-        ASSERT_EQ("D", irs::to_string<irs::string_ref>(actual_value.c_str())); // 'name' value in doc4
-        ASSERT_FALSE(docsItr->next());
-      }
+        auto& segment = reader[0];
+        const auto* column = segment.column_reader("name");
+        ASSERT_NE(nullptr, column);
+        auto values = column->values();
+        ASSERT_EQ(4, segment.docs_count()); // total count of documents
+        ASSERT_EQ(2, segment.live_docs_count()); // total count of live documents
+        auto terms = segment.field("same");
+        ASSERT_NE(nullptr, terms);
+        auto termItr = terms->iterator();
+        ASSERT_TRUE(termItr->next());
 
-      // without deleted docs
-      {
-        auto docsItr = segment.mask(termItr->postings(iresearch::flags()));
-        ASSERT_TRUE(docsItr->next());
-        ASSERT_TRUE(values(docsItr->value(), actual_value));
-        ASSERT_EQ("B", irs::to_string<irs::string_ref>(actual_value.c_str())); // 'name' value in doc3
-        ASSERT_TRUE(docsItr->next());
-        ASSERT_TRUE(values(docsItr->value(), actual_value));
-        ASSERT_EQ("C", irs::to_string<irs::string_ref>(actual_value.c_str())); // 'name' value in doc4
-        ASSERT_FALSE(docsItr->next());
+        // with deleted docs
+        {
+          auto docsItr = termItr->postings(iresearch::flags());
+          ASSERT_TRUE(docsItr->next());
+          ASSERT_TRUE(values(docsItr->value(), actual_value));
+          ASSERT_EQ("A", irs::to_string<irs::string_ref>(actual_value.c_str())); // 'name' value in doc3
+          ASSERT_TRUE(docsItr->next());
+          ASSERT_TRUE(values(docsItr->value(), actual_value));
+          ASSERT_EQ("B", irs::to_string<irs::string_ref>(actual_value.c_str())); // 'name' value in doc3
+          ASSERT_TRUE(docsItr->next());
+          ASSERT_TRUE(values(docsItr->value(), actual_value));
+          ASSERT_EQ("C", irs::to_string<irs::string_ref>(actual_value.c_str())); // 'name' value in doc4
+          ASSERT_TRUE(docsItr->next());
+          ASSERT_TRUE(values(docsItr->value(), actual_value));
+          ASSERT_EQ("D", irs::to_string<irs::string_ref>(actual_value.c_str())); // 'name' value in doc4
+          ASSERT_FALSE(docsItr->next());
+        }
+
+        // without deleted docs
+        {
+          auto docsItr = segment.mask(termItr->postings(iresearch::flags()));
+          ASSERT_TRUE(docsItr->next());
+          ASSERT_TRUE(values(docsItr->value(), actual_value));
+          ASSERT_EQ("B", irs::to_string<irs::string_ref>(actual_value.c_str())); // 'name' value in doc3
+          ASSERT_TRUE(docsItr->next());
+          ASSERT_TRUE(values(docsItr->value(), actual_value));
+          ASSERT_EQ("C", irs::to_string<irs::string_ref>(actual_value.c_str())); // 'name' value in doc4
+          ASSERT_FALSE(docsItr->next());
+        }
       }
     }
+
+    // check for dangling old segment versions in writers cache 
+    // segment 5
+    ASSERT_TRUE(insert(*writer,
+        doc5->indexed.begin(), doc5->indexed.end(),
+        doc5->stored.begin(), doc5->stored.end()
+    ));
+    ASSERT_TRUE(insert(*writer,
+        doc6->indexed.begin(), doc6->indexed.end(),
+        doc6->stored.begin(), doc6->stored.end()
+    ));
+    writer->commit();
+
+    auto query_doc3 = iresearch::iql::query_builder().build("name==C", std::locale::classic());
+    auto query_doc5 = iresearch::iql::query_builder().build("name==E", std::locale::classic());
+    writer->documents().remove(*query_doc3.filter);
+    writer->documents().remove(*query_doc5.filter);
+    writer->commit();
+
+
+    // segment 6 should be created
+    ASSERT_TRUE(writer->consolidate(irs::index_utils::consolidation_policy(irs::index_utils::consolidate_count())));
+    writer->commit();
+
+    // segments 
+    ASSERT_EQ(23, irs::directory_cleaner::clean(dir())); 
+
   }
 
   // consolidate with deletes + inserts


### PR DESCRIPTION
During consolidation readers cache is populated. If consolidation is finished during commit (additional removes are applied) newly created segment will immediately change version (while old version is in readers cache). This old version should be added to segments mask for purging from cache despite  of this segment is not empty (it is already outdated!)