### PR TITLE
Add payload to segment created after index_writer::clear

### DIFF
--- a/core/index/index_writer.hpp
+++ b/core/index/index_writer.hpp
@@ -432,6 +432,12 @@ class IRESEARCH_API index_writer
     size_t segment_memory_max{0};
   };
 
+  ////////////////////////////////////////////////////////////////////////////
+  /// @brief functor for creating payload. Operation tick is provided for 
+  /// payload generation.
+  ////////////////////////////////////////////////////////////////////////////
+  using payload_provider_t = std::function<bool(uint64_t, bstring&)>;
+
   //////////////////////////////////////////////////////////////////////////////
   /// @brief options the the writer should use after creation
   //////////////////////////////////////////////////////////////////////////////
@@ -440,6 +446,11 @@ class IRESEARCH_API index_writer
     /// @brief returns column info the writer should use for columnstore
     ////////////////////////////////////////////////////////////////////////////
     column_info_provider_t column_info;
+
+    ////////////////////////////////////////////////////////////////////////////
+    /// @brief Provides payload for index_meta created by writer
+    ////////////////////////////////////////////////////////////////////////////
+    payload_provider_t meta_payload_provider;
 
     ////////////////////////////////////////////////////////////////////////////
     /// @brief comparator defines physical order of documents in each segment
@@ -526,9 +537,10 @@ class IRESEARCH_API index_writer
   ////////////////////////////////////////////////////////////////////////////
   /// @brief Clears the existing index repository by staring an empty index.
   ///        Previously opened readers still remain valid.
+  /// @param truncate transaction tick
   /// @note call will rollback any opened transaction
   ////////////////////////////////////////////////////////////////////////////
-  void clear();
+  void clear(uint64_t tick = 0);
 
   ////////////////////////////////////////////////////////////////////////////
   /// @brief merges segments accepted by the specified defragment policty into
@@ -604,17 +616,15 @@ class IRESEARCH_API index_writer
     return comparator_;
   }
 
-  typedef std::function<bool(uint64_t, bstring&)> before_commit_f;
-
   ////////////////////////////////////////////////////////////////////////////
   /// @brief begins the two-phase transaction
   /// @param payload arbitrary user supplied data to store in the index
   /// @returns true if transaction has been sucessflully started
   ////////////////////////////////////////////////////////////////////////////
-  bool begin(const before_commit_f& before_commit = {}) {
+  bool begin() {
     SCOPED_LOCK(commit_lock_);
 
-    return start(before_commit);
+    return start();
   }
 
   ////////////////////////////////////////////////////////////////////////////
@@ -633,10 +643,10 @@ class IRESEARCH_API index_writer
   /// @note that if begin() has been already called commit() is
   /// relatively lightweight operation 
   ////////////////////////////////////////////////////////////////////////////
-  void commit(const before_commit_f& before_commit = {}) {
+  void commit() {
     SCOPED_LOCK(commit_lock_);
 
-    start(before_commit);
+    start();
     finish();
   }
 
@@ -1021,21 +1031,23 @@ class IRESEARCH_API index_writer
     const segment_options& segment_limits,
     const comparer* comparator,
     const column_info_provider_t& column_info,
+    const payload_provider_t& meta_payload_provider,
     index_meta&& meta,
     committed_state_t&& committed_state
   );
 
-  pending_context_t flush_all(const before_commit_f& before_commit);
+  pending_context_t flush_all();
 
   flush_context_ptr get_flush_context(bool shared = true);
   active_segment_context get_segment_context(flush_context& ctx); // return a usable segment or a nullptr segment if retry is required (e.g. no free segments available)
 
-  bool start(const before_commit_f& before_commit); // starts transaction
+  bool start(); // starts transaction
   void finish(); // finishes transaction
   void abort(); // aborts transaction
 
   IRESEARCH_API_PRIVATE_VARIABLES_BEGIN
   column_info_provider_t column_info_;
+  payload_provider_t meta_payload_provider_; // provides payload for new segments
   const comparer* comparator_;
   readers_cache cached_readers_; // readers by segment name
   format::ptr codec_;


### PR DESCRIPTION
Moves segment meta payload functor to index_writer params.
Adds payload for segment created after index is cleared

Fix is verified by gtest

http://jenkins.arangodb.biz:8080/view/PR/job/iresearch_s-pr/136/