### PR TITLE
bug-fix/internal-issue-#704

### DIFF
--- a/core/formats/formats_burst_trie.cpp
+++ b/core/formats/formats_burst_trie.cpp
@@ -554,7 +554,8 @@ class term_iterator_base
         { type<frequency>::id(), owner.field_.features.check<frequency>() ? &freq_ : nullptr },
         { type<payload>::id(), pay }
       }},
-      owner_(&owner) {
+      owner_(&owner),
+      terms_cipher_(owner.owner_->terms_in_cipher_.get()) {
     assert(owner_);
   }
 
@@ -601,7 +602,7 @@ class term_iterator_base
   index_input& terms_input() const;
 
   irs::encryption::stream* terms_cipher() const noexcept {
-    return owner_->owner_->terms_in_cipher_.get();
+    return terms_cipher_;
   }
 
  protected:
@@ -625,6 +626,7 @@ class term_iterator_base
   }
 
   const term_reader* owner_;
+  irs::encryption::stream* terms_cipher_;
   mutable version10::term_meta state_;
   frequency freq_;
   mutable index_input::ptr terms_in_;

--- a/core/formats/formats_burst_trie.cpp
+++ b/core/formats/formats_burst_trie.cpp
@@ -516,7 +516,7 @@ class block_iterator : util::noncopyable {
   const byte_type* stats_end_{stats_begin_ + stats_block_.size()}; // end of valid stats input stream
 #endif
   const byte_type* suffix_{}; // current suffix
-  size_t suffix_length_{}; // current suffix length
+  uint64_t suffix_length_{}; // current suffix length
   version10::term_meta state_;
   uint64_t cur_ent_{}; // current entry in a block
   uint64_t ent_count_{}; // number of entries in a current block
@@ -1743,7 +1743,7 @@ void term_reader::prepare(
   if (!fst_) {
     throw irs::index_error(string_utils::to_string(
       "failed to read term index for field '%s'",
-      field_.name));
+      field_.name.c_str()));
   }
 
   owner_ = &owner;

--- a/core/formats/formats_burst_trie.cpp
+++ b/core/formats/formats_burst_trie.cpp
@@ -720,8 +720,7 @@ class term_iterator final : public term_iterator_base {
 
   ptrdiff_t seek_cached(
     size_t& prefix, arc::stateid_t& state,
-    byte_weight& weight, const bytes_ref& term
-  );
+    byte_weight& weight, const bytes_ref& term);
 
   /// @brief Seek to the closest block which contain a specified term
   /// @param prefix size of the common term/block prefix
@@ -2309,8 +2308,7 @@ void field_writer::write_field_features(data_output& out, const flags& features)
       // should not happen in reality
       throw irs::index_error(string_utils::to_string(
         "feature '%s' is not listed in segment features",
-        feature().name().c_str()
-      ));
+        feature().name().c_str()));
     }
 
     out.write_vlong(it->second);
@@ -2426,8 +2424,7 @@ void field_reader::prepare(
     field_writer::FORMAT_TERMS_INDEX,
     field_writer::FORMAT_MIN,
     field_writer::FORMAT_MAX,
-    &checksum
-  );
+    &checksum);
 
   constexpr const size_t FOOTER_LEN =
       sizeof(uint64_t) // fields count
@@ -2457,15 +2454,13 @@ void field_reader::prepare(
 
       const auto blocks_in_buffer = math::div_ceil64(
         buffered_index_input::DEFAULT_BUFFER_SIZE,
-        index_in_cipher->block_size()
-      );
+        index_in_cipher->block_size());
 
       index_in = index_input::make<encrypted_input>(
         std::move(index_in),
         *index_in_cipher,
         blocks_in_buffer,
-        FOOTER_LEN
-      );
+        FOOTER_LEN);
     }
   }
 
@@ -2492,8 +2487,7 @@ void field_reader::prepare(
       throw irs::index_error(string_utils::to_string(
         "duplicated field: '%s' found in segment: '%s'",
         name.c_str(),
-        meta.name.c_str()
-      ));
+        meta.name.c_str()));
     }
 
     --fields_count;
@@ -2507,8 +2501,7 @@ void field_reader::prepare(
   if (!std::is_sorted(fields_.begin(), fields_.end(), less)) {
     throw index_error(string_utils::to_string(
       "invalid field order in segment '%s'",
-      meta.name.c_str()
-    ));
+      meta.name.c_str()));
   }
 
   //-----------------------------------------------------------------
@@ -2521,16 +2514,14 @@ void field_reader::prepare(
     field_writer::TERMS_EXT,
     field_writer::FORMAT_TERMS,
     field_writer::FORMAT_MIN,
-    field_writer::FORMAT_MAX
-  );
+    field_writer::FORMAT_MAX);
 
   if (term_index_version != term_dict_version) {
     throw index_error(string_utils::to_string(
       "term index version '%d' mismatches term dictionary version '%d' in segment '%s'",
       term_index_version,
       meta.name.c_str(),
-      term_dict_version
-    ));
+      term_dict_version));
   }
 
   if (term_dict_version > field_writer::FORMAT_MIN) {

--- a/core/formats/formats_burst_trie.cpp
+++ b/core/formats/formats_burst_trie.cpp
@@ -466,12 +466,6 @@ class block_iterator : util::noncopyable {
   SeekResult scan_to_term(const bytes_ref& term, Reader& reader) {
     assert(!dirty_);
 
-    if (cur_ent_ == ent_count_) {
-      // have reached the end of the block
-      reader(suffix_, suffix_length_);
-      return SeekResult::END;
-    }
-
     const SeekResult res = leaf_
       ? scan_to_term_leaf(term)
       : scan_to_term_nonleaf(term);
@@ -1178,7 +1172,7 @@ SeekResult block_iterator::scan_to_term_leaf(const bytes_ref& term) {
   assert(leaf_);
   assert(!dirty_);
 
-  for (; cur_ent_ < ent_count_;) {
+  while (cur_ent_ < ent_count_) {
     ++cur_ent_;
     ++term_count_;
     cur_type_ = ET_TERM;
@@ -1227,7 +1221,7 @@ SeekResult block_iterator::scan_to_term_nonleaf(const bytes_ref& term) {
   assert(!leaf_);
   assert(!dirty_);
 
-  for (; cur_ent_ < ent_count_;) {
+  while (cur_ent_ < ent_count_) {
     ++cur_ent_;
     cur_type_ = shift_unpack_64(vread<uint64_t>(suffix_begin_), suffix_length_)
         ? ET_BLOCK : ET_TERM;

--- a/core/formats/formats_burst_trie.cpp
+++ b/core/formats/formats_burst_trie.cpp
@@ -1187,21 +1187,20 @@ SeekResult block_iterator::scan_to_term_leaf(const bytes_ref& term) {
     suffix_begin_ += suffix_length_; // skip to the next term
     assert(suffix_begin_ <= suffix_end_);
 
-    const size_t term_len = prefix_ + suffix_length_;
-    const byte_type* max = term.c_str() + std::min(term.size(), term_len); // max limit of comparison
+    const byte_type* suffix = suffix_;
+    const byte_type* target = term.c_str() + prefix_;
+    const size_t target_len = prefix_ + suffix_length_;
+    const byte_type* target_end = term.c_str() + std::min(term.size(), target_len);
 
     ptrdiff_t cmp;
-    const byte_type* suffix = suffix_;
-    const byte_type* tpos = term.c_str() + prefix_;
-
     for (bool stop = false;;) {
-      if (tpos < max) {
-        cmp = *suffix - *tpos;
-        ++tpos;
+      if (target < target_end) {
+        cmp = *suffix - *target;
+        ++target;
         ++suffix;
       } else {
-        assert(tpos == max);
-        cmp = term_len - term.size();
+        assert(target == target_end);
+        cmp = target_len - term.size();
         stop = true;
       }
 
@@ -1242,21 +1241,20 @@ SeekResult block_iterator::scan_to_term_nonleaf(const bytes_ref& term) {
       default: assert(false); break;
     }
 
-    const size_t term_len = prefix_ + suffix_length_;
-    const byte_type* max = term.c_str() + std::min(term.size(), term_len); // max limit of comparison
+    const byte_type* suffix = suffix_;
+    const size_t target_len = prefix_ + suffix_length_;
+    const byte_type* target = term.c_str() + prefix_;
+    const byte_type* target_end = term.c_str() + std::min(term.size(), target_len);
 
     ptrdiff_t cmp;
-    const byte_type* suffix = suffix_;
-    const byte_type* tpos = term.c_str() + prefix_;
-
     for (bool stop = false;;) {
-      if (tpos < max) {
-        cmp = *suffix - *tpos;
-        ++tpos;
+      if (target < target_end) {
+        cmp = *suffix - *target;
+        ++target;
         ++suffix;
       } else {
-        assert(tpos == max);
-        cmp = term_len - term.size();
+        assert(target == target_end);
+        cmp = target_len - term.size();
         stop = true;
       }
 

--- a/core/formats/formats_burst_trie.cpp
+++ b/core/formats/formats_burst_trie.cpp
@@ -1711,14 +1711,12 @@ term_reader::term_reader(term_reader&& rhs) noexcept
 
 seek_term_iterator::ptr term_reader::iterator() const {
   return memory::make_managed<seek_term_iterator>(
-    memory::make_unique<detail::term_iterator>(*this)
-  );
+    memory::make_unique<detail::term_iterator>(*this));
 }
 
 seek_term_iterator::ptr term_reader::iterator(automaton_table_matcher& matcher) const {
   return memory::make_managed<seek_term_iterator>(
-    memory::make_unique<detail::automaton_term_iterator>(*this, matcher)
-  );
+    memory::make_unique<detail::automaton_term_iterator>(*this, matcher));
 }
 
 void term_reader::prepare(
@@ -1747,7 +1745,12 @@ void term_reader::prepare(
 
   // read FST
   fst_.reset(fst_t::Read(in, fst_read_options()));
-  assert(fst_);
+
+  if (!fst_) {
+    throw irs::index_error(string_utils::to_string(
+      "failed to read term index for field '%s'",
+      field_.name));
+  }
 
   owner_ = &owner;
 }
@@ -2250,8 +2253,7 @@ field_reader::field_reader(irs::postings_reader::ptr&& pr)
 void field_reader::prepare(
     const directory& dir,
     const segment_meta& meta,
-    const document_mask& /*mask*/
-) {
+    const document_mask& /*mask*/) {
   std::string filename;
 
   //-----------------------------------------------------------------

--- a/core/formats/formats_burst_trie.hpp
+++ b/core/formats/formats_burst_trie.hpp
@@ -328,8 +328,7 @@ class field_writer final : public irs::field_writer {
     const irs::flags& features,
     uint64_t total_doc_freq, 
     uint64_t total_term_freq, 
-    size_t doc_count
-  );
+    size_t doc_count);
 
   void write_term_entry(const detail::entry& e, size_t prefix, bool leaf);
 
@@ -344,8 +343,7 @@ class field_writer final : public irs::field_writer {
     std::list<detail::entry>& blocks,
     size_t prefix, size_t begin,
     size_t end, byte_type meta,
-    int16_t label
-  );
+    int16_t label);
 
   // prefix - prefix length ( in last_term
   // count - number of entries to write into block

--- a/core/search/ngram_similarity_filter.cpp
+++ b/core/search/ngram_similarity_filter.cpp
@@ -513,9 +513,8 @@ filter::prepared::ptr by_ngram_similarity::prepare(
     field_stats.collect(segment, *field); // collect field statistics once per segment
     size_t term_idx = 0;
     size_t count_terms = 0;
+    seek_term_iterator::ptr term = field->iterator();
     for (const auto& ngram : ngrams) {
-      seek_term_iterator::ptr term = field->iterator();
-
       term_states.emplace_back();
       auto& state = term_states.back();
       if (term->seek(ngram)) {


### PR DESCRIPTION
don't invalidate suffix when block iterator is already positioned at the last element in a block