### PR TITLE
feature/external-buffers-for-buffered-streams

### DIFF
--- a/core/formats/formats_10.cpp
+++ b/core/formats/formats_10.cpp
@@ -2671,9 +2671,8 @@ bool meta_reader::prepare(
       assert(in_cipher_ && in_cipher_->block_size());
 
       const auto blocks_in_buffer = math::div_ceil64(
-        buffered_index_input::DEFAULT_BUFFER_SIZE,
-        in_cipher_->block_size()
-      );
+        encrypted_input::BUFFER_SIZE,
+        in_cipher_->block_size());
 
       in_ = memory::make_unique<encrypted_input>(
         std::move(in_),

--- a/core/formats/formats_10.cpp
+++ b/core/formats/formats_10.cpp
@@ -2550,7 +2550,7 @@ void meta_writer::prepare(directory& dir, const segment_meta& meta) {
       assert(out_cipher_ && out_cipher_->block_size());
 
       const auto blocks_in_buffer = math::div_ceil64(
-        encrypted_output::BUFFER_SIZE,
+        DEFAULT_ENCRYPTION_BUFFER_SIZE,
         out_cipher_->block_size());
 
       out_ = index_output::make<encrypted_output>(
@@ -2671,7 +2671,7 @@ bool meta_reader::prepare(
       assert(in_cipher_ && in_cipher_->block_size());
 
       const auto blocks_in_buffer = math::div_ceil64(
-        encrypted_input::BUFFER_SIZE,
+        DEFAULT_ENCRYPTION_BUFFER_SIZE,
         in_cipher_->block_size());
 
       in_ = memory::make_unique<encrypted_input>(

--- a/core/formats/formats_10.cpp
+++ b/core/formats/formats_10.cpp
@@ -2550,9 +2550,8 @@ void meta_writer::prepare(directory& dir, const segment_meta& meta) {
       assert(out_cipher_ && out_cipher_->block_size());
 
       const auto blocks_in_buffer = math::div_ceil64(
-        buffered_index_output::DEFAULT_BUFFER_SIZE,
-        out_cipher_->block_size()
-      );
+        encrypted_output::BUFFER_SIZE,
+        out_cipher_->block_size());
 
       out_ = index_output::make<encrypted_output>(
         std::move(out_),

--- a/core/formats/formats_burst_trie.cpp
+++ b/core/formats/formats_burst_trie.cpp
@@ -978,7 +978,7 @@ void field_writer::prepare(const irs::flush_state& state) {
       assert(index_out_cipher_ && index_out_cipher_->block_size());
 
       const auto blocks_in_buffer = math::div_ceil64(
-        encrypted_output::BUFFER_SIZE,
+        DEFAULT_ENCRYPTION_BUFFER_SIZE,
         index_out_cipher_->block_size());
 
       index_out_ = index_output::make<encrypted_output>(
@@ -2733,7 +2733,7 @@ void field_reader::prepare(
       assert(index_in_cipher && index_in_cipher->block_size());
 
       const auto blocks_in_buffer = math::div_ceil64(
-        encrypted_input::BUFFER_SIZE,
+        DEFAULT_ENCRYPTION_BUFFER_SIZE,
         index_in_cipher->block_size());
 
       index_in = memory::make_unique<encrypted_input>(

--- a/core/formats/formats_burst_trie.cpp
+++ b/core/formats/formats_burst_trie.cpp
@@ -2733,7 +2733,7 @@ void field_reader::prepare(
       assert(index_in_cipher && index_in_cipher->block_size());
 
       const auto blocks_in_buffer = math::div_ceil64(
-        buffered_index_input::DEFAULT_BUFFER_SIZE,
+        encrypted_input::BUFFER_SIZE,
         index_in_cipher->block_size());
 
       index_in = memory::make_unique<encrypted_input>(

--- a/core/formats/formats_burst_trie.cpp
+++ b/core/formats/formats_burst_trie.cpp
@@ -978,9 +978,8 @@ void field_writer::prepare(const irs::flush_state& state) {
       assert(index_out_cipher_ && index_out_cipher_->block_size());
 
       const auto blocks_in_buffer = math::div_ceil64(
-        buffered_index_output::DEFAULT_BUFFER_SIZE,
-        index_out_cipher_->block_size()
-      );
+        encrypted_output::BUFFER_SIZE,
+        index_out_cipher_->block_size());
 
       index_out_ = index_output::make<encrypted_output>(
         std::move(index_out_),

--- a/core/store/data_input.cpp
+++ b/core/store/data_input.cpp
@@ -71,21 +71,6 @@ std::streamsize input_buf::showmanyc() {
 // --SECTION--                               buffered_index_input implementation
 // -----------------------------------------------------------------------------
 
-buffered_index_input::buffered_index_input(
-    size_t buf_size/*= DEFAULT_BUFFER_SIZE*/
-) noexcept
-  : start_(0),
-    buf_size_(buf_size) {
-}
-
-buffered_index_input::buffered_index_input(
-    const buffered_index_input& rhs
-) noexcept
-  : index_input(),
-    start_(rhs.start_ + rhs.offset()),
-    buf_size_(rhs.buf_size_) {
-}
-
 byte_type buffered_index_input::read_byte() {
   if (begin_ >= end_) {
     refill();
@@ -157,7 +142,7 @@ size_t buffered_index_input::read_bytes(byte_type* b, size_t count) {
   } else { // read directly to output buffer if possible
     size  = read_internal(b, size);
     start_ += (offset() + size);
-    begin_ = end_ = buf_.get(); // will trigger refill on the next read
+    begin_ = end_ = buf_; // will trigger refill on the next read
   }
 
   return read += size;
@@ -172,14 +157,8 @@ size_t buffered_index_input::refill() {
     throw eof_error(); // read past eof
   }
 
-  if (!buf_) {
-    buf_ = memory::make_unique<byte_type[]>(buf_size_);
-    begin_ = end_ = buf_.get();
-    seek_internal(start_);
-  }
-
-  begin_ = buf_.get();
-  end_ = begin_ + read_internal(buf_.get(), data_size);
+  begin_ = buf_;
+  end_ = begin_ + read_internal(buf_, data_size);
   start_ = data_start;
 
   return data_size;
@@ -187,10 +166,10 @@ size_t buffered_index_input::refill() {
 
 void buffered_index_input::seek(size_t p) {
   if (p >= start_ && p < (start_ + size())) {
-    begin_ = buf_.get() + p - start_;
+    begin_ = buf_ + p - start_;
   } else {
     seek_internal(p);
-    begin_ = end_ = buf_.get();
+    begin_ = end_ = buf_;
     start_ = p;
   }
 }

--- a/core/store/data_input.cpp
+++ b/core/store/data_input.cpp
@@ -157,6 +157,7 @@ size_t buffered_index_input::refill() {
     throw eof_error(); // read past eof
   }
 
+  assert(buf_);
   begin_ = buf_;
   end_ = begin_ + read_internal(buf_, data_size);
   start_ = data_start;

--- a/core/store/data_input.hpp
+++ b/core/store/data_input.hpp
@@ -181,8 +181,6 @@ class IRESEARCH_API buffered_index_input : public index_input {
 
   virtual uint64_t read_vlong() override final;
 
-  size_t buffer_size() const noexcept { return buf_size_; }
-
  protected:
   buffered_index_input() = default;
 

--- a/core/store/data_input.hpp
+++ b/core/store/data_input.hpp
@@ -157,15 +157,13 @@ class IRESEARCH_API input_buf final : public std::streambuf, util::noncopyable {
 //////////////////////////////////////////////////////////////////////////////
 class IRESEARCH_API buffered_index_input : public index_input {
  public:
-  static const size_t DEFAULT_BUFFER_SIZE = 1024;
-
   virtual byte_type read_byte() override final;
 
   virtual size_t read_bytes(byte_type* b, size_t count) override final;
 
   virtual const byte_type* read_buffer(size_t size, BufferHint hint) noexcept final;
 
-  virtual size_t file_pointer() const override final {
+  virtual size_t file_pointer() const noexcept override final {
     return start_ + offset();
   }
 
@@ -175,8 +173,6 @@ class IRESEARCH_API buffered_index_input : public index_input {
 
   virtual void seek(size_t pos) override final;
 
-  size_t buffer_size() const { return buf_size_; }
-
   virtual int32_t read_int() override final;
 
   virtual int64_t read_long() override final;
@@ -185,42 +181,51 @@ class IRESEARCH_API buffered_index_input : public index_input {
 
   virtual uint64_t read_vlong() override final;
 
- protected:
-  explicit buffered_index_input(
-    size_t buf_size = DEFAULT_BUFFER_SIZE
-  ) noexcept;
+  size_t buffer_size() const noexcept { return buf_size_; }
 
-  buffered_index_input(const buffered_index_input& rhs) noexcept;
+ protected:
+  buffered_index_input() = default;
+
+  void reset(byte_type* buf, size_t size, size_t start) noexcept {
+    buf_ = buf;
+    begin_ = buf;
+    end_ = buf;
+    buf_size_ = size;
+    start_ = start;
+  }
 
   virtual void seek_internal(size_t pos) = 0;
 
   virtual size_t read_internal(byte_type* b, size_t count) = 0;
 
   // returns number of reamining bytes in the buffer
-  FORCE_INLINE size_t remain() const {
+  FORCE_INLINE size_t remain() const noexcept {
     return std::distance(begin_, end_);
   }
 
  private:
+  buffered_index_input(const buffered_index_input&) = delete;
+  buffered_index_input& operator=(const buffered_index_input&) = delete;
+
   // returns number of bytes between begin_ & end_
   size_t refill();
 
   // returns number of elements between current position and beginning of the buffer
-  FORCE_INLINE size_t offset() const { 
-    return std::distance(buf_.get(), begin_); 
+  FORCE_INLINE size_t offset() const noexcept {
+    return std::distance(buf_, begin_);
   }
 
   // returns number of valid bytes in the buffer 
-  FORCE_INLINE size_t size() const { 
-    return std::distance(buf_.get(), end_); 
+  FORCE_INLINE size_t size() const noexcept {
+    return std::distance(buf_, end_);
   }
 
   IRESEARCH_API_PRIVATE_VARIABLES_BEGIN
-  std::unique_ptr< byte_type[] > buf_; // buffer itself
-  byte_type* begin_{ buf_.get() }; // current position in the buffer
-  byte_type* end_{ buf_.get() }; // end of the valid bytes in the buffer
+  byte_type* buf_{}; // buffer itself
+  byte_type* begin_{ buf_ }; // current position in the buffer
+  byte_type* end_{ buf_ }; // end of the valid bytes in the buffer
   size_t start_{}; // position of the buffer in file
-  size_t buf_size_; // size of the buffer in bytes
+  size_t buf_size_{}; // size of the buffer in bytes
   IRESEARCH_API_PRIVATE_VARIABLES_END
 }; // buffered_index_input
 

--- a/core/store/data_output.cpp
+++ b/core/store/data_output.cpp
@@ -53,15 +53,6 @@ output_buf::int_type output_buf::overflow(int_type c) {
 // --SECTION--                              buffered_index_output implementation
 // -----------------------------------------------------------------------------
 
-buffered_index_output::buffered_index_output(
-    byte_type* buf, size_t buf_size) noexcept
-  : buf_(buf),
-    pos_(buf),
-    end_(pos_ + buf_size),
-    start_(0),
-    buf_size_(buf_size) {
-}
-
 void buffered_index_output::write_int(int32_t value) {
   if (remain() < sizeof(uint32_t)) {
     index_output::write_int(value);

--- a/core/store/data_output.cpp
+++ b/core/store/data_output.cpp
@@ -53,11 +53,12 @@ output_buf::int_type output_buf::overflow(int_type c) {
 // --SECTION--                              buffered_index_output implementation
 // -----------------------------------------------------------------------------
 
-buffered_index_output::buffered_index_output(size_t buf_size)
-  : buf_(memory::make_unique<byte_type[]>(buf_size)),
-    start_(0),
-    pos_(buf_.get()),
+buffered_index_output::buffered_index_output(
+    byte_type* buf, size_t buf_size) noexcept
+  : buf_(buf),
+    pos_(buf),
     end_(pos_ + buf_size),
+    start_(0),
     buf_size_(buf_size) {
 }
 
@@ -114,7 +115,7 @@ void buffered_index_output::write_bytes(const byte_type* b, size_t length) {
     // is data larger or equal than buffer?
     if (length >= buf_size_) {
       // we flush the buffer
-      if (pos_ > buf_.get()) {
+      if (pos_ > buf_) {
         flush();
       }
 
@@ -144,24 +145,24 @@ void buffered_index_output::write_bytes(const byte_type* b, size_t length) {
 }
 
 size_t buffered_index_output::file_pointer() const {
-  assert(buf_.get() <= pos_);
-  return start_ + size_t(std::distance(buf_.get(), pos_));
+  assert(buf_ <= pos_);
+  return start_ + size_t(std::distance(buf_, pos_));
 }
 
 void buffered_index_output::flush() {
-  assert(buf_.get() <= pos_);
-  const auto size = size_t(std::distance(buf_.get(), pos_));
-  flush_buffer(buf_.get(), size);
+  assert(buf_ <= pos_);
+  const auto size = size_t(std::distance(buf_, pos_));
+  flush_buffer(buf_, size);
   start_ += size;
-  pos_ = buf_.get();
+  pos_ = buf_;
 }
 
 void buffered_index_output::close() {
-  if (pos_ > buf_.get()) {
+  if (pos_ > buf_) {
     flush();
   }
   start_ = 0;
-  pos_ = buf_.get();
+  pos_ = buf_;
 }
 
 }

--- a/core/store/data_output.hpp
+++ b/core/store/data_output.hpp
@@ -124,9 +124,9 @@ class IRESEARCH_API output_buf final : public std::streambuf, util::noncopyable 
 //////////////////////////////////////////////////////////////////////////////
 class IRESEARCH_API buffered_index_output : public index_output, util::noncopyable {
  public:
-  static constexpr size_t DEFAULT_BUFFER_SIZE = 1024;
+//  static constexpr size_t DEFAULT_BUFFER_SIZE = 1024;
 
-  buffered_index_output(size_t buf_size = DEFAULT_BUFFER_SIZE);
+  buffered_index_output(byte_type* buf, size_t buf_size) noexcept;
 
   virtual void flush() override;
 
@@ -156,11 +156,11 @@ class IRESEARCH_API buffered_index_output : public index_output, util::noncopyab
 
  private:
   IRESEARCH_API_PRIVATE_VARIABLES_BEGIN
-  std::unique_ptr<byte_type[]> buf_;
-  size_t start_; // position of buffer in a file
-  byte_type* pos_;   // position in buffer
+  byte_type* buf_;
+  byte_type* pos_; // position in buffer
   byte_type* end_;
-  const size_t buf_size_;
+  size_t start_;   // position of buffer in a file
+  size_t buf_size_;
   IRESEARCH_API_PRIVATE_VARIABLES_END
 }; // buffered_index_output
 

--- a/core/store/data_output.hpp
+++ b/core/store/data_output.hpp
@@ -124,10 +124,6 @@ class IRESEARCH_API output_buf final : public std::streambuf, util::noncopyable 
 //////////////////////////////////////////////////////////////////////////////
 class IRESEARCH_API buffered_index_output : public index_output, util::noncopyable {
  public:
-//  static constexpr size_t DEFAULT_BUFFER_SIZE = 1024;
-
-  buffered_index_output(byte_type* buf, size_t buf_size) noexcept;
-
   virtual void flush() override;
 
   virtual void close() override;
@@ -147,6 +143,14 @@ class IRESEARCH_API buffered_index_output : public index_output, util::noncopyab
   virtual void write_long(int64_t v) override final;
 
  protected:
+  void reset(byte_type* buf, size_t size) noexcept {
+    buf_ = buf;
+    pos_ = buf;
+    end_ = buf + size;
+    buf_size_ = size;
+    start_ = 0;
+  }
+
   virtual void flush_buffer(const byte_type* b, size_t len) = 0;
 
   // returns number of reamining bytes in the buffer
@@ -156,11 +160,11 @@ class IRESEARCH_API buffered_index_output : public index_output, util::noncopyab
 
  private:
   IRESEARCH_API_PRIVATE_VARIABLES_BEGIN
-  byte_type* buf_;
-  byte_type* pos_; // position in buffer
-  byte_type* end_;
-  size_t start_;   // position of buffer in a file
-  size_t buf_size_;
+  byte_type* buf_{};
+  byte_type* pos_{}; // position in buffer
+  byte_type* end_{};
+  size_t start_{};   // position of buffer in a file
+  size_t buf_size_{};
   IRESEARCH_API_PRIVATE_VARIABLES_END
 }; // buffered_index_output
 

--- a/core/store/fs_directory.cpp
+++ b/core/store/fs_directory.cpp
@@ -177,9 +177,9 @@ class fs_index_output : public buffered_index_output {
   static index_output::ptr open(const file_path_t name) noexcept {
     assert(name);
 
-    file_utils::handle_t handle(irs::file_utils::open(name, 
-                                                      irs::file_utils::OpenMode::Write,
-                                                      IR_FADVICE_NORMAL));
+    file_utils::handle_t handle(file_utils::open(name,
+                                                 file_utils::OpenMode::Write,
+                                                 IR_FADVICE_NORMAL));
 
     if (nullptr == handle) {
       typedef std::remove_pointer<file_path_t>::type char_t;
@@ -197,12 +197,8 @@ class fs_index_output : public buffered_index_output {
       return nullptr;
     }
 
-    const auto buf_size = buffer_size(handle.get());
-
     try {
-      return fs_index_output::make<fs_index_output>(
-        std::move(handle),
-        buf_size);
+      return fs_index_output::make<fs_index_output>(std::move(handle));
     } catch(...) {
     }
 
@@ -234,11 +230,12 @@ class fs_index_output : public buffered_index_output {
   }
 
  private:
-  fs_index_output(file_utils::handle_t&& handle, size_t buf_size) noexcept
-    : buffered_index_output(buf_size),
+  fs_index_output(file_utils::handle_t&& handle) noexcept
+    : buffered_index_output(buf_, sizeof buf_),
       handle(std::move(handle)) {
   }
 
+  byte_type buf_[1024];
   file_utils::handle_t handle;
   crc32c crc;
 }; // fs_index_output

--- a/core/store/fs_directory.cpp
+++ b/core/store/fs_directory.cpp
@@ -231,8 +231,8 @@ class fs_index_output : public buffered_index_output {
 
  private:
   fs_index_output(file_utils::handle_t&& handle) noexcept
-    : buffered_index_output(buf_, sizeof buf_),
-      handle(std::move(handle)) {
+    : handle(std::move(handle)) {
+    buffered_index_output::reset(buf_, sizeof buf_);
   }
 
   byte_type buf_[1024];

--- a/core/store/fs_directory.cpp
+++ b/core/store/fs_directory.cpp
@@ -39,19 +39,6 @@
 
 namespace {
 
-inline size_t buffer_size(void* file) noexcept {
-  UNUSED(file);
-  return 1024;
-//  auto block_size = irs::file_utils::block_size(file_no(file));
-//
-//  if (block_size < 0) {
-//    // fallback to default value
-//    block_size = 1024;
-//  }
-//
-//  return block_size;
-}
-
 //////////////////////////////////////////////////////////////////////////////
 /// @brief converts the specified IOAdvice to corresponding posix fadvice
 //////////////////////////////////////////////////////////////////////////////

--- a/core/store/fs_directory.cpp
+++ b/core/store/fs_directory.cpp
@@ -398,7 +398,7 @@ class fs_index_input : public buffered_index_input {
   fs_index_input(const fs_index_input& rhs) noexcept
     : handle_(rhs.handle_),
       pool_size_(rhs.pool_size_),
-      pos_(rhs.pos_) {
+      pos_(rhs.file_pointer()) {
     buffered_index_input::reset(buf_, sizeof buf_, pos_);
   }
 

--- a/core/utils/encryption.cpp
+++ b/core/utils/encryption.cpp
@@ -247,7 +247,7 @@ void encrypted_output::write_bytes(const byte_type* b, size_t length) {
   }
 }
 
-size_t encrypted_output::file_pointer() const {
+size_t encrypted_output::file_pointer() const noexcept {
   assert(buf_.get() <= pos_);
   return start_ + size_t(std::distance(buf_.get(), pos_));
 }
@@ -285,34 +285,38 @@ void encrypted_output::close() {
 encrypted_input::encrypted_input(
     index_input& in,
     encryption::stream& cipher,
-    size_t buf_size,
-    size_t padding /* = 0*/
-) : buffered_index_input(cipher.block_size() * std::max(size_t(1), buf_size)),
+    size_t num_buffers,
+    size_t padding /* = 0*/)
+  : buf_size_(cipher.block_size() * std::max(size_t(1), num_buffers)),
+    buf_(std::make_unique<byte_type[]>(buf_size_)),
     in_(&in),
     cipher_(&cipher),
     start_(in_->file_pointer()),
     length_(in_->length() - start_ - padding) {
   assert(cipher.block_size() && buffer_size());
   assert(in_ && in_->length() >= in_->file_pointer() + padding);
+  buffered_index_input::reset(buf_.get(), buf_size_, 0);
 }
 
 encrypted_input::encrypted_input(
     index_input::ptr&& in,
     encryption::stream& cipher,
-    size_t buf_size,
-    size_t padding /* = 0*/
-) : encrypted_input(*in, cipher, buf_size, padding) {
+    size_t num_buffers,
+    size_t padding /* = 0*/)
+  : encrypted_input(*in, cipher, num_buffers, padding) {
   managed_in_ = std::move(in);
 }
 
 encrypted_input::encrypted_input(const encrypted_input& rhs, index_input::ptr&& in) noexcept
-  : buffered_index_input(rhs.buffer_size()),
+  : buf_size_(rhs.buf_size_),
+    buf_(std::make_unique<byte_type[]>(buf_size_)),
     managed_in_(std::move(in)),
     in_(managed_in_.get()),
     cipher_(rhs.cipher_),
     start_(rhs.start_),
     length_(rhs.length_) {
   assert(cipher_->block_size());
+  buffered_index_input::reset(buf_.get(), buf_size_, rhs.file_pointer());
 }
 
 int64_t encrypted_input::checksum(size_t offset) const {
@@ -324,7 +328,7 @@ int64_t encrypted_input::checksum(size_t offset) const {
   });
 
   crc32c crc;
-  byte_type buf[DEFAULT_BUFFER_SIZE];
+  byte_type buf[BUFFER_SIZE];
 
   for (auto pos = begin; pos < end; ) {
     const auto to_read = (std::min)(end - pos, sizeof buf);

--- a/core/utils/encryption.cpp
+++ b/core/utils/encryption.cpp
@@ -293,7 +293,7 @@ encrypted_input::encrypted_input(
     cipher_(&cipher),
     start_(in_->file_pointer()),
     length_(in_->length() - start_ - padding) {
-  assert(cipher.block_size() && buffer_size());
+  assert(cipher.block_size() && buf_size_);
   assert(in_ && in_->length() >= in_->file_pointer() + padding);
   buffered_index_input::reset(buf_.get(), buf_size_, 0);
 }

--- a/core/utils/encryption.cpp
+++ b/core/utils/encryption.cpp
@@ -152,10 +152,10 @@ bool decrypt(
 encrypted_output::encrypted_output(
     index_output& out,
     encryption::stream& cipher,
-    size_t buf_size)
+    size_t num_buffers)
   : out_(&out),
     cipher_(&cipher),
-    buf_size_(cipher.block_size() * std::max(size_t(1), buf_size)),
+    buf_size_(cipher.block_size() * std::max(size_t(1), num_buffers)),
     buf_(memory::make_unique<byte_type[]>(buf_size_)),
     start_(0),
     pos_(buf_.get()),
@@ -166,8 +166,8 @@ encrypted_output::encrypted_output(
 encrypted_output::encrypted_output(
     index_output::ptr&& out,
     encryption::stream& cipher,
-    size_t buf_size)
-  : encrypted_output(*out, cipher, buf_size) {
+    size_t num_buffers)
+  : encrypted_output(*out, cipher, num_buffers) {
   managed_out_ = std::move(out);
 }
 

--- a/core/utils/encryption.cpp
+++ b/core/utils/encryption.cpp
@@ -328,7 +328,7 @@ int64_t encrypted_input::checksum(size_t offset) const {
   });
 
   crc32c crc;
-  byte_type buf[BUFFER_SIZE];
+  byte_type buf[DEFAULT_ENCRYPTION_BUFFER_SIZE];
 
   for (auto pos = begin; pos < end; ) {
     const auto to_read = (std::min)(end - pos, sizeof buf);

--- a/core/utils/encryption.hpp
+++ b/core/utils/encryption.hpp
@@ -129,7 +129,7 @@ class IRESEARCH_API encrypted_output : public irs::index_output, util::noncopyab
 
   virtual void close() override final;
 
-  virtual size_t file_pointer() const override final;
+  virtual size_t file_pointer() const noexcept override final;
 
   virtual void write_byte(byte_type b) override final;
 
@@ -177,25 +177,25 @@ class IRESEARCH_API encrypted_output : public irs::index_output, util::noncopyab
 
 class IRESEARCH_API encrypted_input : public buffered_index_input, util::noncopyable {
  public:
+  static const size_t BUFFER_SIZE = 1024;
+
   encrypted_input(
     index_input& in,
     encryption::stream& cipher,
     size_t buf_size,
-    size_t padding = 0
-  );
+    size_t padding = 0);
 
   encrypted_input(
     index_input::ptr&& in,
     encryption::stream& cipher,
     size_t buf_size,
-    size_t padding = 0
-  );
+    size_t padding = 0);
 
   virtual index_input::ptr dup() const override final;
 
   virtual index_input::ptr reopen() const override final;
 
-  virtual size_t length() const override final {
+  virtual size_t length() const noexcept override final {
     return length_;
   }
 
@@ -217,6 +217,8 @@ class IRESEARCH_API encrypted_input : public buffered_index_input, util::noncopy
  private:
   encrypted_input(const encrypted_input& rhs, index_input::ptr&& in) noexcept;
 
+  size_t buf_size_;
+  std::unique_ptr<byte_type[]> buf_;
   index_input::ptr managed_in_;
   index_input* in_;
   encryption::stream* cipher_;

--- a/core/utils/encryption.hpp
+++ b/core/utils/encryption.hpp
@@ -201,6 +201,8 @@ class IRESEARCH_API encrypted_input : public buffered_index_input, util::noncopy
 
   virtual int64_t checksum(size_t offset) const override final;
 
+  size_t buffer_size() const noexcept { return buf_size_; }
+
   const index_input& stream() const noexcept {
     return *in_;
   }

--- a/core/utils/encryption.hpp
+++ b/core/utils/encryption.hpp
@@ -112,17 +112,18 @@ IRESEARCH_API bool decrypt(
 ////////////////////////////////////////////////////////////////////////////////
 class IRESEARCH_API encrypted_output : public irs::index_output, util::noncopyable {
  public:
+  static const size_t BUFFER_SIZE = 1024;
+
   encrypted_output(
     index_output& out,
     encryption::stream& cipher,
-    size_t buf_size
+    size_t num_buffers
   );
 
   encrypted_output(
     index_output::ptr&& out,
     encryption::stream& cipher,
-    size_t buf_size
-  );
+    size_t num_buffers);
 
   virtual void flush() override final;
 

--- a/core/utils/encryption.hpp
+++ b/core/utils/encryption.hpp
@@ -108,17 +108,19 @@ IRESEARCH_API bool decrypt(
 );
 
 ////////////////////////////////////////////////////////////////////////////////
+///// @brief reasonable default value for a buffer serving encryption
+////////////////////////////////////////////////////////////////////////////////
+constexpr size_t DEFAULT_ENCRYPTION_BUFFER_SIZE = 1024;
+
+////////////////////////////////////////////////////////////////////////////////
 ///// @class encrypted_output
 ////////////////////////////////////////////////////////////////////////////////
 class IRESEARCH_API encrypted_output : public irs::index_output, util::noncopyable {
  public:
-  static const size_t BUFFER_SIZE = 1024;
-
   encrypted_output(
     index_output& out,
     encryption::stream& cipher,
-    size_t num_buffers
-  );
+    size_t num_buffers);
 
   encrypted_output(
     index_output::ptr&& out,
@@ -177,8 +179,6 @@ class IRESEARCH_API encrypted_output : public irs::index_output, util::noncopyab
 
 class IRESEARCH_API encrypted_input : public buffered_index_input, util::noncopyable {
  public:
-  static const size_t BUFFER_SIZE = 1024;
-
   encrypted_input(
     index_input& in,
     encryption::stream& cipher,

--- a/tests/store/directory_test_case.cpp
+++ b/tests/store/directory_test_case.cpp
@@ -124,12 +124,39 @@ class directory_test_case : public tests::directory_test_case_base {
       EXPECT_EQ(0, file->file_pointer());
       EXPECT_EQ(file->length(), it->size());
 
+      auto dup_file = file->dup();
+      ASSERT_FALSE(!dup_file);
+      ASSERT_EQ(0, dup_file->file_pointer());
+      EXPECT_FALSE(dup_file->eof());
+      EXPECT_EQ(dup_file->length(), it->size());
+      auto reopened_file = file->reopen();
+      ASSERT_FALSE(!reopened_file);
+      ASSERT_EQ(0, reopened_file->file_pointer());
+      EXPECT_FALSE(reopened_file->eof());
+      EXPECT_EQ(reopened_file->length(), it->size());
+
       const auto checksum = file->checksum(file->length());
 
       buf.resize(it->size());
       const auto read = file->read_bytes(&(buf[0]), it->size());
       ASSERT_EQ(read, it->size());
       ASSERT_EQ(ref_cast<byte_type>(string_ref(*it)), buf);
+
+      {
+        buf.clear();
+        buf.resize(it->size());
+        const auto read = dup_file->read_bytes(&(buf[0]), it->size());
+        ASSERT_EQ(read, it->size());
+        ASSERT_EQ(ref_cast<byte_type>(string_ref(*it)), buf);
+      }
+
+      {
+        buf.clear();
+        buf.resize(it->size());
+        const auto read = reopened_file->read_bytes(&(buf[0]), it->size());
+        ASSERT_EQ(read, it->size());
+        ASSERT_EQ(ref_cast<byte_type>(string_ref(*it)), buf);
+      }
 
       crc.process_bytes(buf.c_str(), buf.size());
 

--- a/tests/utils/encryption_test.cpp
+++ b/tests/utils/encryption_test.cpp
@@ -430,7 +430,7 @@ TEST(ecnryption_test_case, ensure_no_double_bufferring) {
       out_->write_bytes(b, size);
     }
 
-    irs::byte_type buf_[1024];
+    irs::byte_type buf_[irs::DEFAULT_ENCRYPTION_BUFFER_SIZE];
     index_output* out_;
     size_t last_written_size_{};
   };
@@ -479,7 +479,7 @@ TEST(ecnryption_test_case, ensure_no_double_bufferring) {
     }
 
    private:
-    irs::byte_type buf_[1024];
+    irs::byte_type buf_[irs::DEFAULT_ENCRYPTION_BUFFER_SIZE];
     index_input* in_;
     size_t last_read_size_{};
   };
@@ -499,20 +499,20 @@ TEST(ecnryption_test_case, ensure_no_double_bufferring) {
 
   {
     buffered_output buf_out(out.stream);
-    irs::encrypted_output enc_out(buf_out, *cipher, irs::encrypted_output::BUFFER_SIZE/cipher->block_size());
+    irs::encrypted_output enc_out(buf_out, *cipher, irs::DEFAULT_ENCRYPTION_BUFFER_SIZE/cipher->block_size());
     ASSERT_EQ(nullptr, enc_out.release()); // unmanaged instance
 
-    for (size_t i = 0; i < 2*irs::encrypted_output::BUFFER_SIZE+1; ++i) {
+    for (size_t i = 0; i < 2*irs::DEFAULT_ENCRYPTION_BUFFER_SIZE+1; ++i) {
       enc_out.write_vint(i);
-      ASSERT_EQ(size_t(irs::encrypted_output::BUFFER_SIZE), buf_out.remain()); // ensure no buffering
-      if (buf_out.file_pointer() >= irs::encrypted_output::BUFFER_SIZE) {
-        ASSERT_EQ(size_t(irs::encrypted_output::BUFFER_SIZE), buf_out.last_written_size());
+      ASSERT_EQ(size_t(irs::DEFAULT_ENCRYPTION_BUFFER_SIZE), buf_out.remain()); // ensure no buffering
+      if (buf_out.file_pointer() >= irs::DEFAULT_ENCRYPTION_BUFFER_SIZE) {
+        ASSERT_EQ(size_t(irs::DEFAULT_ENCRYPTION_BUFFER_SIZE), buf_out.last_written_size());
       }
     }
 
     enc_out.flush();
     buf_out.flush();
-    ASSERT_EQ(enc_out.file_pointer() - 3*irs::encrypted_output::BUFFER_SIZE, buf_out.last_written_size());
+    ASSERT_EQ(enc_out.file_pointer() - 3*irs::DEFAULT_ENCRYPTION_BUFFER_SIZE, buf_out.last_written_size());
   }
 
   out.stream.flush();
@@ -520,15 +520,15 @@ TEST(ecnryption_test_case, ensure_no_double_bufferring) {
   {
     irs::memory_index_input in(out.file);
     buffered_input buf_in(in);
-    irs::encrypted_input enc_in(buf_in, *cipher, irs::encrypted_input::BUFFER_SIZE/cipher->block_size());
+    irs::encrypted_input enc_in(buf_in, *cipher, irs::DEFAULT_ENCRYPTION_BUFFER_SIZE/cipher->block_size());
 
-    for (size_t i = 0; i < 2*irs::encrypted_input::BUFFER_SIZE+1; ++i) {
+    for (size_t i = 0; i < 2*irs::DEFAULT_ENCRYPTION_BUFFER_SIZE+1; ++i) {
       ASSERT_EQ(i, enc_in.read_vint());
       ASSERT_EQ(0, buf_in.remain()); // ensure no buffering
-      if (buf_in.file_pointer() <= 3*irs::encrypted_output::BUFFER_SIZE) {
-        ASSERT_EQ(size_t(irs::encrypted_input::BUFFER_SIZE), buf_in.last_read_size());
+      if (buf_in.file_pointer() <= 3*irs::DEFAULT_ENCRYPTION_BUFFER_SIZE) {
+        ASSERT_EQ(size_t(irs::DEFAULT_ENCRYPTION_BUFFER_SIZE), buf_in.last_read_size());
       } else {
-        ASSERT_EQ(buf_in.length() - 3*irs::encrypted_input::BUFFER_SIZE, buf_in.last_read_size());
+        ASSERT_EQ(buf_in.length() - 3*irs::DEFAULT_ENCRYPTION_BUFFER_SIZE, buf_in.last_read_size());
       }
     }
   }

--- a/tests/utils/encryption_test.cpp
+++ b/tests/utils/encryption_test.cpp
@@ -406,7 +406,7 @@ TEST(ecnryption_test_case, ensure_no_double_bufferring) {
   class buffered_output : public irs::buffered_index_output {
    public:
     buffered_output(index_output& out)
-      : out_(&out) {
+      : buffered_index_output(buf_, sizeof buf_), out_(&out) {
     }
 
     virtual int64_t checksum() const override {
@@ -429,6 +429,7 @@ TEST(ecnryption_test_case, ensure_no_double_bufferring) {
       out_->write_bytes(b, size);
     }
 
+    irs::byte_type buf_[1024];
     index_output* out_;
     size_t last_written_size_{};
   };
@@ -495,20 +496,20 @@ TEST(ecnryption_test_case, ensure_no_double_bufferring) {
 
   {
     buffered_output buf_out(out.stream);
-    irs::encrypted_output enc_out(buf_out, *cipher, buffered_output::DEFAULT_BUFFER_SIZE/cipher->block_size());
+    irs::encrypted_output enc_out(buf_out, *cipher, irs::encrypted_output::BUFFER_SIZE/cipher->block_size());
     ASSERT_EQ(nullptr, enc_out.release()); // unmanaged instance
 
-    for (auto i = 0; i < 2*buffered_output::DEFAULT_BUFFER_SIZE+1; ++i) {
+    for (size_t i = 0; i < 2*irs::encrypted_output::BUFFER_SIZE+1; ++i) {
       enc_out.write_vint(i);
-      ASSERT_EQ(size_t(buffered_output::DEFAULT_BUFFER_SIZE), buf_out.remain()); // ensure no buffering
-      if (buf_out.file_pointer() >= buffered_output::DEFAULT_BUFFER_SIZE) {
-        ASSERT_EQ(size_t(buffered_output::DEFAULT_BUFFER_SIZE), buf_out.last_written_size());
+      ASSERT_EQ(size_t(irs::encrypted_output::BUFFER_SIZE), buf_out.remain()); // ensure no buffering
+      if (buf_out.file_pointer() >= irs::encrypted_output::BUFFER_SIZE) {
+        ASSERT_EQ(size_t(irs::encrypted_output::BUFFER_SIZE), buf_out.last_written_size());
       }
     }
 
     enc_out.flush();
     buf_out.flush();
-    ASSERT_EQ(enc_out.file_pointer() - 3*buffered_output::DEFAULT_BUFFER_SIZE, buf_out.last_written_size());
+    ASSERT_EQ(enc_out.file_pointer() - 3*irs::encrypted_output::BUFFER_SIZE, buf_out.last_written_size());
   }
 
   out.stream.flush();
@@ -518,13 +519,13 @@ TEST(ecnryption_test_case, ensure_no_double_bufferring) {
     buffered_input buf_in(in);
     irs::encrypted_input enc_in(buf_in, *cipher, buffered_input::DEFAULT_BUFFER_SIZE/cipher->block_size());
 
-    for (auto i = 0; i < 2*buffered_output::DEFAULT_BUFFER_SIZE+1; ++i) {
+    for (size_t i = 0; i < 2*irs::encrypted_output::BUFFER_SIZE+1; ++i) {
       ASSERT_EQ(i, enc_in.read_vint());
       ASSERT_EQ(0, buf_in.remain()); // ensure no buffering
-      if (buf_in.file_pointer() <= 3*buffered_output::DEFAULT_BUFFER_SIZE) {
-        ASSERT_EQ(size_t(buffered_output::DEFAULT_BUFFER_SIZE), buf_in.last_read_size());
+      if (buf_in.file_pointer() <= 3*irs::encrypted_output::BUFFER_SIZE) {
+        ASSERT_EQ(size_t(irs::encrypted_output::BUFFER_SIZE), buf_in.last_read_size());
       } else {
-        ASSERT_EQ(buf_in.length() - 3*buffered_output::DEFAULT_BUFFER_SIZE, buf_in.last_read_size());
+        ASSERT_EQ(buf_in.length() - 3*irs::encrypted_output::BUFFER_SIZE, buf_in.last_read_size());
       }
     }
   }

--- a/tests/utils/encryption_test.cpp
+++ b/tests/utils/encryption_test.cpp
@@ -405,8 +405,9 @@ TEST_P(encryption_test_case, encrypted_io) {
 TEST(ecnryption_test_case, ensure_no_double_bufferring) {
   class buffered_output : public irs::buffered_index_output {
    public:
-    buffered_output(index_output& out)
-      : buffered_index_output(buf_, sizeof buf_), out_(&out) {
+    buffered_output(index_output& out) noexcept
+      : out_(&out) {
+      buffered_index_output::reset(buf_, sizeof buf_);
     }
 
     virtual int64_t checksum() const override {


### PR DESCRIPTION
Previously buffered streams owned memory buffer they use for serving low level IO operations. That's not very convenient for modern IO API. This PR refactors buffered streams to allow setting an external buffer. 