### PR TITLE
fixes a compile warning when using `-Wsuggest-override`

### DIFF
--- a/core/search/term_filter.hpp
+++ b/core/search/term_filter.hpp
@@ -76,7 +76,7 @@ class IRESEARCH_API by_term : public filter_base<by_term_options> {
       const index_reader& rdr,
       const order::prepared& ord,
       boost_t boost,
-      const attribute_provider* /*ctx*/) const {
+      const attribute_provider* /*ctx*/) const override {
     return prepare(rdr, ord, boost*this->boost(),
                    field(), options().term);
   }


### PR DESCRIPTION
When compiling with g++, there is an option to suggest missing `override` specifications, `-Wsuggest-override`.

Using this option, compilation produces the following warning:
``` 
In file included from /home/jsteemann/ArangoNoAsan/3rdParty/iresearch/core/search/phrase_filter.hpp:32,
                 from /home/jsteemann/ArangoNoAsan/arangod/IResearch/IResearchFilterFactory.cpp:46:
/home/jsteemann/ArangoNoAsan/3rdParty/iresearch/core/search/term_filter.hpp:79:25: warning: ‘virtual iresearch::filter::prepared::ptr iresearch::by_term::prepare(const iresearch::index_reader&, const iresearch::order::prepared&, iresearch::boost_t, const iresearch::attribute_provider*) const’ can be marked override [-Wsuggest-override]
   79 |   virtual prepared::ptr prepare(
```
This PR tries to fix this warning.