### PR TITLE
Bug fix/issue #11104

### DIFF
--- a/core/search/boolean_filter.cpp
+++ b/core/search/boolean_filter.cpp
@@ -544,6 +544,10 @@ filter::prepared::ptr Or::prepare(
     return all().prepare(rdr, ord, boost, ctx);
   }
 
+  if (!incl.empty() && incl.back()->type() == irs::type<irs::empty>::id()) {
+    incl.pop_back();
+  }
+
   if (incl.empty()) {
     return prepared::empty();
   }
@@ -551,9 +555,7 @@ filter::prepared::ptr Or::prepare(
   irs::all cumulative_all;
   size_t optimized_match_count = 0;
   // Optimization steps
-  if (incl.back()->type() == irs::type<irs::empty>::id()) {
-    incl.pop_back();
-  }
+
   boost_t all_boost{ 0 };
   size_t all_count{ 0 };
   const irs::filter* incl_all{ nullptr };

--- a/core/search/boolean_filter.cpp
+++ b/core/search/boolean_filter.cpp
@@ -622,7 +622,7 @@ filter::prepared::ptr Or::prepare(
     return all().prepare(rdr, ord, boost, ctx);
   }
 
-  // check strictly less to not roll back to 'all' in case of
+  // check strictly less to not roll back to 0 min_match (we`ve handled this case above!)
   // single 'all' left -> it could contain boost we want to preserve
   const auto adjusted_min_match_count = (optimized_match_count_ < min_match_count_) ?
                                         min_match_count_ - optimized_match_count_ :

--- a/core/search/boolean_filter.cpp
+++ b/core/search/boolean_filter.cpp
@@ -45,7 +45,6 @@ std::pair<const irs::filter*, bool> optimize_not(const irs::Not& node) {
 }
 
 const irs::all all_docs_zero_boost = []() {irs::all a; a.boost(0); return a;}();
-const irs::all all_docs_no_boost;
 //////////////////////////////////////////////////////////////////////////////
 /// @returns disjunction iterator created from the specified queries
 //////////////////////////////////////////////////////////////////////////////
@@ -382,8 +381,10 @@ filter::prepared::ptr boolean_filter::prepare(
   // determine incl/excl parts
   std::vector<const filter*> incl;
   std::vector<const filter*> excl;
-
+  
   group_filters(incl, excl);
+
+  const irs::all all_docs_no_boost;
   if (incl.empty() && !excl.empty()) {
     // single negative query case
     incl.push_back(&all_docs_no_boost);

--- a/core/search/boolean_filter.cpp
+++ b/core/search/boolean_filter.cpp
@@ -579,7 +579,7 @@ void Or::optimize(
 
   if (ord.empty()) {
     // if we have at least one all in include group - all other filters are not necessary
-    // in case there is no scoring and min_match = 1
+    // in case there is no scoring and 'all' count satisfies  min_match
     auto incl_all = std::find_if(incl.begin(), incl.end(), [](const irs::filter* filter) {
         return irs::type<irs::all>::id() == filter->type();
       });

--- a/core/search/boolean_filter.cpp
+++ b/core/search/boolean_filter.cpp
@@ -468,14 +468,12 @@ filter::prepared::ptr And::prepare(
   irs::all cumulative_all;
   boost_t all_boost{ 0 };
   size_t all_count{ 0 };
-  std::for_each(
-    incl.begin(), incl.end(),
-    [&all_count, &all_boost](const irs::filter* filter) {
-      if (filter->type() == irs::type<irs::all>::id()) {
-        all_count++;
-        all_boost += filter->boost();
-      }
-    });
+  for (auto filter : incl) {
+    if (filter->type() == irs::type<irs::all>::id()) {
+      all_count++;
+      all_boost += filter->boost();
+    }
+  }
   if (all_count != 0) {
     const auto non_all_count = incl.size() - all_count;
     auto it = std::remove_if(

--- a/core/search/boolean_filter.cpp
+++ b/core/search/boolean_filter.cpp
@@ -24,7 +24,6 @@
 
 #include <boost/functional/hash.hpp>
 
-#include "all_filter.hpp"
 #include "conjunction.hpp"
 #include "disjunction.hpp"
 #include "min_match_disjunction.hpp"
@@ -44,6 +43,7 @@ std::pair<const irs::filter*, bool> optimize_not(const irs::Not& node) {
 
   return std::make_pair(inner, neg);
 }
+
 
 //////////////////////////////////////////////////////////////////////////////
 /// @returns disjunction iterator created from the specified queries
@@ -356,6 +356,7 @@ class min_match_query final : public boolean_query {
 
 boolean_filter::boolean_filter(const type_info& type) noexcept
   : filter(type) {
+  all_docs_zero_.boost(0.f);
 }
 
 size_t boolean_filter::hash() const noexcept {
@@ -389,12 +390,11 @@ filter::prepared::ptr boolean_filter::prepare(
   std::vector<const filter*> excl;
 
   group_filters(incl, excl);
-  remove_excess(incl, excl, boost);
+  optimize(incl, excl, ord, boost);
 
-  all all_docs;
   if (incl.empty() && !excl.empty()) {
     // single negative query case
-    incl.push_back(&all_docs);
+    incl.push_back(&all_docs_);
   }
 
   return prepare(incl, excl, rdr, ord, boost, ctx);
@@ -405,6 +405,7 @@ void boolean_filter::group_filters(
     std::vector<const filter*>& excl) const {
   incl.reserve(size() / 2);
   excl.reserve(incl.capacity());
+  
   for (auto begin = this->begin(), end = this->end(); begin != end; ++begin) {
     if (irs::type<Not>::id() == begin->type()) {
 #ifdef IRESEARCH_DEBUG
@@ -426,6 +427,11 @@ void boolean_filter::group_filters(
         }
 
         excl.push_back(res.first);
+        if (type() == irs::type<Or>::id()) {
+          // FIXME: this should have same boost as Not filter.
+          // But for now we do not boost negation.
+          incl.push_back(&all_docs_zero_);
+        }
       } else {
         incl.push_back(res.first);
       }
@@ -445,36 +451,74 @@ And::And() noexcept
   : boolean_filter(irs::type<And>::get()) {
 }
 
-void And::remove_excess(
+void And::optimize(
     std::vector<const filter*>& incl,
     std::vector<const filter*>& /*excl*/,
+    const order::prepared& ord,
     boost_t& boost) const {
   if (incl.empty()) {
     // nothing to do
     return;
   }
 
-  // find `all` filters
-  auto it = std::remove_if(
-    incl.begin(), incl.end(),
+  // if include group has empty -> this whole conjunction is empty
+  auto incl_empty = std::find_if(incl.begin(), incl.end(),
     [](const irs::filter* filter) {
-      return irs::type<all>::id() == filter->type();
-  });
+      return irs::type<irs::empty>::id() == filter->type();
+    });
 
-  if (it == incl.begin()) {
-    // all iterators are of type `all`, preserve one
-    ++it;
+  if (incl_empty != incl.end()) {
+    // remove all except one empty
+    std::swap(*incl.begin(), *incl_empty);
+    incl.erase(incl.begin() + 1, incl.end());
+    return;
   }
 
-  // accumulate boost
-  boost = std::accumulate(
-    it, incl.end(), boost,
-    [](boost_t boost, const irs::filter* filter) {
-      return filter->boost() * boost;
-  });
 
-  // remove found `all` filters
-  incl.erase(it, incl.end());
+  boost_t all_boost{ 0 };
+  size_t all_count{ 0 };
+  std::for_each(
+    incl.begin(), incl.end(),     
+    [&all_count, &all_boost](const irs::filter* filter) {
+      if (filter->type() == irs::type<irs::all>::id()) {
+        all_count++;
+        all_boost += filter->boost();
+      }
+    });
+  if (all_count != 0) {
+    const auto non_all_count = incl.size() - all_count;
+    if (non_all_count == 0) {
+      // only all filters. erase all but first
+      if (all_count > 1) {
+        incl.erase(incl.begin() + 1, incl.end());
+        auto single = const_cast<irs::filter*>(*incl.begin()); // FIXME: remove cast and make optimize non const
+        assert(single->type() == irs::type<all>::id());
+        single->boost(all_boost);
+      }
+    }
+    else {
+      // find `all` filters
+      auto it = std::remove_if(
+        incl.begin(), incl.end(),
+        [](const irs::filter* filter) {
+          return irs::type<all>::id() == filter->type();
+        });
+
+      // remove found `all` filters
+      incl.erase(it, incl.end());
+
+      // now all left filters should get boost addition from removed filters
+      // to preserve same boost value as if filters were not removed
+      std::for_each(
+        incl.begin(), incl.end(),
+        [all_boost](const irs::filter* filter) {
+          auto nc = const_cast<irs::filter*>(filter); // FIXME: remove cast and make optimize non const
+          assert(filter->type() != irs::type<irs::all>::id());
+          nc->boost(nc->boost() + all_boost);
+        });
+      
+    }
+  }
 }
 
 filter::prepared::ptr And::prepare(
@@ -510,13 +554,55 @@ Or::Or() noexcept
     min_match_count_(1) {
 }
 
-void Or::remove_excess(
+void Or::optimize(
     std::vector<const filter*>& incl,
     std::vector<const filter*>& /*excl*/,
-    boost_t& /*boost*/) const {
+    const order::prepared& ord,
+    boost_t& boost) const {
   if (incl.empty()) {
     // nothing to do
     return;
+  }
+
+  if (ord.empty()) {
+    // if we have at least one all in include group - all other filters are not necessary
+    // in case there is no scoring
+    auto incl_all = std::find_if(incl.begin(), incl.end(), [](const irs::filter* filter) {
+        return irs::type<irs::all>::id() == filter->type();
+      });
+    if (incl_all != incl.end()) {
+      auto without_others = std::remove_if(
+        incl.begin(), incl.end(),
+        [](const irs::filter* filter) {
+          return irs::type<irs::all>::id() != filter->type();
+        });
+      assert(incl.begin() != without_others);
+      // leave only first all
+      incl.erase(incl.begin() + 1, incl.end());
+      return;
+    }
+  } else {
+    // find `all` filters
+    auto it = std::remove_if(
+      incl.begin(), incl.end(),
+      [](const irs::filter* filter) {
+        return irs::type<all>::id() == filter->type();
+      });
+
+    // accumulate boost
+    boost = std::accumulate(
+      it, incl.end(), boost,
+      [](boost_t boost, const irs::filter* filter) {
+        return filter->boost() + boost;
+      });
+
+    if (it == incl.begin()) {
+      // all iterators are of type `all`, preserve one
+      ++it;
+    }
+
+    // remove found `all` filters
+    incl.erase(it, incl.end());
   }
 
   // find `empty` filters
@@ -524,7 +610,7 @@ void Or::remove_excess(
     incl.begin(), incl.end(),
     [](const irs::filter* filter) {
       return irs::type<irs::empty>::id() == filter->type();
-  });
+    });
 
   // remove found `empty` filters
   incl.erase(it, incl.end());

--- a/core/search/boolean_filter.hpp
+++ b/core/search/boolean_filter.hpp
@@ -74,18 +74,9 @@ class IRESEARCH_API boolean_filter : public filter, private util::noncopyable {
   explicit boolean_filter(const type_info& type) noexcept;
   virtual bool equals(const filter& rhs) const noexcept override;
 
-  virtual void optimize(
-      std::vector<const filter*>& /*incl*/,
-      std::vector<const filter*>& /*excl*/,
-      const order::prepared& /*ord*/,
-      boost_t& /*boost*/,
-      filters_t& /*aux_filters*/) const{
-    // noop
-  }
-
   virtual filter::prepared::ptr prepare(
-    const std::vector<const filter*>& incl,
-    const std::vector<const filter*>& excl,
+    std::vector<const filter*>& incl,
+    std::vector<const filter*>& excl,
     const index_reader& rdr,
     const order::prepared& ord,
     boost_t boost,
@@ -117,17 +108,9 @@ class IRESEARCH_API And: public boolean_filter {
   using filter::prepare;
 
  protected:
-  virtual void optimize(
+  virtual filter::prepared::ptr prepare(
     std::vector<const filter*>& incl,
     std::vector<const filter*>& excl,
-    const order::prepared& ord,
-    boost_t& boost,
-    filters_t& aux_filters
-  ) const override;
-
-  virtual filter::prepared::ptr prepare(
-    const std::vector<const filter*>& incl,
-    const std::vector<const filter*>& excl,
     const index_reader& rdr,
     const order::prepared& ord,
     boost_t boost,
@@ -163,16 +146,9 @@ class IRESEARCH_API Or : public boolean_filter {
   }
 
  protected:
-  virtual void optimize(
+  virtual filter::prepared::ptr prepare(
     std::vector<const filter*>& incl,
     std::vector<const filter*>& excl,
-    const order::prepared& ord,
-    boost_t& boost,
-    filters_t& aux_filters) const override;
-
-  virtual filter::prepared::ptr prepare(
-    const std::vector<const filter*>& incl,
-    const std::vector<const filter*>& excl,
     const index_reader& rdr,
     const order::prepared& ord,
     boost_t boost,
@@ -180,7 +156,6 @@ class IRESEARCH_API Or : public boolean_filter {
 
  private:
   size_t min_match_count_;
-  mutable size_t optimized_match_count_{0}; // count of always matched filters optimized away
 }; // Or
 
 //////////////////////////////////////////////////////////////////////////////

--- a/core/search/boolean_filter.hpp
+++ b/core/search/boolean_filter.hpp
@@ -181,6 +181,7 @@ class IRESEARCH_API Or : public boolean_filter {
 
  private:
   size_t min_match_count_;
+  mutable size_t optimized_match_count_{0}; // count of always matched filters optimized away
 }; // Or
 
 //////////////////////////////////////////////////////////////////////////////

--- a/core/search/boolean_filter.hpp
+++ b/core/search/boolean_filter.hpp
@@ -99,7 +99,7 @@ class IRESEARCH_API boolean_filter : public filter, private util::noncopyable {
   IRESEARCH_API_PRIVATE_VARIABLES_BEGIN
   filters_t filters_;
   all all_docs_;
-  all all_docs_zero_;
+  all all_docs_zero_boost_;
   IRESEARCH_API_PRIVATE_VARIABLES_END
 };
 

--- a/core/search/boolean_filter.hpp
+++ b/core/search/boolean_filter.hpp
@@ -94,8 +94,7 @@ class IRESEARCH_API boolean_filter : public filter, private util::noncopyable {
  private:
   void group_filters(
     std::vector<const filter*>& incl,
-    std::vector<const filter*>& excl,
-    filters_t& aux_filters) const;
+    std::vector<const filter*>& excl) const;
 
   IRESEARCH_API_PRIVATE_VARIABLES_BEGIN
   filters_t filters_;

--- a/core/search/boolean_filter.hpp
+++ b/core/search/boolean_filter.hpp
@@ -98,8 +98,6 @@ class IRESEARCH_API boolean_filter : public filter, private util::noncopyable {
 
   IRESEARCH_API_PRIVATE_VARIABLES_BEGIN
   filters_t filters_;
-  all all_docs_;
-  all all_docs_zero_boost_;
   IRESEARCH_API_PRIVATE_VARIABLES_END
 };
 

--- a/core/search/boolean_filter.hpp
+++ b/core/search/boolean_filter.hpp
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "filter.hpp"
+#include "all_filter.hpp"
 #include "utils/iterator.hpp"
 
 NS_ROOT
@@ -73,9 +74,10 @@ class IRESEARCH_API boolean_filter : public filter, private util::noncopyable {
   explicit boolean_filter(const type_info& type) noexcept;
   virtual bool equals(const filter& rhs) const noexcept override;
 
-  virtual void remove_excess(
+  virtual void optimize(
       std::vector<const filter*>& /*incl*/,
       std::vector<const filter*>& /*excl*/,
+      const order::prepared& /*ord*/,
       boost_t& /*boost*/) const {
     // noop
   }
@@ -96,6 +98,8 @@ class IRESEARCH_API boolean_filter : public filter, private util::noncopyable {
 
   IRESEARCH_API_PRIVATE_VARIABLES_BEGIN
   filters_t filters_;
+  all all_docs_;
+  all all_docs_zero_;
   IRESEARCH_API_PRIVATE_VARIABLES_END
 };
 
@@ -115,9 +119,10 @@ class IRESEARCH_API And: public boolean_filter {
   using filter::prepare;
 
  protected:
-  virtual void remove_excess(
+  virtual void optimize(
     std::vector<const filter*>& incl,
     std::vector<const filter*>& excl,
+    const order::prepared& ord,
     boost_t& boost
   ) const override;
 
@@ -159,9 +164,10 @@ class IRESEARCH_API Or : public boolean_filter {
   }
 
  protected:
-  virtual void remove_excess(
+  virtual void optimize(
     std::vector<const filter*>& incl,
     std::vector<const filter*>& excl,
+    const order::prepared& ord,
     boost_t& boost) const override;
 
   virtual filter::prepared::ptr prepare(

--- a/core/search/boolean_filter.hpp
+++ b/core/search/boolean_filter.hpp
@@ -78,7 +78,8 @@ class IRESEARCH_API boolean_filter : public filter, private util::noncopyable {
       std::vector<const filter*>& /*incl*/,
       std::vector<const filter*>& /*excl*/,
       const order::prepared& /*ord*/,
-      boost_t& /*boost*/) const {
+      boost_t& /*boost*/,
+      filters_t& /*aux_filters*/) const{
     // noop
   }
 
@@ -93,8 +94,8 @@ class IRESEARCH_API boolean_filter : public filter, private util::noncopyable {
  private:
   void group_filters(
     std::vector<const filter*>& incl,
-    std::vector<const filter*>& excl
-  ) const;
+    std::vector<const filter*>& excl,
+    filters_t& aux_filters) const;
 
   IRESEARCH_API_PRIVATE_VARIABLES_BEGIN
   filters_t filters_;
@@ -121,7 +122,8 @@ class IRESEARCH_API And: public boolean_filter {
     std::vector<const filter*>& incl,
     std::vector<const filter*>& excl,
     const order::prepared& ord,
-    boost_t& boost
+    boost_t& boost,
+    filters_t& aux_filters
   ) const override;
 
   virtual filter::prepared::ptr prepare(
@@ -166,7 +168,8 @@ class IRESEARCH_API Or : public boolean_filter {
     std::vector<const filter*>& incl,
     std::vector<const filter*>& excl,
     const order::prepared& ord,
-    boost_t& boost) const override;
+    boost_t& boost,
+    filters_t& aux_filters) const override;
 
   virtual filter::prepared::ptr prepare(
     const std::vector<const filter*>& incl,

--- a/tests/search/boolean_filter_tests.cpp
+++ b/tests/search/boolean_filter_tests.cpp
@@ -7820,7 +7820,10 @@ TEST_P(boolean_filter_test_case, not_sequential) {
       irs::Or root;
       root.add<irs::by_term>() = make_filter<irs::by_term>("duplicated", "abcd");
       root.add<irs::Not>().filter<irs::by_term>() = make_filter<irs::by_term>("name", "A");
-      check_query(root, docs_t{ 5, 11, 21, 27, 31 }, rdr);
+      check_query(root, docs_t{ 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 
+                                13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+                                24, 25, 26, 27, 28, 29, 30, 31, 32 },
+                  rdr);
     }
   }
 
@@ -7839,7 +7842,10 @@ TEST_P(boolean_filter_test_case, not_sequential) {
       root.add<irs::by_term>() = make_filter<irs::by_term>("duplicated", "abcd");
       root.add<irs::Not>().filter<irs::by_term>() = make_filter<irs::by_term>("name", "A");
       root.add<irs::Not>().filter<irs::by_term>() = make_filter<irs::by_term>("name", "A");
-      check_query(root, docs_t{ 5, 11, 21, 27, 31 }, rdr);
+      check_query(root, docs_t{ 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+                                13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+                                24, 25, 26, 27, 28, 29, 30, 31, 32 },
+                  rdr);
     }
   }
 
@@ -7857,8 +7863,11 @@ TEST_P(boolean_filter_test_case, not_sequential) {
       irs::Or root;
       root.add<irs::by_term>() = make_filter<irs::by_term>("duplicated", "abcd");
       root.add<irs::Not>().filter<irs::by_term>() = make_filter<irs::by_term>("name", "A");
-      root.add<irs::Not>().filter<irs::by_term>() = make_filter<irs::by_term>("name", "E");
-      check_query(root, docs_t{ 11, 21, 27, 31 }, rdr);
+      root.add<irs::Not>().filter<irs::by_term>() = make_filter<irs::by_term>("prefix", "abcd");
+      check_query(root, docs_t{ 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+                                13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+                                24, 25, 26, 27, 28, 29, 30, 31, 32 },
+                  rdr);
     }
   }
 }

--- a/tests/search/boolean_filter_tests.cpp
+++ b/tests/search/boolean_filter_tests.cpp
@@ -8350,8 +8350,8 @@ TEST(And_test, not_boosted) {
   auto pord = ord.prepare();
   irs::And root;
   {
-    auto& not = root.add<irs::Not>();
-    auto& node = not.filter<detail::boosted>();
+    auto& neg = root.add<irs::Not>();
+    auto& node = neg.filter<detail::boosted>();
     node.docs = { 5 , 6 };
     node.boost(4);
   }
@@ -8690,8 +8690,8 @@ TEST(Or_test, not_boosted) {
   auto pord = ord.prepare();
   irs::Or root;
   {
-    auto & not = root.add<irs::Not>();
-    auto& node = not.filter<detail::boosted>();
+    auto& neg = root.add<irs::Not>();
+    auto& node = neg.filter<detail::boosted>();
     node.docs = { 5 , 6 };
     node.boost(4);
   }

--- a/tests/search/boolean_filter_tests.cpp
+++ b/tests/search/boolean_filter_tests.cpp
@@ -8689,7 +8689,7 @@ TEST(Or_test, optimize_only_all_boosted) {
   ASSERT_EQ(1, detail::test_all::execute_count); // only one all should be executed
 }
 
-TEST(Or_test, not_boosted) {
+TEST(Or_test, boosted_not) {
   irs::order ord;
   ord.add<tests::sort::boost>(false);
   auto pord = ord.prepare();

--- a/tests/search/boolean_filter_tests.cpp
+++ b/tests/search/boolean_filter_tests.cpp
@@ -1557,9 +1557,14 @@ TEST( boolean_query_estimation, or ) {
     root.add<irs::Not>().filter<detail::estimated>().est = 0;
     root.add<detail::unestimated>();
 
+    // we need order to suppress optimization
+    // which will clean include group and leave only 'all' filter
+    irs::order ord;
+    ord.add<tests::sort::boost>(false);
+    auto pord = ord.prepare();
     auto prep = root.prepare(
       irs::sub_reader::empty(),
-      irs::order::prepared::unordered()
+      pord
     );
 
     auto docs = prep->execute(irs::sub_reader::empty());

--- a/utils/index-dump.cpp
+++ b/utils/index-dump.cpp
@@ -88,7 +88,7 @@ int dump(
              << std::endl;
 
       auto term = field.iterator();
-      auto& term_meta = term->attributes().get<irs::term_meta>();
+      auto const& term_meta = irs::get<irs::term_meta>(*term);
       stream << "Values" << std::endl;
       for (; term->next(); ) {
         term->read();


### PR DESCRIPTION
Added optimization for collapsing several 'all' filters to one in And/Or queries
Changed behavior of Not subquery inside Or. Now query under 'Not' filter not only added to exclude group but implicitly 'All' filter(with zero boost) is added to include group - this fixes issue #11104

Also fixes issue #102 