### PR TITLE
Feature/standalone ngram similarity function

### DIFF
--- a/core/utils/levenshtein_utils.cpp
+++ b/core/utils/levenshtein_utils.cpp
@@ -129,12 +129,15 @@ class parametric_state {
       }
     }
 
-    for (auto begin = positions_.begin(); begin != positions_.end(); ) {
-      if (subsumes(new_pos, *begin)) {
-        std::swap(*begin, positions_.back());
-        positions_.pop_back(); // removed positions subsumed by new_pos
-      } else {
-        ++begin;
+    if (!positions_.empty()) {
+      for (auto begin = positions_.data(), end = positions_.data() + positions_.size(); begin != end; ) {
+        if (subsumes(new_pos, *begin)) {
+          std::swap(*begin, positions_.back());
+          positions_.pop_back(); // removed positions subsumed by new_pos
+          end = positions_.data() + positions_.size();
+        } else {
+          ++begin;
+        }
       }
     }
 

--- a/core/utils/ngram_match_utils.hpp
+++ b/core/utils/ngram_match_utils.hpp
@@ -39,7 +39,7 @@ NS_ROOT
 /// true disables normalizing resulting similarity by length of longest string and
 /// result is evaluated based strictly on target length (search-like semantics).
 /// If search_semantics is false there is no difference which string pass
-/// as target.
+/// as target. First characters affixing currently is not implemented
 /// @param target string to seek similarity for
 /// @param target_size length of target string
 /// @param src string to seek similarity in
@@ -88,8 +88,10 @@ float_t ngram_similarity(const T* target, size_t target_size,
   const T* t_ngram_start = target;
   const T* t_ngram_start_end  = target + target_size - ngram_size + 1; // end() analog for target ngram start
 
-  float_t d = 0; // will store upper-left cell value for current case
+  float_t d = 0; // will store upper-left cell value for current cache row
   std::vector<float_t> cache(s_ngram_count + 1, 0);
+
+  // here could be constructed source string with start characters affixing
 
   size_t t_ngram_idx = 1;
   for (; t_ngram_start != t_ngram_start_end; ++t_ngram_start, ++t_ngram_idx) {

--- a/core/utils/ngram_match_utils.hpp
+++ b/core/utils/ngram_match_utils.hpp
@@ -1,0 +1,84 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2020 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Andrei Lobov
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef IRESEARCH_NGRAM_MATCH_UTILS_H
+#define IRESEARCH_NGRAM_MATCH_UTILS_H
+
+#include "shared.hpp"
+#include "utf8_utils.hpp"
+#include <vector>
+
+NS_ROOT
+
+template<typename T>
+float_t ngram_similarity(const T* lhs, size_t lhs_size,
+                         const T* rhs, size_t rhs_size,
+                         size_t ngram_size) {
+
+  if (lhs_size < ngram_size || rhs_size < ngram_size) {
+    return 0.f;
+  }
+
+  const size_t lhs_ngram_length = lhs_size - ngram_size + 1;
+  const size_t rhs_ngram_length = rhs_size - ngram_size + 1;
+
+  const T* lhs_ngram_start = lhs;
+  
+  const T* lhs_ngram_start_end  = lhs + lhs_size - ngram_size + 1; // <end> for ngram start
+
+  //auxilarry table for storing previous calc results
+  std::vector<float_t> S((std::max(lhs_ngram_length, rhs_ngram_length) + 1) * 
+                         (std::max(lhs_ngram_length, rhs_ngram_length) + 1), 0);
+
+  size_t lhs_ngram_idx = 1;
+  for (; lhs_ngram_start != lhs_ngram_start_end; ++lhs_ngram_start, ++lhs_ngram_idx) {
+    const T* lhs_ngram_end = lhs_ngram_start + ngram_size;
+    const T* rhs_ngram_start = rhs;
+    size_t rhs_ngram_idx = 1;
+    const T* rhs_ngram_start_end  = rhs + rhs_size - ngram_size + 1; // <end> for ngram start
+
+    for (; rhs_ngram_start != rhs_ngram_start_end; ++rhs_ngram_start, ++rhs_ngram_idx) {
+      const T* rhs_ngram_end = rhs_ngram_start + ngram_size;
+      // boolean similarity by now. Just match or not!
+      float_t similarity = 1;
+      for (const T* l = lhs_ngram_start, *r = rhs_ngram_start; l != lhs_ngram_end && r != rhs_ngram_end; ++l, ++r) {
+        if (*l != *r) {
+          similarity = 0;
+          break;
+        }
+      }
+      S[lhs_ngram_idx * (lhs_ngram_length + 1) + rhs_ngram_idx] =
+          std::max(
+            std::max(S[(lhs_ngram_idx - 1) * (lhs_ngram_length + 1) + rhs_ngram_idx],
+                     S[lhs_ngram_idx * (lhs_ngram_length  + 1) + rhs_ngram_idx - 1]),
+            S[(lhs_ngram_idx - 1) * (lhs_ngram_length + 1) + rhs_ngram_idx - 1] + similarity);
+    }
+  }
+
+  return S[(lhs_ngram_length) * (lhs_ngram_length + 1) + rhs_ngram_length] / 
+         float_t(std::max(lhs_ngram_length, rhs_ngram_length));
+}
+
+NS_END
+
+
+#endif IRESEARCH_NGRAM_MATCH_UTILS_H // IRESEARCH_NGRAM_MATCH_UTILS_H

--- a/core/utils/ngram_match_utils.hpp
+++ b/core/utils/ngram_match_utils.hpp
@@ -35,8 +35,15 @@ float_t ngram_similarity(const T* lhs, size_t lhs_size,
                          const T* rhs, size_t rhs_size,
                          size_t ngram_size) {
 
-  if (lhs_size < ngram_size || rhs_size < ngram_size) {
+  if (ngram_size == 0 || lhs_size < ngram_size || rhs_size < ngram_size) {
     return 0.f;
+  }
+
+  if /*consexpr*/ (use_ngram_position_match) {
+    if (lhs_size > rhs_size) {
+      std::swap(lhs_size, rhs_size);
+      std::swap(lhs, rhs);
+    }
   }
 
   const size_t lhs_ngram_count = lhs_size - ngram_size + 1;
@@ -80,13 +87,13 @@ float_t ngram_similarity(const T* lhs, size_t lhs_size,
       cache[rhs_ngram_idx] =
           std::max(
             std::max(cache[rhs_ngram_idx - 1],
-                     cache[lhs_ngram_idx]),
+                     cache[rhs_ngram_idx]),
             d + similarity);
       d = tmp;
     }
   }
 
-  return cache[rhs_ngram_count] / float_t(std::max(lhs_ngram_count, rhs_ngram_count));
+  return cache[rhs_ngram_count] / float_t(rhs_ngram_count);
 }
 
 NS_END

--- a/core/utils/ngram_match_utils.hpp
+++ b/core/utils/ngram_match_utils.hpp
@@ -45,9 +45,8 @@ float_t ngram_similarity(const T* lhs, size_t lhs_size,
   
   const T* lhs_ngram_start_end  = lhs + lhs_size - ngram_size + 1; // <end> for ngram start
 
-  //auxilarry table for storing previous calc results
-  std::vector<float_t> S((std::max(lhs_ngram_length, rhs_ngram_length) + 1) * 
-                         (std::max(lhs_ngram_length, rhs_ngram_length) + 1), 0);
+  float_t prev_best = 0;
+  std::vector<float_t> S(std::max(lhs_ngram_length, rhs_ngram_length) + 1, 0);
 
   size_t lhs_ngram_idx = 1;
   for (; lhs_ngram_start != lhs_ngram_start_end; ++lhs_ngram_start, ++lhs_ngram_idx) {
@@ -66,16 +65,17 @@ float_t ngram_similarity(const T* lhs, size_t lhs_size,
           break;
         }
       }
-      S[lhs_ngram_idx * (lhs_ngram_length + 1) + rhs_ngram_idx] =
+      auto tmp = S[rhs_ngram_idx];
+      S[rhs_ngram_idx] =
           std::max(
-            std::max(S[(lhs_ngram_idx - 1) * (lhs_ngram_length + 1) + rhs_ngram_idx],
-                     S[lhs_ngram_idx * (lhs_ngram_length  + 1) + rhs_ngram_idx - 1]),
-            S[(lhs_ngram_idx - 1) * (lhs_ngram_length + 1) + rhs_ngram_idx - 1] + similarity);
+            std::max(S[rhs_ngram_idx - 1],
+                     S[lhs_ngram_idx]),
+            prev_best + similarity);
+      prev_best = tmp;
     }
   }
 
-  return S[(lhs_ngram_length) * (lhs_ngram_length + 1) + rhs_ngram_length] / 
-         float_t(std::max(lhs_ngram_length, rhs_ngram_length));
+  return S[rhs_ngram_length] / float_t(std::max(lhs_ngram_length, rhs_ngram_length));
 }
 
 NS_END

--- a/core/utils/ngram_match_utils.hpp
+++ b/core/utils/ngram_match_utils.hpp
@@ -29,7 +29,8 @@
 
 NS_ROOT
 
-template<typename T>
+
+template<typename T, bool use_ngram_position_match>
 float_t ngram_similarity(const T* lhs, size_t lhs_size,
                          const T* rhs, size_t rhs_size,
                          size_t ngram_size) {
@@ -38,15 +39,15 @@ float_t ngram_similarity(const T* lhs, size_t lhs_size,
     return 0.f;
   }
 
-  const size_t lhs_ngram_length = lhs_size - ngram_size + 1;
-  const size_t rhs_ngram_length = rhs_size - ngram_size + 1;
+  const size_t lhs_ngram_count = lhs_size - ngram_size + 1;
+  const size_t rhs_ngram_count = rhs_size - ngram_size + 1;
 
   const T* lhs_ngram_start = lhs;
   
   const T* lhs_ngram_start_end  = lhs + lhs_size - ngram_size + 1; // <end> for ngram start
 
-  float_t prev_best = 0;
-  std::vector<float_t> S(std::max(lhs_ngram_length, rhs_ngram_length) + 1, 0);
+  float_t d = 0;
+  std::vector<float_t> cache(std::max(lhs_ngram_count, rhs_ngram_count) + 1, 0);
 
   size_t lhs_ngram_idx = 1;
   for (; lhs_ngram_start != lhs_ngram_start_end; ++lhs_ngram_start, ++lhs_ngram_idx) {
@@ -58,24 +59,34 @@ float_t ngram_similarity(const T* lhs, size_t lhs_size,
     for (; rhs_ngram_start != rhs_ngram_start_end; ++rhs_ngram_start, ++rhs_ngram_idx) {
       const T* rhs_ngram_end = rhs_ngram_start + ngram_size;
       // boolean similarity by now. Just match or not!
-      float_t similarity = 1;
+      float_t similarity = use_ngram_position_match ? 0 : 1;
       for (const T* l = lhs_ngram_start, *r = rhs_ngram_start; l != lhs_ngram_end && r != rhs_ngram_end; ++l, ++r) {
-        if (*l != *r) {
-          similarity = 0;
-          break;
+        if /*constexpr*/ (!use_ngram_position_match) {
+          if (*l != *r) {
+            similarity = 0;
+            break;
+          }
+        } else {
+          if (*l == *r) {
+            ++similarity;
+          }
         }
       }
-      auto tmp = S[rhs_ngram_idx];
-      S[rhs_ngram_idx] =
+      if /*constexpr*/ (use_ngram_position_match) {
+        similarity = similarity / float_t(ngram_size);
+      }
+
+      auto tmp = cache[rhs_ngram_idx];
+      cache[rhs_ngram_idx] =
           std::max(
-            std::max(S[rhs_ngram_idx - 1],
-                     S[lhs_ngram_idx]),
-            prev_best + similarity);
-      prev_best = tmp;
+            std::max(cache[rhs_ngram_idx - 1],
+                     cache[lhs_ngram_idx]),
+            d + similarity);
+      d = tmp;
     }
   }
 
-  return S[rhs_ngram_length] / float_t(std::max(lhs_ngram_length, rhs_ngram_length));
+  return cache[rhs_ngram_count] / float_t(std::max(lhs_ngram_count, rhs_ngram_count));
 }
 
 NS_END

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -122,6 +122,7 @@ set(IReSearch_tests_sources
   ./utils/fst_builder_test.cpp
   ./utils/fst_utils_test.cpp
   ./utils/fst_string_weight_test.cpp
+  ./utils/ngram_match_utils_tests.cpp
   ./tests_param.cpp
   ./tests_main.cpp
 )

--- a/tests/search/ngram_similarity_filter_tests.cpp
+++ b/tests/search/ngram_similarity_filter_tests.cpp
@@ -25,6 +25,7 @@
 #include "search/ngram_similarity_filter.hpp"
 #include "search/tfidf.hpp"
 #include "search/bm25.hpp"
+#include "utils/ngram_match_utils.hpp"
 
 #include <functional>
 
@@ -248,6 +249,11 @@ TEST_P(ngram_similarity_filter_test_case, check_matcher_1) {
     ASSERT_EQ(docs->value(), doc->value);
     ASSERT_FALSE(irs::doc_limits::eof(doc->value));
     ASSERT_DOUBLE_EQ(0.75, boost->value);
+    const irs::string_ref rhs = "134";
+    const irs::string_ref lhs = "1234";
+    ASSERT_DOUBLE_EQ(
+      boost->value,
+      (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
     ASSERT_EQ(1, frequency->value);
     ASSERT_FALSE(docs->next());
   }
@@ -287,6 +293,11 @@ TEST_P(ngram_similarity_filter_test_case, check_matcher_2) {
     ASSERT_EQ(docs->value(), doc->value);
     ASSERT_FALSE(irs::doc_limits::eof(doc->value));
     ASSERT_DOUBLE_EQ(1, boost->value);
+    const irs::string_ref rhs = "11223344";
+    const irs::string_ref lhs = "1234";
+    ASSERT_DOUBLE_EQ(
+      boost->value,
+      (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
     ASSERT_EQ(1, frequency->value);
     ASSERT_FALSE(docs->next());
   }
@@ -324,6 +335,11 @@ TEST_P(ngram_similarity_filter_test_case, check_matcher_3) {
     ASSERT_EQ(docs->value(), doc->value);
     ASSERT_FALSE(irs::doc_limits::eof(doc->value));
     ASSERT_DOUBLE_EQ(1, boost->value);
+    const irs::string_ref rhs = "121134";
+    const irs::string_ref lhs = "1234";
+    ASSERT_DOUBLE_EQ(
+      boost->value,
+      (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
     ASSERT_EQ(1, frequency->value);
     ASSERT_FALSE(docs->next());
   }
@@ -361,6 +377,11 @@ TEST_P(ngram_similarity_filter_test_case, check_matcher_4) {
     ASSERT_EQ(docs->value(), doc->value);
     ASSERT_FALSE(irs::doc_limits::eof(doc->value));
     ASSERT_DOUBLE_EQ(1, boost->value);
+    const irs::string_ref rhs = "121111";
+    const irs::string_ref lhs = "11";
+    ASSERT_DOUBLE_EQ(
+        boost->value,
+        (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
     ASSERT_EQ(2, frequency->value);
     ASSERT_FALSE(docs->next());
   }
@@ -399,6 +420,11 @@ TEST_P(ngram_similarity_filter_test_case, check_matcher_5) {
     ASSERT_EQ(docs->value(), doc->value);
     ASSERT_FALSE(irs::doc_limits::eof(doc->value));
     ASSERT_DOUBLE_EQ(1, boost->value);
+    const irs::string_ref rhs = "121212121212121";
+    const irs::string_ref lhs = "121";
+    ASSERT_DOUBLE_EQ(
+      boost->value,
+      (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
     ASSERT_EQ(4, frequency->value);
     ASSERT_FALSE(docs->next());
   }
@@ -436,6 +462,11 @@ TEST_P(ngram_similarity_filter_test_case, check_matcher_6) {
     ASSERT_EQ(docs->value(), doc->value);
     ASSERT_FALSE(irs::doc_limits::eof(doc->value));
     ASSERT_DOUBLE_EQ(1, boost->value);
+    const irs::string_ref rhs = "11";
+    const irs::string_ref lhs = "11";
+    ASSERT_DOUBLE_EQ(
+      boost->value,
+      (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
     ASSERT_EQ(1, frequency->value);
     ASSERT_FALSE(docs->next());
   }
@@ -473,6 +504,11 @@ TEST_P(ngram_similarity_filter_test_case, check_matcher_7) {
         ASSERT_EQ(docs->value(), doc->value);
         ASSERT_FALSE(irs::doc_limits::eof(doc->value));
         ASSERT_DOUBLE_EQ(0.5, boost->value);
+        const irs::string_ref rhs = "24241313";
+        const irs::string_ref lhs = "1234";
+        ASSERT_DOUBLE_EQ(
+          boost->value,
+          (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
         ASSERT_EQ(2, frequency->value);
         ASSERT_FALSE(docs->next());
     }
@@ -510,6 +546,11 @@ TEST_P(ngram_similarity_filter_test_case, check_matcher_8) {
     ASSERT_EQ(docs->value(), doc->value);
     ASSERT_FALSE(irs::doc_limits::eof(doc->value));
     ASSERT_DOUBLE_EQ(0.5, boost->value);
+    const irs::string_ref lhs = "1234";
+    const irs::string_ref rhs = "1562";
+    ASSERT_DOUBLE_EQ(
+      boost->value,
+      (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
     ASSERT_EQ(1, frequency->value);
     ASSERT_FALSE(docs->next());
   }
@@ -549,6 +590,11 @@ TEST_P(ngram_similarity_filter_test_case, check_matcher_9) {
     ASSERT_EQ(docs->value(), doc->value);
     ASSERT_FALSE(irs::doc_limits::eof(doc->value));
     ASSERT_DOUBLE_EQ(1., boost->value);
+    const irs::string_ref rhs = "1123451";
+    const irs::string_ref lhs = "123451";
+    ASSERT_DOUBLE_EQ(
+      boost->value,
+      (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
     ASSERT_EQ(1, frequency->value);
     ASSERT_FALSE(docs->next());
   }

--- a/tests/utils/ngram_match_utils_tests.cpp
+++ b/tests/utils/ngram_match_utils_tests.cpp
@@ -28,196 +28,196 @@ TEST(ngram_match_utils_test, test_similarity_empty_left) {
   const irs::string_ref lhs = "";
   const irs::string_ref rhs = "abcd";
 
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 0)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
-
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 0)));
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
+
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 0)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
 }
 
 TEST(ngram_match_utils_test, test_similarity_empty_right) {
   const irs::string_ref lhs = "abcd";
   const irs::string_ref rhs = "";
 
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 0)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
-
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 0)));
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
+
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 0)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
 }
 
 TEST(ngram_match_utils_test, test_similarity_no_match) {
   const irs::string_ref lhs = "abcd";
   const irs::string_ref rhs = "efgh";
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 0)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
-
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 0)));
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
+
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 0)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
 }
 
 TEST(ngram_match_utils_test, test_similarity_simple) {
   const irs::string_ref lhs = "aecd";
   const irs::string_ref rhs = "abcd";
 
-  ASSERT_DOUBLE_EQ(0.75f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
-  ASSERT_DOUBLE_EQ(0.75f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 1)));
   ASSERT_DOUBLE_EQ(0.75f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
   ASSERT_DOUBLE_EQ(0.75f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 1)));
+  ASSERT_DOUBLE_EQ(0.75f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
+  ASSERT_DOUBLE_EQ(0.75f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 1)));
 
-  ASSERT_DOUBLE_EQ(2.f/3.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
-  ASSERT_DOUBLE_EQ(2.f/3.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
-  ASSERT_DOUBLE_EQ(1.f/3.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
-  ASSERT_DOUBLE_EQ(1.f/3.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
+  ASSERT_DOUBLE_EQ(2.f/3.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+  ASSERT_DOUBLE_EQ(2.f/3.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
+  ASSERT_DOUBLE_EQ(1.f/3.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+  ASSERT_DOUBLE_EQ(1.f/3.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
 
-  ASSERT_DOUBLE_EQ(2.f/3.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
-  ASSERT_DOUBLE_EQ(2.f/3.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 3)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 3)));
+  ASSERT_DOUBLE_EQ(2.f/3.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
+  ASSERT_DOUBLE_EQ(2.f/3.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 3)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 3)));
 
-  ASSERT_DOUBLE_EQ(3.f/4.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
-  ASSERT_DOUBLE_EQ(3.f/4.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 4)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 4)));
+  ASSERT_DOUBLE_EQ(3.f/4.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
+  ASSERT_DOUBLE_EQ(3.f/4.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 4)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 4)));
 }
 
 TEST(ngram_match_utils_test, test_similarity_different_length) {
   const irs::string_ref lhs = "applejuice";
   const irs::string_ref rhs = "aplejuice";
-  ASSERT_DOUBLE_EQ(0.9f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
-  ASSERT_DOUBLE_EQ(0.9f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 1)));
   ASSERT_DOUBLE_EQ(0.9f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
-  ASSERT_DOUBLE_EQ(1, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 1)));
+  ASSERT_DOUBLE_EQ(0.9f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 1)));
+  ASSERT_DOUBLE_EQ(0.9f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
+  ASSERT_DOUBLE_EQ(1, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 1)));
 
-  ASSERT_DOUBLE_EQ(8.f/9.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
-  ASSERT_DOUBLE_EQ(8.f/9.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
   ASSERT_DOUBLE_EQ(8.f/9.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
-  ASSERT_DOUBLE_EQ(1, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
+  ASSERT_DOUBLE_EQ(8.f/9.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
+  ASSERT_DOUBLE_EQ(8.f/9.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+  ASSERT_DOUBLE_EQ(1, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
 
   ASSERT_DOUBLE_EQ((2.f/3.f + 1.f + 1.f + 1.f + 1.f + 1.f + 1.f)/8.f,
-                   (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
+                   (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
   ASSERT_DOUBLE_EQ((2.f/3.f + 1.f + 1.f + 1.f + 1.f + 1.f + 1.f)/8.f,
-                   (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 3)));
-  ASSERT_DOUBLE_EQ(0.75f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
-  ASSERT_DOUBLE_EQ(6.f/7.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 3)));
+                   (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 3)));
+  ASSERT_DOUBLE_EQ(0.75f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
+  ASSERT_DOUBLE_EQ(6.f/7.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 3)));
 
-  ASSERT_DOUBLE_EQ(5.75f/7.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
-  ASSERT_DOUBLE_EQ(5.75f/7.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 4)));
-  ASSERT_DOUBLE_EQ(5.f/7.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
-  ASSERT_DOUBLE_EQ(5.f/6.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 4)));
+  ASSERT_DOUBLE_EQ(5.75f/7.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
+  ASSERT_DOUBLE_EQ(5.75f/7.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 4)));
+  ASSERT_DOUBLE_EQ(5.f/7.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
+  ASSERT_DOUBLE_EQ(5.f/6.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 4)));
 
-  ASSERT_DOUBLE_EQ(4.8f/6.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
-  ASSERT_DOUBLE_EQ(4.8f/6.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
-  ASSERT_DOUBLE_EQ(4.f/6.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
-  ASSERT_DOUBLE_EQ(4.f/5.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
+  ASSERT_DOUBLE_EQ(4.8f/6.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
+  ASSERT_DOUBLE_EQ(4.8f/6.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
+  ASSERT_DOUBLE_EQ(4.f/6.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
+  ASSERT_DOUBLE_EQ(4.f/5.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
 
-  ASSERT_DOUBLE_EQ((8.f/9.f)/2.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 9)));
-  ASSERT_DOUBLE_EQ((8.f/9.f)/2.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 9)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 9)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 9)));
+  ASSERT_DOUBLE_EQ((8.f/9.f)/2.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 9)));
+  ASSERT_DOUBLE_EQ((8.f/9.f)/2.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 9)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 9)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 9)));
 }
 
 TEST(ngram_match_utils_test, test_similarity_with_gaps) {
   const irs::string_ref lhs = "apple1234juice";
   const irs::string_ref rhs = "aple567juice";
 
-  ASSERT_DOUBLE_EQ(9.f/14.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
-  ASSERT_DOUBLE_EQ(9.f/14.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 1)));
   ASSERT_DOUBLE_EQ(9.f/14.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
-  ASSERT_DOUBLE_EQ(9.f/12.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 1)));
+  ASSERT_DOUBLE_EQ(9.f/14.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 1)));
+  ASSERT_DOUBLE_EQ(9.f/14.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
+  ASSERT_DOUBLE_EQ(9.f/12.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 1)));
 
-  ASSERT_DOUBLE_EQ(8.f/13.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
-  ASSERT_DOUBLE_EQ(8.f/13.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
-  ASSERT_DOUBLE_EQ(7.f/13.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
-  ASSERT_DOUBLE_EQ(7.f/11.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
+  ASSERT_DOUBLE_EQ(8.f/13.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+  ASSERT_DOUBLE_EQ(8.f/13.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
+  ASSERT_DOUBLE_EQ(7.f/13.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+  ASSERT_DOUBLE_EQ(7.f/11.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
 
   ASSERT_DOUBLE_EQ((2.f/3.f + 1 + 2.f/3.f + 1.f/3.f + 2.f/3.f + 1.f/3.f + 3.f)/12.f,
-      (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
+      (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
   ASSERT_DOUBLE_EQ((2.f/3.f + 1 + 2.f/3.f + 1.f/3.f + 2.f/3.f + 1.f/3.f + 3.f)/12.f,
-      (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 3)));
-  ASSERT_DOUBLE_EQ(4.f/12.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
-  ASSERT_DOUBLE_EQ(4.f/10.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 3)));
+      (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 3)));
+  ASSERT_DOUBLE_EQ(4.f/12.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
+  ASSERT_DOUBLE_EQ(4.f/10.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 3)));
 
   ASSERT_DOUBLE_EQ((0.75f + 0.75f + 0.5f + 0.25f + 0.25f + 0.5f + 0.75f + 2)/11.f,
-      (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
+      (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
   ASSERT_DOUBLE_EQ((0.75f + 0.75f + 0.5f + 0.25f + 0.25f + 0.5f + 0.75f + 2)/11.f,
-      (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 4)));
-  ASSERT_DOUBLE_EQ(2.f/11.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
-  ASSERT_DOUBLE_EQ(2.f/9.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 4)));
+      (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 4)));
+  ASSERT_DOUBLE_EQ(2.f/11.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
+  ASSERT_DOUBLE_EQ(2.f/9.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 4)));
 
   ASSERT_DOUBLE_EQ((3.f/5.f + 3.f/5.f + 2.f/5.f + 1.f/5.f + 2.f/5.f + 3.f/5.f + 4.f/5.f + 1)/10.f,
-      (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
+      (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
   ASSERT_DOUBLE_EQ((3.f/5.f + 3.f/5.f + 2.f/5.f + 1.f/5.f + 2.f/5.f + 3.f/5.f + 4.f/5.f + 1)/10.f,
-      (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
-  ASSERT_DOUBLE_EQ(1.f/10.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
-  ASSERT_DOUBLE_EQ(1.f/8.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
+      (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
+  ASSERT_DOUBLE_EQ(1.f/10.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
+  ASSERT_DOUBLE_EQ(1.f/8.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
 
   ASSERT_DOUBLE_EQ((1.f + 4.f/6.f + 0.5f + 4.f/6.f + 5.f/6.f) / 9.f,
-                   (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 6)));
+                   (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 6)));
   ASSERT_DOUBLE_EQ((1.f + 4.f/6.f + 0.5f + 4.f/6.f + 5.f/6.f) / 9.f,
-                   (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 6)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 6)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 6)));
+                   (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 6)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 6)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 6)));
 }
 
-TEST(ngram_match_utils_test_mixed, test_similarity) {
+TEST(ngram_match_utils_test, test_similarity) {
   { // bin and pos similarity shows different results as first ngram has 0.5 pos match but 0 bin match
     const irs::string_ref lhs = "abba";
     const irs::string_ref rhs = "apba";
 
-    ASSERT_DOUBLE_EQ(2.f / 3.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
-    ASSERT_DOUBLE_EQ(2.f / 3.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
-    ASSERT_DOUBLE_EQ(1.f / 3.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
-    ASSERT_DOUBLE_EQ(1.f / 3.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
+    ASSERT_DOUBLE_EQ(2.f / 3.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+    ASSERT_DOUBLE_EQ(2.f / 3.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
+    ASSERT_DOUBLE_EQ(1.f / 3.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+    ASSERT_DOUBLE_EQ(1.f / 3.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
   }
   { // first 2-gram has 0.5 sim but second one is 1 (and is chosen by pos) so bin and pos similarity works the same
     // result is different for bin similarity only due to abscence of length normalization
     const irs::string_ref lhs = "11234561";
     const irs::string_ref rhs = "1234561";
 
-    ASSERT_DOUBLE_EQ(6.f / 7.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
-    ASSERT_DOUBLE_EQ(6.f / 7.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
     ASSERT_DOUBLE_EQ(6.f / 7.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
-    ASSERT_DOUBLE_EQ(1, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
+    ASSERT_DOUBLE_EQ(6.f / 7.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
+    ASSERT_DOUBLE_EQ(6.f / 7.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+    ASSERT_DOUBLE_EQ(1, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
   }
 }
 
-TEST(ngram_match_utils_test_mixed, test_similarity_shorter) {
+TEST(ngram_match_utils_test, test_similarity_shorter) {
   {
     // strings are shorter than ngram length.
     const irs::string_ref lhs = "abb";
     const irs::string_ref rhs = "abpa";
 
     // for "positional" semantics this will force to find best matched ngram
-    ASSERT_DOUBLE_EQ(0.5f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
-    ASSERT_DOUBLE_EQ(0.5f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
+    ASSERT_DOUBLE_EQ(0.5f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
+    ASSERT_DOUBLE_EQ(0.5f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
     // for "search" semantics this is 0 as there will be no binary matching ngrams found in index
-    ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
-    ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
+    ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
+    ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
   }
   {
     // strings are shorter than ngram length.
@@ -225,23 +225,35 @@ TEST(ngram_match_utils_test_mixed, test_similarity_shorter) {
     const irs::string_ref rhs = "abb";
 
     // for "positional" semantics this will force to find best matched ngram
+    ASSERT_DOUBLE_EQ(1, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
+    ASSERT_DOUBLE_EQ(1, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
+    // for "search" semantics this is 1 as there is binary match of shorter string
     ASSERT_DOUBLE_EQ(1, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
     ASSERT_DOUBLE_EQ(1, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
-    // for "search" semantics this is 0 as there will be no binary matching ngrams found in index
-    ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
-    ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
+  }
+  {
+    // strings are shorter than ngram length.
+    const irs::string_ref lhs = "abb";
+    const irs::string_ref rhs = "abc";
+
+    // for "positional" semantics this will force to find best matched ngram
+    ASSERT_DOUBLE_EQ(2.f/3.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
+    ASSERT_DOUBLE_EQ(2.f/3.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
+    // for "search" semantics this is 0 as there no binary match of shorter string
+    ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
+    ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
   }
 }
 
-TEST(ngram_match_utils_test_mixed, test_similarity_all_empty) {
+TEST(ngram_match_utils_test, test_similarity_all_empty) {
   // strings are shorter than ngram length.
   const irs::string_ref lhs = "";
   const irs::string_ref rhs = "";
 
   // for "positional" semantics this will mean full similarity
-  ASSERT_DOUBLE_EQ(1.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
-  ASSERT_DOUBLE_EQ(1.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
-  // for "search" semantics this is 0 as there will be no binary matching ngrams found in index
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
+  ASSERT_DOUBLE_EQ(1, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
+  ASSERT_DOUBLE_EQ(1, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
+  // for "search" semantics this is 1 as binary strings match
+  ASSERT_DOUBLE_EQ(1, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
+  ASSERT_DOUBLE_EQ(1, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
 }

--- a/tests/utils/ngram_match_utils_tests.cpp
+++ b/tests/utils/ngram_match_utils_tests.cpp
@@ -1,0 +1,87 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2020 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Andrei Lobov
+////////////////////////////////////////////////////////////////////////////////
+
+#include "tests_shared.hpp"
+#include "utils/ngram_match_utils.hpp"
+
+
+TEST(ngram_match_utils_test, test_similarity_empty_left) {
+  const irs::string_ref lhs = ""; 
+  const irs::string_ref rhs = "abcd";
+  ASSERT_DOUBLE_EQ(0, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1));
+  ASSERT_DOUBLE_EQ(0, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2));
+  ASSERT_DOUBLE_EQ(0, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3));
+  ASSERT_DOUBLE_EQ(0, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4));
+  ASSERT_DOUBLE_EQ(0, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5));
+}
+
+TEST(ngram_match_utils_test, test_similarity_empty_right) {
+  const irs::string_ref lhs = "abcd"; 
+  const irs::string_ref rhs = "";
+  ASSERT_DOUBLE_EQ(0, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1));
+  ASSERT_DOUBLE_EQ(0, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2));
+  ASSERT_DOUBLE_EQ(0, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3));
+  ASSERT_DOUBLE_EQ(0, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4));
+  ASSERT_DOUBLE_EQ(0, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5));
+}
+
+TEST(ngram_match_utils_test, test_similarity_no_match) {
+  const irs::string_ref lhs = "abcd"; 
+  const irs::string_ref rhs = "efgh";
+  ASSERT_DOUBLE_EQ(0, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1));
+  ASSERT_DOUBLE_EQ(0, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2));
+  ASSERT_DOUBLE_EQ(0, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3));
+  ASSERT_DOUBLE_EQ(0, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4));
+  ASSERT_DOUBLE_EQ(0, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5));
+}
+
+TEST(ngram_match_utils_test, test_similarity_simple) {
+  const irs::string_ref lhs = "aecd"; 
+  const irs::string_ref rhs = "abcd";
+  ASSERT_DOUBLE_EQ(0.75f, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1));
+  ASSERT_DOUBLE_EQ(1.f/3.f, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2));
+  ASSERT_DOUBLE_EQ(0, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3));
+  ASSERT_DOUBLE_EQ(0, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4));
+  ASSERT_DOUBLE_EQ(0, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5));
+}
+
+TEST(ngram_match_utils_test, test_similarity_different_length) {
+  const irs::string_ref lhs = "applejuice"; 
+  const irs::string_ref rhs = "aplejuice"; 
+  ASSERT_DOUBLE_EQ(0.9f, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1));
+  ASSERT_DOUBLE_EQ(8.f/9.f, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2));
+  ASSERT_DOUBLE_EQ(0.75, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3));
+  ASSERT_DOUBLE_EQ(5.f/7.f, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4));
+  ASSERT_DOUBLE_EQ(4.f/6.f, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5));
+  ASSERT_DOUBLE_EQ(0, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 9));
+}
+
+TEST(ngram_match_utils_test, test_similarity_with_gaps) {
+  const irs::string_ref lhs = "apple1234juice"; 
+  const irs::string_ref rhs = "aple567juice"; 
+  ASSERT_DOUBLE_EQ(9.f/14.f, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1));
+  ASSERT_DOUBLE_EQ(7.f/13.f, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2));
+  ASSERT_DOUBLE_EQ(4.f/12.f, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3));
+  ASSERT_DOUBLE_EQ(2.f/11.f, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4));
+  ASSERT_DOUBLE_EQ(1.f/10.f, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5));
+  ASSERT_DOUBLE_EQ(0, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 6));
+}

--- a/tests/utils/ngram_match_utils_tests.cpp
+++ b/tests/utils/ngram_match_utils_tests.cpp
@@ -27,61 +27,83 @@
 TEST(ngram_match_utils_test, test_similarity_empty_left) {
   const irs::string_ref lhs = ""; 
   const irs::string_ref rhs = "abcd";
-  ASSERT_DOUBLE_EQ(0, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1));
-  ASSERT_DOUBLE_EQ(0, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2));
-  ASSERT_DOUBLE_EQ(0, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3));
-  ASSERT_DOUBLE_EQ(0, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4));
-  ASSERT_DOUBLE_EQ(0, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
 }
 
 TEST(ngram_match_utils_test, test_similarity_empty_right) {
   const irs::string_ref lhs = "abcd"; 
   const irs::string_ref rhs = "";
-  ASSERT_DOUBLE_EQ(0, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1));
-  ASSERT_DOUBLE_EQ(0, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2));
-  ASSERT_DOUBLE_EQ(0, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3));
-  ASSERT_DOUBLE_EQ(0, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4));
-  ASSERT_DOUBLE_EQ(0, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
 }
 
 TEST(ngram_match_utils_test, test_similarity_no_match) {
   const irs::string_ref lhs = "abcd"; 
   const irs::string_ref rhs = "efgh";
-  ASSERT_DOUBLE_EQ(0, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1));
-  ASSERT_DOUBLE_EQ(0, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2));
-  ASSERT_DOUBLE_EQ(0, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3));
-  ASSERT_DOUBLE_EQ(0, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4));
-  ASSERT_DOUBLE_EQ(0, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
 }
 
 TEST(ngram_match_utils_test, test_similarity_simple) {
   const irs::string_ref lhs = "aecd"; 
   const irs::string_ref rhs = "abcd";
-  ASSERT_DOUBLE_EQ(0.75f, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1));
-  ASSERT_DOUBLE_EQ(1.f/3.f, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2));
-  ASSERT_DOUBLE_EQ(0, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3));
-  ASSERT_DOUBLE_EQ(0, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4));
-  ASSERT_DOUBLE_EQ(0, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5));
+  ASSERT_DOUBLE_EQ(0.75f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
+  ASSERT_DOUBLE_EQ(1.f/3.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
 }
 
 TEST(ngram_match_utils_test, test_similarity_different_length) {
   const irs::string_ref lhs = "applejuice"; 
   const irs::string_ref rhs = "aplejuice"; 
-  ASSERT_DOUBLE_EQ(0.9f, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1));
-  ASSERT_DOUBLE_EQ(8.f/9.f, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2));
-  ASSERT_DOUBLE_EQ(0.75, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3));
-  ASSERT_DOUBLE_EQ(5.f/7.f, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4));
-  ASSERT_DOUBLE_EQ(4.f/6.f, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5));
-  ASSERT_DOUBLE_EQ(0, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 9));
+  ASSERT_DOUBLE_EQ(0.9f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
+  ASSERT_DOUBLE_EQ(8.f/9.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+  ASSERT_DOUBLE_EQ(0.75, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
+  ASSERT_DOUBLE_EQ(5.f/7.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
+  ASSERT_DOUBLE_EQ(4.f/6.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 9)));
 }
 
 TEST(ngram_match_utils_test, test_similarity_with_gaps) {
   const irs::string_ref lhs = "apple1234juice"; 
   const irs::string_ref rhs = "aple567juice"; 
-  ASSERT_DOUBLE_EQ(9.f/14.f, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1));
-  ASSERT_DOUBLE_EQ(7.f/13.f, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2));
-  ASSERT_DOUBLE_EQ(4.f/12.f, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3));
-  ASSERT_DOUBLE_EQ(2.f/11.f, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4));
-  ASSERT_DOUBLE_EQ(1.f/10.f, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5));
-  ASSERT_DOUBLE_EQ(0, irs::ngram_similarity(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 6));
+  ASSERT_DOUBLE_EQ(9.f/14.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
+  ASSERT_DOUBLE_EQ(7.f/13.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+  ASSERT_DOUBLE_EQ(4.f/12.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
+  ASSERT_DOUBLE_EQ(2.f/11.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
+  ASSERT_DOUBLE_EQ(1.f/10.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 6)));
+}
+
+TEST(ngram_match_utils_test_with_position, test_similarity_with_gaps) {
+  const irs::string_ref lhs = "apple1234juice"; 
+  const irs::string_ref rhs = "aple567juice"; 
+  ASSERT_DOUBLE_EQ(9.f/14.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
+  ASSERT_DOUBLE_EQ(7.f/13.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+  ASSERT_DOUBLE_EQ(4.f/12.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
+  ASSERT_DOUBLE_EQ(2.f/11.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
+  ASSERT_DOUBLE_EQ(1.f/10.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 6)));
+}
+
+TEST(ngram_match_utils_test_with_positions, test_similarity_with_gaps) {
+  const irs::string_ref lhs = "apple1234juice"; 
+  const irs::string_ref rhs = "aple567juice"; 
+  ASSERT_DOUBLE_EQ(9.f/14.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
+  ASSERT_DOUBLE_EQ(7.f/13.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+  ASSERT_DOUBLE_EQ(4.f/12.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
+  ASSERT_DOUBLE_EQ(2.f/11.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
+  ASSERT_DOUBLE_EQ(1.f/10.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 6)));
 }

--- a/tests/utils/ngram_match_utils_tests.cpp
+++ b/tests/utils/ngram_match_utils_tests.cpp
@@ -27,52 +27,103 @@
 TEST(ngram_match_utils_test, test_similarity_empty_left) {
   const irs::string_ref lhs = ""; 
   const irs::string_ref rhs = "abcd";
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 0)));
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
+
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 0)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
 }
 
 TEST(ngram_match_utils_test, test_similarity_empty_right) {
   const irs::string_ref lhs = "abcd"; 
   const irs::string_ref rhs = "";
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 0)));
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
+
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 0)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
 }
 
 TEST(ngram_match_utils_test, test_similarity_no_match) {
   const irs::string_ref lhs = "abcd"; 
   const irs::string_ref rhs = "efgh";
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 0)));
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
+
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 0)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
 }
 
 TEST(ngram_match_utils_test, test_similarity_simple) {
   const irs::string_ref lhs = "aecd"; 
   const irs::string_ref rhs = "abcd";
+ 
   ASSERT_DOUBLE_EQ(0.75f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
   ASSERT_DOUBLE_EQ(1.f/3.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
+  ASSERT_FALSE(true);
 }
 
 TEST(ngram_match_utils_test, test_similarity_different_length) {
   const irs::string_ref lhs = "applejuice"; 
   const irs::string_ref rhs = "aplejuice"; 
-  ASSERT_DOUBLE_EQ(0.9f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
-  ASSERT_DOUBLE_EQ(8.f/9.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
-  ASSERT_DOUBLE_EQ(0.75, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
-  ASSERT_DOUBLE_EQ(5.f/7.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
-  ASSERT_DOUBLE_EQ(4.f/6.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
+  ASSERT_DOUBLE_EQ(0.9f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
+  ASSERT_DOUBLE_EQ(0.9f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 1)));
+  ASSERT_DOUBLE_EQ(1, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
+  ASSERT_DOUBLE_EQ(0.9f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 1)));
+
+  ASSERT_DOUBLE_EQ(8.f/9.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+  ASSERT_DOUBLE_EQ(8.f/9.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
+  ASSERT_DOUBLE_EQ(1, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+  ASSERT_DOUBLE_EQ(8.f/9.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
+
+  ASSERT_DOUBLE_EQ((2.f/3.f + 1.f + 1.f + 1.f + 1.f + 1.f + 1.f)/8.f, 
+                   (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
+  ASSERT_DOUBLE_EQ((2.f/3.f + 1.f + 1.f + 1.f + 1.f + 1.f + 1.f)/8.f, 
+                   (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 3)));
+  ASSERT_DOUBLE_EQ(6.f/7.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
+  ASSERT_DOUBLE_EQ(0.75f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 3)));
+
+  ASSERT_DOUBLE_EQ(5.75f/7.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
+  ASSERT_DOUBLE_EQ(5.75f/7.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 4)));
+  ASSERT_DOUBLE_EQ(5.f/6.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
+  ASSERT_DOUBLE_EQ(5.f/7.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 4)));
+
+  ASSERT_DOUBLE_EQ(4.8f/6.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
+  ASSERT_DOUBLE_EQ(4.8f/6.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
+  ASSERT_DOUBLE_EQ(4.f/5.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
+  ASSERT_DOUBLE_EQ(4.f/6.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
+
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 9)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 9)));
+  ASSERT_DOUBLE_EQ((8.f/9.f)/2.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 9)));
+  ASSERT_DOUBLE_EQ((8.f/9.f)/2.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 9)));
 }
 
 TEST(ngram_match_utils_test, test_similarity_with_gaps) {
@@ -90,20 +141,38 @@ TEST(ngram_match_utils_test_with_position, test_similarity_with_gaps) {
   const irs::string_ref lhs = "apple1234juice"; 
   const irs::string_ref rhs = "aple567juice"; 
   ASSERT_DOUBLE_EQ(9.f/14.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
-  ASSERT_DOUBLE_EQ(7.f/13.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
-  ASSERT_DOUBLE_EQ(4.f/12.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
-  ASSERT_DOUBLE_EQ(2.f/11.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
-  ASSERT_DOUBLE_EQ(1.f/10.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 6)));
+  ASSERT_DOUBLE_EQ(8.f/13.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+  ASSERT_DOUBLE_EQ((2.f/3.f + 1 + 2.f/3.f + 1.f/3.f + 2.f/3.f + 1.f/3.f + 3.f)/12.f,
+                   (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
+  ASSERT_DOUBLE_EQ((0.75f + 0.75f + 0.5f + 0.25f + 0.25f + 0.5f + 0.75f + 2)/11.f,
+                   (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
+  ASSERT_DOUBLE_EQ((3.f/5.f + 3.f/5.f + 2.f/5.f + 1.f/5.f + 2.f/5.f + 3.f/5.f + 4.f/5.f + 1)/10.f, 
+                   (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 6)));
 }
 
-TEST(ngram_match_utils_test_with_positions, test_similarity_with_gaps) {
-  const irs::string_ref lhs = "apple1234juice"; 
-  const irs::string_ref rhs = "aple567juice"; 
-  ASSERT_DOUBLE_EQ(9.f/14.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
-  ASSERT_DOUBLE_EQ(7.f/13.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
-  ASSERT_DOUBLE_EQ(4.f/12.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
-  ASSERT_DOUBLE_EQ(2.f/11.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
-  ASSERT_DOUBLE_EQ(1.f/10.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 6)));
+TEST(ngram_match_utils_test_mixed, test_similarity) {
+
+  { // bin and pos similarity shows different results as first ngram has 0.5 pos match but 0 bin match
+    const irs::string_ref lhs = "abba";
+    const irs::string_ref rhs = "apba";
+    ASSERT_DOUBLE_EQ(1.f / 3.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+    ASSERT_DOUBLE_EQ(2.f / 3.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+  }
+  { //  first 2-gram has 0.5 sim but second one is 1 so bin and pos similarity works the same
+    const irs::string_ref lhs = "11234561";
+    const irs::string_ref rhs = "1234561";
+    ASSERT_DOUBLE_EQ(6.f / 7.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+    ASSERT_DOUBLE_EQ(6.f / 7.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+  }
+  // postional size normalization
+  {
+    const irs::string_ref lhs = "abba";
+    const irs::string_ref rhs = "abbaabbaabba";
+    ASSERT_DOUBLE_EQ(1, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+    ASSERT_DOUBLE_EQ(1, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
+    ASSERT_DOUBLE_EQ(1.f / 3.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+    ASSERT_DOUBLE_EQ(1.f / 3.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
+  }
+ 
 }

--- a/tests/utils/ngram_match_utils_tests.cpp
+++ b/tests/utils/ngram_match_utils_tests.cpp
@@ -25,14 +25,8 @@
 
 
 TEST(ngram_match_utils_test, test_similarity_empty_left) {
-  const irs::string_ref lhs = ""; 
+  const irs::string_ref lhs = "";
   const irs::string_ref rhs = "abcd";
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 0)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
 
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 0)));
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
@@ -40,17 +34,18 @@ TEST(ngram_match_utils_test, test_similarity_empty_left) {
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
+
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 0)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
 }
 
 TEST(ngram_match_utils_test, test_similarity_empty_right) {
-  const irs::string_ref lhs = "abcd"; 
+  const irs::string_ref lhs = "abcd";
   const irs::string_ref rhs = "";
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 0)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
 
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 0)));
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
@@ -58,10 +53,17 @@ TEST(ngram_match_utils_test, test_similarity_empty_right) {
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
+
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 0)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
 }
 
 TEST(ngram_match_utils_test, test_similarity_no_match) {
-  const irs::string_ref lhs = "abcd"; 
+  const irs::string_ref lhs = "abcd";
   const irs::string_ref rhs = "efgh";
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 0)));
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
@@ -79,124 +81,128 @@ TEST(ngram_match_utils_test, test_similarity_no_match) {
 }
 
 TEST(ngram_match_utils_test, test_similarity_simple) {
-  const irs::string_ref lhs = "aecd"; 
+  const irs::string_ref lhs = "aecd";
   const irs::string_ref rhs = "abcd";
- 
-  ASSERT_DOUBLE_EQ(0.75f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
-  ASSERT_DOUBLE_EQ(0.75f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 1)));
+
   ASSERT_DOUBLE_EQ(0.75f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
   ASSERT_DOUBLE_EQ(0.75f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 1)));
+  ASSERT_DOUBLE_EQ(0.75f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
+  ASSERT_DOUBLE_EQ(0.75f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 1)));
 
-  ASSERT_DOUBLE_EQ(1.f/3.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
-  ASSERT_DOUBLE_EQ(1.f/3.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
   ASSERT_DOUBLE_EQ(2.f/3.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
   ASSERT_DOUBLE_EQ(2.f/3.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
+  ASSERT_DOUBLE_EQ(1.f/3.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+  ASSERT_DOUBLE_EQ(1.f/3.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
 
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 3)));
   ASSERT_DOUBLE_EQ(2.f/3.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
   ASSERT_DOUBLE_EQ(2.f/3.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 3)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 3)));
 
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 4)));
   ASSERT_DOUBLE_EQ(3.f/4.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
   ASSERT_DOUBLE_EQ(3.f/4.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 4)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 4)));
 }
 
 TEST(ngram_match_utils_test, test_similarity_different_length) {
-  const irs::string_ref lhs = "applejuice"; 
-  const irs::string_ref rhs = "aplejuice"; 
+  const irs::string_ref lhs = "applejuice";
+  const irs::string_ref rhs = "aplejuice";
   ASSERT_DOUBLE_EQ(0.9f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
   ASSERT_DOUBLE_EQ(0.9f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 1)));
-  ASSERT_DOUBLE_EQ(1, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
-  ASSERT_DOUBLE_EQ(0.9f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 1)));
+  ASSERT_DOUBLE_EQ(0.9f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
+  ASSERT_DOUBLE_EQ(1, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 1)));
 
   ASSERT_DOUBLE_EQ(8.f/9.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
   ASSERT_DOUBLE_EQ(8.f/9.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
-  ASSERT_DOUBLE_EQ(1, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
-  ASSERT_DOUBLE_EQ(8.f/9.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
+  ASSERT_DOUBLE_EQ(8.f/9.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+  ASSERT_DOUBLE_EQ(1, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
 
-  ASSERT_DOUBLE_EQ((2.f/3.f + 1.f + 1.f + 1.f + 1.f + 1.f + 1.f)/8.f, 
+  ASSERT_DOUBLE_EQ((2.f/3.f + 1.f + 1.f + 1.f + 1.f + 1.f + 1.f)/8.f,
                    (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
-  ASSERT_DOUBLE_EQ((2.f/3.f + 1.f + 1.f + 1.f + 1.f + 1.f + 1.f)/8.f, 
+  ASSERT_DOUBLE_EQ((2.f/3.f + 1.f + 1.f + 1.f + 1.f + 1.f + 1.f)/8.f,
                    (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 3)));
-  ASSERT_DOUBLE_EQ(6.f/7.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
-  ASSERT_DOUBLE_EQ(0.75f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 3)));
+  ASSERT_DOUBLE_EQ(0.75f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
+  ASSERT_DOUBLE_EQ(6.f/7.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 3)));
 
   ASSERT_DOUBLE_EQ(5.75f/7.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
   ASSERT_DOUBLE_EQ(5.75f/7.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 4)));
-  ASSERT_DOUBLE_EQ(5.f/6.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
-  ASSERT_DOUBLE_EQ(5.f/7.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 4)));
+  ASSERT_DOUBLE_EQ(5.f/7.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
+  ASSERT_DOUBLE_EQ(5.f/6.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 4)));
 
   ASSERT_DOUBLE_EQ(4.8f/6.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
   ASSERT_DOUBLE_EQ(4.8f/6.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
-  ASSERT_DOUBLE_EQ(4.f/5.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
-  ASSERT_DOUBLE_EQ(4.f/6.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
+  ASSERT_DOUBLE_EQ(4.f/6.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
+  ASSERT_DOUBLE_EQ(4.f/5.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
 
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 9)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 9)));
   ASSERT_DOUBLE_EQ((8.f/9.f)/2.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 9)));
   ASSERT_DOUBLE_EQ((8.f/9.f)/2.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 9)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 9)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 9)));
 }
 
 TEST(ngram_match_utils_test, test_similarity_with_gaps) {
-  const irs::string_ref lhs = "apple1234juice"; 
-  const irs::string_ref rhs = "aple567juice"; 
-  ASSERT_DOUBLE_EQ(9.f/12.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
-  ASSERT_DOUBLE_EQ(9.f/14.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 1)));
+  const irs::string_ref lhs = "apple1234juice";
+  const irs::string_ref rhs = "aple567juice";
+
   ASSERT_DOUBLE_EQ(9.f/14.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
   ASSERT_DOUBLE_EQ(9.f/14.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 1)));
+  ASSERT_DOUBLE_EQ(9.f/14.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
+  ASSERT_DOUBLE_EQ(9.f/12.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 1)));
 
-  ASSERT_DOUBLE_EQ(7.f/11.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
-  ASSERT_DOUBLE_EQ(7.f/13.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
   ASSERT_DOUBLE_EQ(8.f/13.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
   ASSERT_DOUBLE_EQ(8.f/13.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
+  ASSERT_DOUBLE_EQ(7.f/13.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+  ASSERT_DOUBLE_EQ(7.f/11.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
 
-  ASSERT_DOUBLE_EQ(4.f/10.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
-  ASSERT_DOUBLE_EQ(4.f/12.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 3)));
   ASSERT_DOUBLE_EQ((2.f/3.f + 1 + 2.f/3.f + 1.f/3.f + 2.f/3.f + 1.f/3.f + 3.f)/12.f,
       (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
   ASSERT_DOUBLE_EQ((2.f/3.f + 1 + 2.f/3.f + 1.f/3.f + 2.f/3.f + 1.f/3.f + 3.f)/12.f,
       (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 3)));
+  ASSERT_DOUBLE_EQ(4.f/12.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
+  ASSERT_DOUBLE_EQ(4.f/10.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 3)));
 
-  ASSERT_DOUBLE_EQ(2.f/9.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
-  ASSERT_DOUBLE_EQ(2.f/11.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 4)));
   ASSERT_DOUBLE_EQ((0.75f + 0.75f + 0.5f + 0.25f + 0.25f + 0.5f + 0.75f + 2)/11.f,
       (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
   ASSERT_DOUBLE_EQ((0.75f + 0.75f + 0.5f + 0.25f + 0.25f + 0.5f + 0.75f + 2)/11.f,
       (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 4)));
+  ASSERT_DOUBLE_EQ(2.f/11.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
+  ASSERT_DOUBLE_EQ(2.f/9.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 4)));
 
-  ASSERT_DOUBLE_EQ(1.f/8.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
-  ASSERT_DOUBLE_EQ(1.f/10.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
-  ASSERT_DOUBLE_EQ((3.f/5.f + 3.f/5.f + 2.f/5.f + 1.f/5.f + 2.f/5.f + 3.f/5.f + 4.f/5.f + 1)/10.f, 
+  ASSERT_DOUBLE_EQ((3.f/5.f + 3.f/5.f + 2.f/5.f + 1.f/5.f + 2.f/5.f + 3.f/5.f + 4.f/5.f + 1)/10.f,
       (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
-  ASSERT_DOUBLE_EQ((3.f/5.f + 3.f/5.f + 2.f/5.f + 1.f/5.f + 2.f/5.f + 3.f/5.f + 4.f/5.f + 1)/10.f, 
+  ASSERT_DOUBLE_EQ((3.f/5.f + 3.f/5.f + 2.f/5.f + 1.f/5.f + 2.f/5.f + 3.f/5.f + 4.f/5.f + 1)/10.f,
       (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 6)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 6)));
+  ASSERT_DOUBLE_EQ(1.f/10.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
+  ASSERT_DOUBLE_EQ(1.f/8.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
+
   ASSERT_DOUBLE_EQ((1.f + 4.f/6.f + 0.5f + 4.f/6.f + 5.f/6.f) / 9.f,
                    (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 6)));
   ASSERT_DOUBLE_EQ((1.f + 4.f/6.f + 0.5f + 4.f/6.f + 5.f/6.f) / 9.f,
                    (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 6)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 6)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 6)));
 }
 
 TEST(ngram_match_utils_test_mixed, test_similarity) {
   { // bin and pos similarity shows different results as first ngram has 0.5 pos match but 0 bin match
     const irs::string_ref lhs = "abba";
     const irs::string_ref rhs = "apba";
-    ASSERT_DOUBLE_EQ(1.f / 3.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
-    ASSERT_DOUBLE_EQ(1.f / 3.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
+
     ASSERT_DOUBLE_EQ(2.f / 3.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
     ASSERT_DOUBLE_EQ(2.f / 3.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
+    ASSERT_DOUBLE_EQ(1.f / 3.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+    ASSERT_DOUBLE_EQ(1.f / 3.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
   }
   { // first 2-gram has 0.5 sim but second one is 1 (and is chosen by pos) so bin and pos similarity works the same
     // result is different for bin similarity only due to abscence of length normalization
     const irs::string_ref lhs = "11234561";
     const irs::string_ref rhs = "1234561";
-    ASSERT_DOUBLE_EQ(1, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
-    ASSERT_DOUBLE_EQ(6.f / 7.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
+
     ASSERT_DOUBLE_EQ(6.f / 7.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
     ASSERT_DOUBLE_EQ(6.f / 7.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
+    ASSERT_DOUBLE_EQ(6.f / 7.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+    ASSERT_DOUBLE_EQ(1, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
   }
 }
 
@@ -205,23 +211,25 @@ TEST(ngram_match_utils_test_mixed, test_similarity_shorter) {
     // strings are shorter than ngram length.
     const irs::string_ref lhs = "abb";
     const irs::string_ref rhs = "abpa";
-    // for "search" semantics this is 0 as there will be no binary matching ngrams found in index
-    ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
-    ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
+
     // for "positional" semantics this will force to find best matched ngram
     ASSERT_DOUBLE_EQ(0.5f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
     ASSERT_DOUBLE_EQ(0.5f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
+    // for "search" semantics this is 0 as there will be no binary matching ngrams found in index
+    ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
+    ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
   }
   {
     // strings are shorter than ngram length.
     const irs::string_ref lhs = "abb";
     const irs::string_ref rhs = "abb";
-    // for "search" semantics this is 0 as there will be no binary matching ngrams found in index
-    ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
-    ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
+
     // for "positional" semantics this will force to find best matched ngram
     ASSERT_DOUBLE_EQ(1, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
     ASSERT_DOUBLE_EQ(1, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
+    // for "search" semantics this is 0 as there will be no binary matching ngrams found in index
+    ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
+    ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
   }
 }
 
@@ -229,10 +237,11 @@ TEST(ngram_match_utils_test_mixed, test_similarity_all_empty) {
   // strings are shorter than ngram length.
   const irs::string_ref lhs = "";
   const irs::string_ref rhs = "";
-  // for "search" semantics this is 0 as there will be no binary matching ngrams found in index
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
+
   // for "positional" semantics this will mean full similarity
   ASSERT_DOUBLE_EQ(1.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
   ASSERT_DOUBLE_EQ(1.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
+  // for "search" semantics this is 0 as there will be no binary matching ngrams found in index
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
 }

--- a/tests/utils/ngram_match_utils_tests.cpp
+++ b/tests/utils/ngram_match_utils_tests.cpp
@@ -83,11 +83,24 @@ TEST(ngram_match_utils_test, test_similarity_simple) {
   const irs::string_ref rhs = "abcd";
  
   ASSERT_DOUBLE_EQ(0.75f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
+  ASSERT_DOUBLE_EQ(0.75f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 1)));
+  ASSERT_DOUBLE_EQ(0.75f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
+  ASSERT_DOUBLE_EQ(0.75f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 1)));
+
   ASSERT_DOUBLE_EQ(1.f/3.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+  ASSERT_DOUBLE_EQ(1.f/3.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
+  ASSERT_DOUBLE_EQ(2.f/3.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+  ASSERT_DOUBLE_EQ(2.f/3.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
+
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 3)));
+  ASSERT_DOUBLE_EQ(2.f/3.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
+  ASSERT_DOUBLE_EQ(2.f/3.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 3)));
+
   ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
-  ASSERT_FALSE(true);
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 4)));
+  ASSERT_DOUBLE_EQ(3.f/4.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
+  ASSERT_DOUBLE_EQ(3.f/4.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 4)));
 }
 
 TEST(ngram_match_utils_test, test_similarity_different_length) {
@@ -129,50 +142,97 @@ TEST(ngram_match_utils_test, test_similarity_different_length) {
 TEST(ngram_match_utils_test, test_similarity_with_gaps) {
   const irs::string_ref lhs = "apple1234juice"; 
   const irs::string_ref rhs = "aple567juice"; 
-  ASSERT_DOUBLE_EQ(9.f/14.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
-  ASSERT_DOUBLE_EQ(7.f/13.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
-  ASSERT_DOUBLE_EQ(4.f/12.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
-  ASSERT_DOUBLE_EQ(2.f/11.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
-  ASSERT_DOUBLE_EQ(1.f/10.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 6)));
-}
-
-TEST(ngram_match_utils_test_with_position, test_similarity_with_gaps) {
-  const irs::string_ref lhs = "apple1234juice"; 
-  const irs::string_ref rhs = "aple567juice"; 
+  ASSERT_DOUBLE_EQ(9.f/12.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
+  ASSERT_DOUBLE_EQ(9.f/14.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 1)));
   ASSERT_DOUBLE_EQ(9.f/14.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 1)));
+  ASSERT_DOUBLE_EQ(9.f/14.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 1)));
+
+  ASSERT_DOUBLE_EQ(7.f/11.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+  ASSERT_DOUBLE_EQ(7.f/13.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
   ASSERT_DOUBLE_EQ(8.f/13.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+  ASSERT_DOUBLE_EQ(8.f/13.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
+
+  ASSERT_DOUBLE_EQ(4.f/10.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
+  ASSERT_DOUBLE_EQ(4.f/12.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 3)));
   ASSERT_DOUBLE_EQ((2.f/3.f + 1 + 2.f/3.f + 1.f/3.f + 2.f/3.f + 1.f/3.f + 3.f)/12.f,
-                   (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
+      (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 3)));
+  ASSERT_DOUBLE_EQ((2.f/3.f + 1 + 2.f/3.f + 1.f/3.f + 2.f/3.f + 1.f/3.f + 3.f)/12.f,
+      (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 3)));
+
+  ASSERT_DOUBLE_EQ(2.f/9.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
+  ASSERT_DOUBLE_EQ(2.f/11.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 4)));
   ASSERT_DOUBLE_EQ((0.75f + 0.75f + 0.5f + 0.25f + 0.25f + 0.5f + 0.75f + 2)/11.f,
-                   (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
+      (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 4)));
+  ASSERT_DOUBLE_EQ((0.75f + 0.75f + 0.5f + 0.25f + 0.25f + 0.5f + 0.75f + 2)/11.f,
+      (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 4)));
+
+  ASSERT_DOUBLE_EQ(1.f/8.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
+  ASSERT_DOUBLE_EQ(1.f/10.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
   ASSERT_DOUBLE_EQ((3.f/5.f + 3.f/5.f + 2.f/5.f + 1.f/5.f + 2.f/5.f + 3.f/5.f + 4.f/5.f + 1)/10.f, 
-                   (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
-  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 6)));
+      (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
+  ASSERT_DOUBLE_EQ((3.f/5.f + 3.f/5.f + 2.f/5.f + 1.f/5.f + 2.f/5.f + 3.f/5.f + 4.f/5.f + 1)/10.f, 
+      (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 6)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 6)));
+  ASSERT_DOUBLE_EQ((1.f + 4.f/6.f + 0.5f + 4.f/6.f + 5.f/6.f) / 9.f,
+                   (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 6)));
+  ASSERT_DOUBLE_EQ((1.f + 4.f/6.f + 0.5f + 4.f/6.f + 5.f/6.f) / 9.f,
+                   (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 6)));
 }
 
 TEST(ngram_match_utils_test_mixed, test_similarity) {
-
   { // bin and pos similarity shows different results as first ngram has 0.5 pos match but 0 bin match
     const irs::string_ref lhs = "abba";
     const irs::string_ref rhs = "apba";
     ASSERT_DOUBLE_EQ(1.f / 3.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+    ASSERT_DOUBLE_EQ(1.f / 3.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
     ASSERT_DOUBLE_EQ(2.f / 3.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+    ASSERT_DOUBLE_EQ(2.f / 3.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
   }
-  { //  first 2-gram has 0.5 sim but second one is 1 so bin and pos similarity works the same
+  { // first 2-gram has 0.5 sim but second one is 1 (and is chosen by pos) so bin and pos similarity works the same
+    // result is different for bin similarity only due to abscence of length normalization
     const irs::string_ref lhs = "11234561";
     const irs::string_ref rhs = "1234561";
-    ASSERT_DOUBLE_EQ(6.f / 7.f, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
-    ASSERT_DOUBLE_EQ(6.f / 7.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
-  }
-  // postional size normalization
-  {
-    const irs::string_ref lhs = "abba";
-    const irs::string_ref rhs = "abbaabbaabba";
     ASSERT_DOUBLE_EQ(1, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
-    ASSERT_DOUBLE_EQ(1, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
-    ASSERT_DOUBLE_EQ(1.f / 3.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
-    ASSERT_DOUBLE_EQ(1.f / 3.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
+    ASSERT_DOUBLE_EQ(6.f / 7.f, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
+    ASSERT_DOUBLE_EQ(6.f / 7.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 2)));
+    ASSERT_DOUBLE_EQ(6.f / 7.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 2)));
   }
- 
+}
+
+TEST(ngram_match_utils_test_mixed, test_similarity_shorter) {
+  {
+    // strings are shorter than ngram length.
+    const irs::string_ref lhs = "abb";
+    const irs::string_ref rhs = "abpa";
+    // for "search" semantics this is 0 as there will be no binary matching ngrams found in index
+    ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
+    ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
+    // for "positional" semantics this will force to find best matched ngram
+    ASSERT_DOUBLE_EQ(0.5f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
+    ASSERT_DOUBLE_EQ(0.5f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
+  }
+  {
+    // strings are shorter than ngram length.
+    const irs::string_ref lhs = "abb";
+    const irs::string_ref rhs = "abb";
+    // for "search" semantics this is 0 as there will be no binary matching ngrams found in index
+    ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
+    ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
+    // for "positional" semantics this will force to find best matched ngram
+    ASSERT_DOUBLE_EQ(1, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
+    ASSERT_DOUBLE_EQ(1, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
+  }
+}
+
+TEST(ngram_match_utils_test_mixed, test_similarity_all_empty) {
+  // strings are shorter than ngram length.
+  const irs::string_ref lhs = "";
+  const irs::string_ref rhs = "";
+  // for "search" semantics this is 0 as there will be no binary matching ngrams found in index
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
+  ASSERT_DOUBLE_EQ(0, (irs::ngram_similarity<char, false>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
+  // for "positional" semantics this will mean full similarity
+  ASSERT_DOUBLE_EQ(1.f, (irs::ngram_similarity<char, true>(lhs.begin(), lhs.size(), rhs.begin(), rhs.size(), 5)));
+  ASSERT_DOUBLE_EQ(1.f, (irs::ngram_similarity<char, true>(rhs.begin(), rhs.size(), lhs.begin(), lhs.size(), 5)));
 }


### PR DESCRIPTION
Implemented standalone ngram_similarity function in two modes - 
search_semantics  - with binary ngram match and target length normalization
postional  - positional ngram match and longest string normalization.
Also PR contains minor fix for levenshtein utils to ensure no invalidated iterator is used.

Added tests for standalone function.
Updated tests for ngram similarity filter  - matcher tests validates results by new  ngram_similarity function.