### PR TITLE
Bug fix/internal issue #701

### DIFF
--- a/core/index/index_writer.cpp
+++ b/core/index/index_writer.cpp
@@ -1473,9 +1473,7 @@ bool index_writer::consolidate(
     }
 
     // register for consolidation
-    for (const auto& c : candidates) {
-      consolidating_segments_.emplace(c);
-    }
+    consolidating_segments_.insert(candidates.begin(), candidates.end());
   }
 
   // unregisterer for all registered candidates

--- a/core/index/index_writer.cpp
+++ b/core/index/index_writer.cpp
@@ -1553,7 +1553,7 @@ bool index_writer::consolidate(
             // not all candidates are valid
             IR_FRMT_DEBUG(
               "Failed to start consolidation for index generation '" IR_UINT64_T_SPECIFIER
-              "', Not found segment %s in committed state",
+              "', not found segment %s in committed state",
               committed_meta->generation(),
               candidate->name.c_str()
             );

--- a/core/index/index_writer.cpp
+++ b/core/index/index_writer.cpp
@@ -1466,7 +1466,7 @@ bool index_writer::consolidate(
   }
 
   // unregisterer for all registered candidates
-  auto unregister_segments = irs::make_finally([&candidates, this]() noexcept {
+  auto unregister_segments = irs::make_finally([&candidates, this]() {
     if (candidates.empty()) {
       return;
     }

--- a/core/index/index_writer.cpp
+++ b/core/index/index_writer.cpp
@@ -1560,7 +1560,7 @@ bool index_writer::consolidate(
       {
         SCOPED_LOCK(consolidation_lock_);
         for (const auto& c : candidates) {
-          consolidating_segments_on_commit_.emplace(c->name, current_committed_meta);
+          consolidating_segments_on_commit_.emplace(c->name, pending_state_.commit);
         }
       }
       // register consolidation for the next transaction

--- a/core/index/index_writer.hpp
+++ b/core/index/index_writer.hpp
@@ -1043,8 +1043,6 @@ class IRESEARCH_API index_writer
   committed_state_t committed_state_; // last successfully committed state
   std::recursive_mutex consolidation_lock_;
   consolidating_segments_t consolidating_segments_; // segments that are under consolidation
-  /// Intermediate storage for consolidating segments.
-  std::unordered_map<std::string, std::weak_ptr<index_meta>> consolidating_segments_on_commit_;
   directory& dir_; // directory used for initialization of readers
   std::vector<flush_context> flush_context_pool_; // collection of contexts that collect data to be flushed, 2 because just swap them
   std::atomic<flush_context*> flush_context_; // currently active context accumulating data to be processed during the next flush

--- a/core/index/index_writer.hpp
+++ b/core/index/index_writer.hpp
@@ -1044,14 +1044,7 @@ class IRESEARCH_API index_writer
   std::recursive_mutex consolidation_lock_;
   consolidating_segments_t consolidating_segments_; // segments that are under consolidation
   /// Intermediate storage for consolidating segments.
-  /// Could be set/reset without lock but any modification to
-  /// segments must be done under the consolidation_lock_.
-  /// Intended to store segments for postponed consolidation
-  /// being committed to close gap between actual finalizing consolidation
-  /// and finishing commit (storing new committed state).
-  /// shared_ptr here is to make commit finish noexcept - only release operation.
-  /// @note Only one running commit is expected!
-  std::shared_ptr<consolidating_segments_t> committing_consolidating_segments_;
+  std::unordered_map<std::string, std::weak_ptr<index_meta>> consolidating_segments_on_commit_;
   directory& dir_; // directory used for initialization of readers
   std::vector<flush_context> flush_context_pool_; // collection of contexts that collect data to be flushed, 2 because just swap them
   std::atomic<flush_context*> flush_context_; // currently active context accumulating data to be processed during the next flush

--- a/core/index/index_writer.hpp
+++ b/core/index/index_writer.hpp
@@ -1043,6 +1043,15 @@ class IRESEARCH_API index_writer
   committed_state_t committed_state_; // last successfully committed state
   std::recursive_mutex consolidation_lock_;
   consolidating_segments_t consolidating_segments_; // segments that are under consolidation
+  /// Intermediate storage for consolidating segments.
+  /// Could be set/reset without lock but any modification to
+  /// segments must be done under the consolidation_lock_.
+  /// Intended to store segments for postponed consolidation
+  /// being committed to close gap between actual finalizing consolidation
+  /// and finishing commit (storing new committed state).
+  /// shared_ptr here is to make commit finish noexcept - only release operation.
+  /// @note Only one running commit is expected!
+  std::shared_ptr<consolidating_segments_t> committing_consolidating_segments_;
   directory& dir_; // directory used for initialization of readers
   std::vector<flush_context> flush_context_pool_; // collection of contexts that collect data to be flushed, 2 because just swap them
   std::atomic<flush_context*> flush_context_; // currently active context accumulating data to be processed during the next flush

--- a/core/index/index_writer.hpp
+++ b/core/index/index_writer.hpp
@@ -142,7 +142,7 @@ class IRESEARCH_API index_writer
         flush_context* flush_ctx = nullptr, // the flush_context the segment_context is currently registered with
         size_t pending_segment_context_offset = integer_traits<size_t>::const_max // the segment offset in flush_ctx_->pending_segments_
     ) noexcept;
-    active_segment_context(active_segment_context&& other) noexcept;
+    active_segment_context(active_segment_context&& other)  = default;
     ~active_segment_context();
     active_segment_context& operator=(active_segment_context&& other) noexcept;
 
@@ -394,8 +394,7 @@ class IRESEARCH_API index_writer
       : filter(match_filter), generation(gen), update(isUpdate), seen(false) {}
     modification_context(irs::filter::ptr&& match_filter, size_t gen, bool isUpdate)
       : filter(std::move(match_filter)), generation(gen), update(isUpdate), seen(false) {}
-    modification_context(modification_context&& other) noexcept
-      : filter(std::move(other.filter)), generation(other.generation), update(other.update), seen(other.seen) {}
+    modification_context(modification_context&& other) = default;
     modification_context& operator=(const modification_context& other) = delete; // no default constructor
   };
 
@@ -648,11 +647,7 @@ class IRESEARCH_API index_writer
   struct consolidation_context_t : util::noncopyable {
     consolidation_context_t() = default;
 
-    consolidation_context_t(consolidation_context_t&& rhs) noexcept
-      : consolidaton_meta(std::move(rhs.consolidaton_meta)),
-        candidates(std::move(rhs.candidates)),
-        merger(std::move(rhs.merger)) {
-    }
+    consolidation_context_t(consolidation_context_t&& rhs) = default; 
 
     consolidation_context_t(
         std::shared_ptr<index_meta>&& consolidaton_meta,
@@ -733,12 +728,7 @@ class IRESEARCH_API index_writer
         segment(std::move(segment)) {
     }
 
-    import_context(import_context&& other) noexcept
-      : generation(other.generation),
-        segment(std::move(other.segment)),
-        refs(std::move(other.refs)),
-        consolidation_ctx(std::move(other.consolidation_ctx)) {
-    }
+    import_context(import_context&& other) = default;
 
     import_context& operator=(const import_context&) = delete;
 
@@ -992,11 +982,7 @@ class IRESEARCH_API index_writer
     sync_context to_sync; // file names and segments to be synced during next commit
 
     pending_context_t() = default;
-    pending_context_t(pending_context_t&& other) noexcept
-      : ctx(std::move(other.ctx)),
-        meta(std::move(other.meta)),
-        to_sync(std::move(other.to_sync)) {
-    }
+    pending_context_t(pending_context_t&& other) = default;
     operator bool() const noexcept { return ctx && meta; }
   }; // pending_context_t
 

--- a/core/iql/parser_context.cpp
+++ b/core/iql/parser_context.cpp
@@ -111,7 +111,7 @@ parser::semantic_type parser_context::sequence(
   parser::location_type const& location
 ) {
   if (location.end.column < location.begin.column ||
-      m_sData.size() < location.end.column) {
+      m_sData.size() < static_cast<size_t>(location.end.column)) {
     return *const_cast<parser::semantic_type*>(&UNKNOWN); // index out of bounds
   }
 

--- a/core/utils/noncopyable.hpp
+++ b/core/utils/noncopyable.hpp
@@ -35,6 +35,7 @@ struct noncopyable {
   noncopyable(const noncopyable&) = delete;
   noncopyable& operator= (const noncopyable&) = delete;
   noncopyable(noncopyable&&) = default;
+  noncopyable& operator= (noncopyable&&) = default;
 };
 
 NS_END

--- a/core/utils/noncopyable.hpp
+++ b/core/utils/noncopyable.hpp
@@ -34,6 +34,7 @@ struct noncopyable {
 
   noncopyable(const noncopyable&) = delete;
   noncopyable& operator= (const noncopyable&) = delete;
+  noncopyable(noncopyable&&) = default;
 };
 
 NS_END

--- a/core/utils/object_pool.hpp
+++ b/core/utils/object_pool.hpp
@@ -49,17 +49,17 @@ class atomic_shared_ptr_helper {
     atomic_shared_ptr_helper(atomic_shared_ptr_helper&&) noexcept { }
     atomic_shared_ptr_helper& operator=(atomic_shared_ptr_helper&&) noexcept { return *this; }
 
-    std::shared_ptr<T> atomic_exchange(std::shared_ptr<T>* p, std::shared_ptr<T> r) const noexcept {
+    std::shared_ptr<T> atomic_exchange(std::shared_ptr<T>* p, std::shared_ptr<T> r) const {
       SCOPED_LOCK(mutex_);
       return std::atomic_exchange(p, r);
     }
 
-    void atomic_store(std::shared_ptr<T>* p, std::shared_ptr<T> r) const noexcept {
+    void atomic_store(std::shared_ptr<T>* p, std::shared_ptr<T> r) const {
       SCOPED_LOCK(mutex_);
       std::atomic_store(p, r);
     }
 
-    std::shared_ptr<T> atomic_load(const std::shared_ptr<T>* p) const noexcept {
+    std::shared_ptr<T> atomic_load(const std::shared_ptr<T>* p) const {
       SCOPED_LOCK(mutex_);
       return std::atomic_load(p);
     }
@@ -68,15 +68,15 @@ class atomic_shared_ptr_helper {
     mutable std::mutex mutex_;
   #else
    public:
-    static std::shared_ptr<T> atomic_exchange(std::shared_ptr<T>* p, std::shared_ptr<T> r) noexcept {
+    static std::shared_ptr<T> atomic_exchange(std::shared_ptr<T>* p, std::shared_ptr<T> r) {
       return std::atomic_exchange(p, r);
     }
 
-    static void atomic_store(std::shared_ptr<T>* p, std::shared_ptr<T> r) noexcept {
+    static void atomic_store(std::shared_ptr<T>* p, std::shared_ptr<T> r) {
       std::atomic_store(p, r);
     }
 
-    static std::shared_ptr<T> atomic_load(const std::shared_ptr<T>* p) noexcept {
+    static std::shared_ptr<T> atomic_load(const std::shared_ptr<T>* p) {
       return std::atomic_load(p);
     }
   #endif // defined(IRESEARCH_VALGRIND)

--- a/tests/index/index_tests.cpp
+++ b/tests/index/index_tests.cpp
@@ -8377,7 +8377,7 @@ TEST_P(index_test_case, consolidate_check_consolidating_segments) {
     };
 
     ASSERT_TRUE(writer->consolidate(merge_adjacent));
-  };
+  }
 
   // check all segments registered
   {
@@ -9194,8 +9194,8 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
       sub_policy(candidates, meta, consolidating_segments);
       writer->commit();
     };
-    
-    ASSERT_TRUE(writer->consolidate(do_commit_and_consolidate_count)); 
+
+    ASSERT_TRUE(writer->consolidate(do_commit_and_consolidate_count));
 
     // check consolidating segments
     expected_consolidating_segments = { 0, 1 };
@@ -9203,11 +9203,11 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
 
     // can't consolidate segments that are already marked for consolidation
     ASSERT_FALSE(writer->consolidate(irs::index_utils::consolidation_policy(irs::index_utils::consolidate_count())));
-    
+
     writer->documents().remove(*query_doc4.filter);
- 
+
     writer->commit(); // commit pending merge + delete
-    ASSERT_EQ(count+8, irs::directory_cleaner::clean(dir())); 
+    ASSERT_EQ(count+8, irs::directory_cleaner::clean(dir()));
 
     // check consolidating segments
     expected_consolidating_segments = { };
@@ -9271,7 +9271,7 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
       }
     }
 
-    // check for dangling old segment versions in writers cache 
+    // check for dangling old segment versions in writers cache
     // first create new segment
     // segment 5
     ASSERT_TRUE(insert(*writer,
@@ -9295,7 +9295,82 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
     writer->commit();
 
     // check all old segments are deleted (no old version of segments is left in cache and blocking )
-    ASSERT_EQ(23, irs::directory_cleaner::clean(dir())); 
+    ASSERT_EQ(23, irs::directory_cleaner::clean(dir()));
+  }
+
+  // repeatable consolidation of already consolidated segment
+  {
+    SetUp();
+    auto query_doc1 = iresearch::iql::query_builder().build("name==A", std::locale::classic());
+    auto query_doc4 = iresearch::iql::query_builder().build("name==D", std::locale::classic());
+    auto writer = open_writer();
+    ASSERT_NE(nullptr, writer);
+
+    // segment 1
+    ASSERT_TRUE(insert(*writer,
+      doc1->indexed.begin(), doc1->indexed.end(),
+      doc1->stored.begin(), doc1->stored.end()));
+    ASSERT_TRUE(insert(*writer,
+      doc2->indexed.begin(), doc2->indexed.end(),
+      doc2->stored.begin(), doc2->stored.end()));
+    writer->commit();
+    ASSERT_EQ(0, irs::directory_cleaner::clean(dir()));
+
+    // count number of files in segments
+    count = 0;
+    ASSERT_TRUE(dir().visit(get_number_of_files_in_segments));
+
+    // segment 2
+    ASSERT_TRUE(insert(*writer,
+      doc3->indexed.begin(), doc3->indexed.end(),
+      doc3->stored.begin(), doc3->stored.end()));
+    ASSERT_TRUE(insert(*writer,
+      doc4->indexed.begin(), doc4->indexed.end(),
+      doc4->stored.begin(), doc4->stored.end()));
+    writer->commit();
+    ASSERT_EQ(1, irs::directory_cleaner::clean(dir())); // segments_1
+
+    // check consolidating segments
+    expected_consolidating_segments = { };
+    ASSERT_TRUE(writer->consolidate(check_consolidating_segments));
+
+    ASSERT_EQ(0, irs::directory_cleaner::clean(dir()));
+
+    writer->documents().remove(*query_doc1.filter);
+    ASSERT_TRUE(writer->begin()); // begin transaction
+    ASSERT_EQ(0, irs::directory_cleaner::clean(dir()));
+
+    // this consolidation will be postponed
+    ASSERT_TRUE(writer->consolidate(irs::index_utils::consolidation_policy(irs::index_utils::consolidate_count())));
+    // check consolidating segments are pending
+    expected_consolidating_segments = { 0, 1 };
+    ASSERT_TRUE(writer->consolidate(check_consolidating_segments));
+
+    // can't consolidate segments that are already marked for consolidation
+    ASSERT_FALSE(writer->consolidate(irs::index_utils::consolidation_policy(irs::index_utils::consolidate_count())));
+
+    auto do_commit_and_consolidate_count = [&writer](
+      std::set<const irs::segment_meta*>& candidates,
+      const irs::index_meta& meta,
+      const irs::index_writer::consolidating_segments_t& consolidating_segments
+      ) {
+        writer->commit();
+        writer->begin(); // another commit to process pending consolidating_segments
+        writer->commit();
+        auto sub_policy = irs::index_utils::consolidation_policy(irs::index_utils::consolidate_count());
+        sub_policy(candidates, meta, consolidating_segments);
+    };
+
+    // this should fail as segments 1 and 0 are actually consolidated on previous  commit
+    // inside our test policy
+    ASSERT_FALSE(writer->consolidate(do_commit_and_consolidate_count));
+    ASSERT_NE(0, irs::directory_cleaner::clean(dir()));
+    // check all data is deleted
+    const auto one_segment_count = count;
+    count = 0;
+    ASSERT_TRUE(dir().visit(get_number_of_files_in_segments));
+    // files count should be the same as with one segment (only +1 for doc_mask)
+    ASSERT_EQ(one_segment_count, count - 1); // -1 for doc-mask from removal
   }
 
   // consolidate with deletes + inserts
@@ -11795,7 +11870,7 @@ TEST_P(index_test_case, segment_consolidate) {
       const irs::index_meta& meta,
       const irs::index_writer::consolidating_segments_t&
   )->void {
-    for (auto& segment: meta) {
+    for (auto& segment : meta) {
       if (segment.meta.live_docs_count != segment.meta.docs_count) {
         candidates.insert(&segment.meta);
       }
@@ -12276,7 +12351,7 @@ TEST_P(index_test_case, segment_consolidate) {
     ASSERT_TRUE(writer->consolidate(always_merge));
     writer->commit();
 
-    // validate merged segment 
+    // validate merged segment
     auto reader = iresearch::directory_reader::open(dir(), codec());
     ASSERT_EQ(1, reader.size());
     auto& segment = reader[0]; // assume 0 is id of first/only segment
@@ -12367,7 +12442,7 @@ TEST_P(index_test_case, segment_consolidate) {
     ASSERT_TRUE(writer->consolidate(always_merge));
     writer->commit();
 
-    // validate merged segment 
+    // validate merged segment
     auto reader = iresearch::directory_reader::open(dir(), codec());
     ASSERT_EQ(1, reader.size());
     auto& segment = reader[0]; // assume 0 is id of first/only segment
@@ -13019,7 +13094,7 @@ TEST_P(index_test_case, segment_options) {
     auto result = cond.wait_for(lock, std::chrono::milliseconds(1000)); // assume thread blocks in 1000ms
 
     // As declaration for wait_for contains "It may also be unblocked spuriously." for all platforms
-    while(!stop && result == std::cv_status::no_timeout) result = cond.wait_for(lock, std::chrono::milliseconds(1000));
+    while (!stop && result == std::cv_status::no_timeout) result = cond.wait_for(lock, std::chrono::milliseconds(1000));
 
     ASSERT_EQ(std::cv_status::timeout, result);
     // ^^^ expecting timeout because pool should block indefinitely
@@ -13197,7 +13272,7 @@ TEST_P(index_test_case, segment_options) {
 
 TEST_P(index_test_case, writer_close) {
   tests::json_doc_generator gen(
-    resource("simple_sequential.json"), 
+    resource("simple_sequential.json"),
     &tests::generic_json_field_factory
   );
   auto& directory = dir();
@@ -13221,7 +13296,7 @@ TEST_P(index_test_case, writer_close) {
   ASSERT_TRUE(directory.visit(list_files));
 
   // file removal should pass for all files (especially valid for Microsoft Windows)
-  for (auto& file: files) {
+  for (auto& file : files) {
     ASSERT_TRUE(directory.remove(file));
   }
 


### PR DESCRIPTION
Fixes dangling segment readers in index_writer readers cache.
This could happen if consolidation will be postponed due to open transaction. Than if next consolidation will start right after commit will be started - following sequence of events could happen: 

1.  Current committed state will be seen as OLD(before commit) by consolidation
2.  Commit thread will cleanup consolidating_segments_ before consolidating thread will get consolidation_lock_
3. Consolidation thread will execute policy and already consolidated segments will be chosen.
4. Commit thread will remove already consolidated segments from cache and from current committed state
5. Consolidation thread will re-add segments reader back to cache as they are not in cache and not in consolidating_segments_ and present in OLD state
6. Consolidation thread eventually will lock and read NEW committed state and see segments as absent.
7. Consolidation will be aborted -> segments readers will be left dangling in readers cache  

To fix issue forced cleanup of cached readers and additional check of segments validity (after getting locked committed state) added

Also PR contains compilation warning fix (thanks to @jsteemann )