### PR TITLE
Fixed hanging

### DIFF
--- a/utils/index-put.cpp
+++ b/utils/index-put.cpp
@@ -475,7 +475,10 @@ int put(
       while (!batch_provider.done_.load()) {
         {
           SCOPED_LOCK_NAMED(consolidation_mutex, lock);
-          consolidation_cv.wait(lock);
+          if (std::cv_status::timeout ==
+              consolidation_cv.wait_for(lock, std::chrono::seconds(5))) {
+            continue;
+          }
         }
 
         {


### PR DESCRIPTION
Fixed case when one consolidation thread resetted condition variable before the second one have began waiting. So second thread is waiting forever. Now timeout is used to wakeup periodically and recheck finalization condition