### PR TITLE
Feature/speedup attributes

### DIFF
--- a/core/analysis/delimited_token_stream.cpp
+++ b/core/analysis/delimited_token_stream.cpp
@@ -238,7 +238,8 @@ bool delimited_token_stream::next() {
   auto& payload = std::get<irs::payload>(attrs_);
   auto& term = std::get<term_attribute>(attrs_);
 
-  offset = { .start = start, .end = uint32_t(end) };
+  offset.start = start;
+  offset.end = uint32_t(end);
   payload.value = bytes_ref(data_.c_str(), size);
   term.value =  delim_.null() ? payload.value
                               : eval_term(term_buf_, payload.value);
@@ -251,10 +252,9 @@ bool delimited_token_stream::next() {
 bool delimited_token_stream::reset(const string_ref& data) {
   data_ = ref_cast<byte_type>(data);
 
-  std::get<irs::offset>(attrs_) = {
-    .start = 0,
-    .end = 0 - uint32_t(delim_.size()) // counterpart to computation in next() above
-  };
+  auto& offset = std::get<irs::offset>(attrs_);
+  offset.start = 0;
+  offset.end = 0 - uint32_t(delim_.size()); // counterpart to computation in next() above
 
   return true;
 }

--- a/core/analysis/delimited_token_stream.cpp
+++ b/core/analysis/delimited_token_stream.cpp
@@ -202,12 +202,7 @@ namespace iresearch {
 namespace analysis {
 
 delimited_token_stream::delimited_token_stream(const string_ref& delimiter)
-  : attributes{{
-      { irs::type<increment>::id(), &inc_       },
-      { irs::type<offset>::id(), &offset_       },
-      { irs::type<payload>::id(), &payload_     },
-      { irs::type<term_attribute>::id(), &term_ }},
-      irs::type<delimited_token_stream>::get()},
+  : analyzer(irs::type<delimited_token_stream>::get()),
     delim_(ref_cast<byte_type>(delimiter)) {
   if (!delim_.null()) {
     delim_buf_ = delim_; // keep a local copy of the delimiter
@@ -229,20 +224,24 @@ bool delimited_token_stream::next() {
     return false;
   }
 
+  auto& offset = std::get<irs::offset>(attrs_);
+
   auto size = find_delimiter(data_, delim_);
   auto next = std::max(size_t(1), size + delim_.size());
-  auto start = offset_.end + uint32_t(delim_.size()); // value is allowed to overflow, will only produce invalid result
+  auto start = offset.end + uint32_t(delim_.size()); // value is allowed to overflow, will only produce invalid result
   auto end = start + size;
 
   if (irs::integer_traits<uint32_t>::const_max < end) {
     return false; // cannot fit the next token into offset calculation
   }
 
-  offset_.start = start;
-  offset_.end = uint32_t(end);
-  payload_.value = bytes_ref(data_.c_str(), size);
-  term_.value =  delim_.null() ? payload_.value
-                               : eval_term(term_buf_, payload_.value);
+  auto& payload = std::get<irs::payload>(attrs_);
+  auto& term = std::get<term_attribute>(attrs_);
+
+  offset = { .start = start, .end = uint32_t(end) };
+  payload.value = bytes_ref(data_.c_str(), size);
+  term.value =  delim_.null() ? payload.value
+                              : eval_term(term_buf_, payload.value);
   data_ = size >= data_.size() ? bytes_ref::NIL
                                : bytes_ref(data_.c_str() + next, data_.size() - next);
 
@@ -251,8 +250,11 @@ bool delimited_token_stream::next() {
 
 bool delimited_token_stream::reset(const string_ref& data) {
   data_ = ref_cast<byte_type>(data);
-  offset_.start = 0;
-  offset_.end = 0 - uint32_t(delim_.size()); // counterpart to computation in next() above
+
+  std::get<irs::offset>(attrs_) = {
+    .start = 0,
+    .end = 0 - uint32_t(delim_.size()) // counterpart to computation in next() above
+  };
 
   return true;
 }

--- a/core/analysis/delimited_token_stream.hpp
+++ b/core/analysis/delimited_token_stream.hpp
@@ -43,8 +43,8 @@ class delimited_token_stream final
   static void init(); // for trigering registration in a static build
   static ptr make(const string_ref& delimiter);
 
-  explicit delimited_token_stream(const irs::string_ref& delimiter);
-  virtual attribute* get_mutable(type_info::type_id type) noexcept override {
+  explicit delimited_token_stream(const string_ref& delimiter);
+  virtual attribute* get_mutable(irs::type_info::type_id type) noexcept override {
     return irs::get_mutable(attrs_, type);
   }
   virtual bool next() override;

--- a/core/analysis/delimited_token_stream.hpp
+++ b/core/analysis/delimited_token_stream.hpp
@@ -51,7 +51,7 @@ class delimited_token_stream final
   virtual bool reset(const string_ref& data) override;
 
  private:
-  using attributes_type = std::tuple<
+  using attributes = std::tuple<
     increment,
     offset,        // token value with evaluated quotes
     payload,       // raw token value
@@ -61,7 +61,7 @@ class delimited_token_stream final
   bytes_ref delim_;
   bstring delim_buf_;
   bstring term_buf_; // buffer for the last evaluated term
-  attributes_type attrs_;
+  attributes attrs_;
 };
 
 } // analysis

--- a/core/analysis/ngram_token_stream.cpp
+++ b/core/analysis/ngram_token_stream.cpp
@@ -350,10 +350,8 @@ bool ngram_token_stream_base::reset(const irs::string_ref& value) noexcept {
   term.value = bytes_ref::NIL;
 
   // reset offset attribute
-  offset = {
-    .start = integer_traits<uint32_t>::const_max,
-    .end = integer_traits<uint32_t>::const_max
-  };
+  offset.start = integer_traits<uint32_t>::const_max;
+  offset.end = integer_traits<uint32_t>::const_max;
 
   // reset stream
   data_ = ref_cast<byte_type>(value);

--- a/core/analysis/ngram_token_stream.cpp
+++ b/core/analysis/ngram_token_stream.cpp
@@ -277,12 +277,8 @@ template<irs::analysis::ngram_token_stream_base::InputType StreamType>
 
 
 ngram_token_stream_base::ngram_token_stream_base(
-    const ngram_token_stream_base::Options& options) 
-  : attributes{{
-      { irs::type<increment>::id(), &inc_       },
-      { irs::type<offset>::id(), &offset_       },
-      { irs::type<term_attribute>::id(), &term_ }},
-      irs::type<ngram_token_stream_base>::get()},
+    const ngram_token_stream_base::Options& options)
+  : analyzer{ irs::type<ngram_token_stream_base>::get() },
     options_(options),
     start_marker_empty_(options.start_marker.empty()),
     end_marker_empty_(options.end_marker.empty()) {
@@ -298,37 +294,45 @@ ngram_token_stream<StreamType>::ngram_token_stream(
 }
 
 void ngram_token_stream_base::emit_original() noexcept {
+  auto& term = std::get<term_attribute>(attrs_);
+  auto& offset = std::get<irs::offset>(attrs_);
+  auto& inc = std::get<increment>(attrs_);
+
   switch (emit_original_) {
     case EmitOriginal::WithoutMarkers:
-      term_.value = data_;
+      term.value = data_;
       assert(data_.size() <= integer_traits<uint32_t>::const_max);
-      offset_.end = uint32_t(data_.size());
+      offset.end = uint32_t(data_.size());
       emit_original_ = EmitOriginal::None;
-      inc_.value = next_inc_val_;
+      inc.value = next_inc_val_;
       break;
     case EmitOriginal::WithEndMarker:
       marked_term_buffer_.clear();
       IRS_ASSERT(marked_term_buffer_.capacity() >= (options_.end_marker.size() + data_.size()));
       marked_term_buffer_.append(data_.begin(), data_end_);
       marked_term_buffer_.append(options_.end_marker.begin(), options_.end_marker.end());
-      term_.value = marked_term_buffer_;
+      term.value = marked_term_buffer_;
       assert(marked_term_buffer_.size() <= integer_traits<uint32_t>::const_max);
-      offset_.start = 0;
-      offset_.end = uint32_t(data_.size());
+      offset = {
+        .start = 0,
+        .end = uint32_t(data_.size())
+      };
       emit_original_ = EmitOriginal::None; // end marker is emitted last, so we are done emitting original
-      inc_.value = next_inc_val_;
+      inc.value = next_inc_val_;
       break;
     case EmitOriginal::WithStartMarker:
       marked_term_buffer_.clear();
       IRS_ASSERT(marked_term_buffer_.capacity() >= (options_.start_marker.size() + data_.size()));
       marked_term_buffer_.append(options_.start_marker.begin(), options_.start_marker.end());
       marked_term_buffer_.append(data_.begin(), data_end_);
-      term_.value = marked_term_buffer_;
+      term.value = marked_term_buffer_;
       assert(marked_term_buffer_.size() <= integer_traits<uint32_t>::const_max);
-      offset_.start = 0;
-      offset_.end = uint32_t(data_.size());
+      offset = {
+        .start = 0,
+        .end = uint32_t(data_.size())
+      };
       emit_original_ = options_.end_marker.empty()? EmitOriginal::None : EmitOriginal::WithEndMarker;
-      inc_.value = next_inc_val_;
+      inc.value = next_inc_val_;
       break;
     default:
       IRS_ASSERT(false); // should not be called when None
@@ -343,19 +347,24 @@ bool ngram_token_stream_base::reset(const irs::string_ref& value) noexcept {
     return false;
   }
 
+  auto& term = std::get<term_attribute>(attrs_);
+  auto& offset = std::get<irs::offset>(attrs_);
+
   // reset term attribute
-  term_.value = bytes_ref::NIL;
+  term.value = bytes_ref::NIL;
 
   // reset offset attribute
-  offset_.start = integer_traits<uint32_t>::const_max;
-  offset_.end = integer_traits<uint32_t>::const_max;
+  offset = {
+    .start = integer_traits<uint32_t>::const_max,
+    .end = integer_traits<uint32_t>::const_max
+  };
 
   // reset stream
   data_ = ref_cast<byte_type>(value);
   begin_ = data_.begin();
   ngram_end_ = begin_;
   data_end_ = data_.end();
-  offset_.start = 0;
+  offset.start = 0;
   length_ = 0;
   if (options_.preserve_original) {
     if (!start_marker_empty_) {
@@ -401,6 +410,10 @@ bool ngram_token_stream<StreamType>::next_symbol(const byte_type*& it) const noe
 
 template<irs::analysis::ngram_token_stream_base::InputType StreamType>
 bool ngram_token_stream<StreamType>::next() noexcept {
+  auto& term = std::get<term_attribute>(attrs_);
+  auto& offset = std::get<irs::offset>(attrs_);
+  auto& inc = std::get<increment>(attrs_);
+
   while (begin_ < data_end_) {
     if (length_ < options_.max_gram && next_symbol(ngram_end_)) {
       // we have next ngram from current position
@@ -409,18 +422,18 @@ bool ngram_token_stream<StreamType>::next() noexcept {
         IRS_ASSERT(begin_ <= ngram_end_);
         assert(static_cast<size_t>(std::distance(begin_, ngram_end_)) <= integer_traits<uint32_t>::const_max);
         const auto ngram_byte_len = static_cast<uint32_t>(std::distance(begin_, ngram_end_));
-        if (EmitOriginal::None == emit_original_ || 0 != offset_.start || ngram_byte_len != data_.size()) {
-          offset_.end = offset_.start + ngram_byte_len;
-          inc_.value = next_inc_val_;
+        if (EmitOriginal::None == emit_original_ || 0 != offset.start || ngram_byte_len != data_.size()) {
+          offset.end = offset.start + ngram_byte_len;
+          inc.value = next_inc_val_;
           next_inc_val_ = 0;
-          if ((0 != offset_.start || start_marker_empty_) && (end_marker_empty_ || ngram_end_ != data_end_)) {
-            term_.value = irs::bytes_ref(begin_, ngram_byte_len);
-          } else if (0 == offset_.start && !start_marker_empty_) {
+          if ((0 != offset.start || start_marker_empty_) && (end_marker_empty_ || ngram_end_ != data_end_)) {
+            term.value = irs::bytes_ref(begin_, ngram_byte_len);
+          } else if (0 == offset.start && !start_marker_empty_) {
             marked_term_buffer_.clear();
             IRS_ASSERT(marked_term_buffer_.capacity() >= (options_.start_marker.size() + ngram_byte_len));
             marked_term_buffer_.append(options_.start_marker.begin(), options_.start_marker.end());
             marked_term_buffer_.append(begin_, ngram_byte_len);
-            term_.value = marked_term_buffer_;
+            term.value = marked_term_buffer_;
             assert(marked_term_buffer_.size() <= integer_traits<uint32_t>::const_max);
             if (ngram_byte_len == data_.size() && !end_marker_empty_) {
               // this term is whole original stream and we have end marker, so we need to emit
@@ -433,7 +446,7 @@ bool ngram_token_stream<StreamType>::next() noexcept {
             IRS_ASSERT(marked_term_buffer_.capacity() >= (options_.end_marker.size() + ngram_byte_len));
             marked_term_buffer_.append(begin_, ngram_byte_len);
             marked_term_buffer_.append(options_.end_marker.begin(), options_.end_marker.end());
-            term_.value = marked_term_buffer_;
+            term.value = marked_term_buffer_;
           }
         } else {
           // if ngram covers original stream we need to process it specially
@@ -448,7 +461,7 @@ bool ngram_token_stream<StreamType>::next() noexcept {
           next_inc_val_ = 1;
           length_ = 0;
           ngram_end_ = begin_;
-          offset_.start = static_cast<uint32_t>(std::distance(data_.begin(), begin_));
+          offset.start = static_cast<uint32_t>(std::distance(data_.begin(), begin_));
         } else {
           return false; // stream exhausted
         }

--- a/core/analysis/ngram_token_stream.cpp
+++ b/core/analysis/ngram_token_stream.cpp
@@ -313,10 +313,8 @@ void ngram_token_stream_base::emit_original() noexcept {
       marked_term_buffer_.append(options_.end_marker.begin(), options_.end_marker.end());
       term.value = marked_term_buffer_;
       assert(marked_term_buffer_.size() <= integer_traits<uint32_t>::const_max);
-      offset = {
-        .start = 0,
-        .end = uint32_t(data_.size())
-      };
+      offset.start = 0;
+      offset.end = uint32_t(data_.size());
       emit_original_ = EmitOriginal::None; // end marker is emitted last, so we are done emitting original
       inc.value = next_inc_val_;
       break;
@@ -327,10 +325,8 @@ void ngram_token_stream_base::emit_original() noexcept {
       marked_term_buffer_.append(data_.begin(), data_end_);
       term.value = marked_term_buffer_;
       assert(marked_term_buffer_.size() <= integer_traits<uint32_t>::const_max);
-      offset = {
-        .start = 0,
-        .end = uint32_t(data_.size())
-      };
+      offset.start = 0;
+      offset.end = uint32_t(data_.size());
       emit_original_ = options_.end_marker.empty()? EmitOriginal::None : EmitOriginal::WithEndMarker;
       inc.value = next_inc_val_;
       break;

--- a/core/analysis/ngram_token_stream.hpp
+++ b/core/analysis/ngram_token_stream.hpp
@@ -37,7 +37,7 @@ namespace analysis {
 ///         [min_gram;max_gram]. Can optionally preserve the original input.
 ////////////////////////////////////////////////////////////////////////////////
 class ngram_token_stream_base
-  : public frozen_attributes<3, analyzer>,
+  : public analyzer,
     private util::noncopyable {
  public:
    enum class InputType {
@@ -82,19 +82,25 @@ class ngram_token_stream_base
    explicit ngram_token_stream_base(const Options& options);
 
    virtual bool reset(const string_ref& data) noexcept override;
+   virtual attribute* get_mutable(type_info::type_id type) noexcept override final {
+     return irs::get_mutable(attrs_, type);
+   }
 
    size_t min_gram() const noexcept { return options_.min_gram; }
    size_t max_gram() const noexcept { return options_.max_gram; }
    bool preserve_original() const noexcept { return options_.preserve_original; }
 
  protected:
+  using attributes_type = std::tuple<
+    increment,
+    offset,
+    term_attribute>;
+
    void emit_original() noexcept;
 
    Options options_;
    bytes_ref data_; // data to process
-   increment inc_;
-   offset offset_;
-   term_attribute term_;
+   attributes_type attrs_;
    const byte_type* begin_{};
    const byte_type* data_end_{};
    const byte_type* ngram_end_{};

--- a/core/analysis/ngram_token_stream.hpp
+++ b/core/analysis/ngram_token_stream.hpp
@@ -91,7 +91,7 @@ class ngram_token_stream_base
    bool preserve_original() const noexcept { return options_.preserve_original; }
 
  protected:
-  using attributes_type = std::tuple<
+  using attributes = std::tuple<
     increment,
     offset,
     term_attribute>;
@@ -100,7 +100,7 @@ class ngram_token_stream_base
 
    Options options_;
    bytes_ref data_; // data to process
-   attributes_type attrs_;
+   attributes attrs_;
    const byte_type* begin_{};
    const byte_type* data_end_{};
    const byte_type* ngram_end_{};

--- a/core/analysis/ngram_token_stream.hpp
+++ b/core/analysis/ngram_token_stream.hpp
@@ -82,7 +82,7 @@ class ngram_token_stream_base
    explicit ngram_token_stream_base(const Options& options);
 
    virtual bool reset(const string_ref& data) noexcept override;
-   virtual attribute* get_mutable(type_info::type_id type) noexcept override final {
+   virtual attribute* get_mutable(irs::type_info::type_id type) noexcept override final {
      return irs::get_mutable(attrs_, type);
    }
 

--- a/core/analysis/pipeline_token_stream.cpp
+++ b/core/analysis/pipeline_token_stream.cpp
@@ -211,7 +211,7 @@ irs::analysis::analyzer::ptr make_json(const irs::string_ref& args) {
 REGISTER_ANALYZER_JSON(irs::analysis::pipeline_token_stream, make_json,
   normalize_json_config);
 
-irs::attribute* find_payload(const std::vector<irs::analysis::analyzer::ptr>& pipeline) {
+irs::payload* find_payload(const std::vector<irs::analysis::analyzer::ptr>& pipeline) {
   for (auto it = pipeline.rbegin(); it != pipeline.rend(); ++it) {
     auto payload = irs::get_mutable<irs::payload>(it->get());
     if (payload) {
@@ -235,14 +235,17 @@ namespace iresearch {
 namespace analysis {
 
 pipeline_token_stream::pipeline_token_stream(pipeline_token_stream::options_t&& options)
-  : attributes{ {
-    { irs::type<payload>::id(), find_payload(options)},
-    { irs::type<increment>::id(), &inc_},
-    { irs::type<offset>::id(), all_have_offset(options)? &offs_: nullptr},
-    { irs::type<term_attribute>::id(), options.empty() ?
-                                         nullptr
-                                         : irs::get_mutable<term_attribute>(options.back().get())}},
-    irs::type<pipeline_token_stream>::get()} {
+  : analyzer{irs::type<pipeline_token_stream>::get()},
+    attrs_{
+      {},
+      options.empty()
+        ? nullptr
+        : irs::get_mutable<term_attribute>(options.back().get()),
+      all_have_offset(options)
+        ? &offs_
+        : attribute_ptr<offset>{},
+      find_payload(options)
+    } {
   const auto track_offset = irs::get<offset>(*this) != nullptr;
   pipeline_.reserve(options.size());
   for (const auto& p : options) {
@@ -311,7 +314,7 @@ bool pipeline_token_stream::next() {
   if (step_for_rollback) {
     pipeline_inc++;
   }
-  inc_.value = pipeline_inc;
+  std::get<increment>(attrs_).value = pipeline_inc;
   offs_.start = current_->start();
   offs_.end = current_->end();
   return true;

--- a/core/analysis/pipeline_token_stream.hpp
+++ b/core/analysis/pipeline_token_stream.hpp
@@ -38,7 +38,8 @@ namespace analysis {
 /// @brief an analyser capable of chaining other analyzers
 ////////////////////////////////////////////////////////////////////////////////
 class pipeline_token_stream final
-  : public frozen_attributes<4, analyzer>, private util::noncopyable {
+  : public analyzer,
+    private util::noncopyable {
  public:
   using options_t = std::vector<irs::analysis::analyzer::ptr>;
 
@@ -46,6 +47,9 @@ class pipeline_token_stream final
   static void init(); // for triggering registration in a static build
 
   explicit pipeline_token_stream(options_t&& options);
+  virtual attribute* get_mutable(type_info::type_id id) noexcept override {
+    return irs::get_mutable(attrs_, id);
+  }
   virtual bool next() override;
   virtual bool reset(const string_ref& data) override;
 
@@ -94,12 +98,16 @@ class pipeline_token_stream final
     irs::analysis::analyzer::ptr analyzer;
   };
   using pipeline_t = std::vector<sub_analyzer_t>;
+  using attributes_type = std::tuple<
+    increment, attribute_ptr<term_attribute>,
+    attribute_ptr<offset>, attribute_ptr<payload>>;
+
   pipeline_t pipeline_;
   pipeline_t::iterator current_;
   pipeline_t::iterator top_;
   pipeline_t::iterator bottom_;
   offset offs_;
-  increment inc_;
+  attributes_type attrs_;
 };
 
 }

--- a/core/analysis/pipeline_token_stream.hpp
+++ b/core/analysis/pipeline_token_stream.hpp
@@ -98,7 +98,7 @@ class pipeline_token_stream final
     irs::analysis::analyzer::ptr analyzer;
   };
   using pipeline_t = std::vector<sub_analyzer_t>;
-  using attributes_type = std::tuple<
+  using attributes = std::tuple<
     increment,
     attribute_ptr<term_attribute>,
     attribute_ptr<offset>,
@@ -109,7 +109,7 @@ class pipeline_token_stream final
   pipeline_t::iterator top_;
   pipeline_t::iterator bottom_;
   offset offs_;
-  attributes_type attrs_;
+  attributes attrs_;
 };
 
 }

--- a/core/analysis/pipeline_token_stream.hpp
+++ b/core/analysis/pipeline_token_stream.hpp
@@ -47,7 +47,7 @@ class pipeline_token_stream final
   static void init(); // for triggering registration in a static build
 
   explicit pipeline_token_stream(options_t&& options);
-  virtual attribute* get_mutable(type_info::type_id id) noexcept override {
+  virtual attribute* get_mutable(irs::type_info::type_id id) noexcept override {
     return irs::get_mutable(attrs_, id);
   }
   virtual bool next() override;

--- a/core/analysis/pipeline_token_stream.hpp
+++ b/core/analysis/pipeline_token_stream.hpp
@@ -99,8 +99,10 @@ class pipeline_token_stream final
   };
   using pipeline_t = std::vector<sub_analyzer_t>;
   using attributes_type = std::tuple<
-    increment, attribute_ptr<term_attribute>,
-    attribute_ptr<offset>, attribute_ptr<payload>>;
+    increment,
+    attribute_ptr<term_attribute>,
+    attribute_ptr<offset>,
+    attribute_ptr<payload>>;
 
   pipeline_t pipeline_;
   pipeline_t::iterator current_;

--- a/core/analysis/text_token_normalizing_stream.cpp
+++ b/core/analysis/text_token_normalizing_stream.cpp
@@ -323,12 +323,7 @@ namespace analysis {
 
 text_token_normalizing_stream::text_token_normalizing_stream(
     const options_t& options)
-  : attributes{{
-      { irs::type<increment>::id(), &inc_       },
-      { irs::type<offset>::id(), &offset_       },
-      { irs::type<payload>::id(), &payload_     },
-      { irs::type<term_attribute>::id(), &term_ }},
-      irs::type<text_token_normalizing_stream>::get()},
+  : analyzer{irs::type<text_token_normalizing_stream>::get()},
     state_(memory::make_unique<state_t>(options)),
     term_eof_(true) {
 }
@@ -460,10 +455,12 @@ bool text_token_normalizing_stream::reset(const irs::string_ref& data) {
   // use the normalized value
   // ...........................................................................
   static_assert(sizeof(irs::byte_type) == sizeof(char), "sizeof(irs::byte_type) != sizeof(char)");
-  term_.value = irs::ref_cast<irs::byte_type>(state_->term_buf);
-  offset_.start = 0;
-  offset_.end = data.size();
-  payload_.value = ref_cast<uint8_t>(data);
+  std::get<term_attribute>(attrs_).value = irs::ref_cast<irs::byte_type>(state_->term_buf);
+  std::get<offset>(attrs_) = {
+    .start = 0,
+    .end = static_cast<uint32_t>(data.size())
+  };
+  std::get<payload>(attrs_).value = ref_cast<uint8_t>(data);
   term_eof_ = false;
 
   return true;

--- a/core/analysis/text_token_normalizing_stream.cpp
+++ b/core/analysis/text_token_normalizing_stream.cpp
@@ -456,10 +456,9 @@ bool text_token_normalizing_stream::reset(const irs::string_ref& data) {
   // ...........................................................................
   static_assert(sizeof(irs::byte_type) == sizeof(char), "sizeof(irs::byte_type) != sizeof(char)");
   std::get<term_attribute>(attrs_).value = irs::ref_cast<irs::byte_type>(state_->term_buf);
-  std::get<offset>(attrs_) = {
-    .start = 0,
-    .end = static_cast<uint32_t>(data.size())
-  };
+  auto& offset = std::get<irs::offset>(attrs_);
+  offset.start = 0;
+  offset.end = static_cast<uint32_t>(data.size());
   std::get<payload>(attrs_).value = ref_cast<uint8_t>(data);
   term_eof_ = false;
 

--- a/core/analysis/text_token_normalizing_stream.hpp
+++ b/core/analysis/text_token_normalizing_stream.hpp
@@ -60,13 +60,13 @@ class text_token_normalizing_stream final
   virtual bool reset(const irs::string_ref& data) override;
 
  private:
-  using attributes_type = std::tuple<
+  using attributes = std::tuple<
     increment,
     offset,
     payload,         // raw token value
     term_attribute>; // token value with evaluated quotes
 
-  attributes_type attrs_;
+  attributes attrs_;
   std::shared_ptr<state_t> state_;
   bool term_eof_;
 };

--- a/core/analysis/text_token_normalizing_stream.hpp
+++ b/core/analysis/text_token_normalizing_stream.hpp
@@ -53,7 +53,7 @@ class text_token_normalizing_stream final
   static ptr make(const string_ref& locale);
 
   explicit text_token_normalizing_stream(const options_t& options);
-  virtual attribute* get_mutable(type_info::type_id type) noexcept override final {
+  virtual attribute* get_mutable(irs::type_info::type_id type) noexcept override final {
     return irs::get_mutable(attrs_, type);
   }
   virtual bool next() override;

--- a/core/analysis/text_token_normalizing_stream.hpp
+++ b/core/analysis/text_token_normalizing_stream.hpp
@@ -35,9 +35,9 @@ namespace analysis {
 /// @brief an analyser capable of normalizing the text, treated as a single
 ///        token, i.e. case conversion and accent removal
 ////////////////////////////////////////////////////////////////////////////////
-class text_token_normalizing_stream
-  : public frozen_attributes<4, analyzer>,
-    util::noncopyable {
+class text_token_normalizing_stream final
+  : public analyzer,
+    private util::noncopyable {
  public:
   struct options_t {
     enum case_convert_t { LOWER, NONE, UPPER };
@@ -53,15 +53,21 @@ class text_token_normalizing_stream
   static ptr make(const string_ref& locale);
 
   explicit text_token_normalizing_stream(const options_t& options);
+  virtual attribute* get_mutable(type_info::type_id type) noexcept override final {
+    return irs::get_mutable(attrs_, type);
+  }
   virtual bool next() override;
   virtual bool reset(const irs::string_ref& data) override;
 
  private:
-  irs::increment inc_;
-  irs::offset offset_;
-  irs::payload payload_; // raw token value
+  using attributes_type = std::tuple<
+    increment,
+    offset,
+    payload,         // raw token value
+    term_attribute>; // token value with evaluated quotes
+
+  attributes_type attrs_;
   std::shared_ptr<state_t> state_;
-  irs::term_attribute term_; // token value with evaluated quotes
   bool term_eof_;
 };
 

--- a/core/analysis/text_token_stemming_stream.cpp
+++ b/core/analysis/text_token_stemming_stream.cpp
@@ -240,10 +240,10 @@ bool text_token_stemming_stream::reset(const irs::string_ref& data) {
     term_buf_ref = term_buf_;
   }
 
-  std::get<offset>(attrs_) = {
-    .start = 0,
-    .end = static_cast<uint32_t>(data.size())
-  };
+  auto& offset = std::get<irs::offset>(attrs_);
+  offset.start = 0;
+  offset.end = static_cast<uint32_t>(data.size());
+
   std::get<payload>(attrs_).value = ref_cast<uint8_t>(data);
   term_eof_ = false;
 

--- a/core/analysis/text_token_stemming_stream.cpp
+++ b/core/analysis/text_token_stemming_stream.cpp
@@ -181,12 +181,7 @@ namespace iresearch {
 namespace analysis {
 
 text_token_stemming_stream::text_token_stemming_stream(const std::locale& locale)
-  : attributes{{
-      { irs::type<increment>::id(), &inc_       },
-      { irs::type<offset>::id(), &offset_       },
-      { irs::type<payload>::id(), &payload_     },
-      { irs::type<term_attribute>::id(), &term_ }},
-      irs::type<text_token_stemming_stream>::get()},
+  : analyzer{irs::type<text_token_stemming_stream>::get()},
     locale_(locale),
     term_eof_(true) {
 }
@@ -222,7 +217,9 @@ bool text_token_stemming_stream::reset(const irs::string_ref& data) {
     );
   }
 
-  term_.value = irs::bytes_ref::NIL; // reset
+  auto& term = std::get<term_attribute>(attrs_);
+
+  term.value = irs::bytes_ref::NIL; // reset
   term_buf_.clear();
   term_eof_ = true;
 
@@ -243,9 +240,11 @@ bool text_token_stemming_stream::reset(const irs::string_ref& data) {
     term_buf_ref = term_buf_;
   }
 
-  offset_.start = 0;
-  offset_.end = data.size();
-  payload_.value = ref_cast<uint8_t>(data);
+  std::get<offset>(attrs_) = {
+    .start = 0,
+    .end = static_cast<uint32_t>(data.size())
+  };
+  std::get<payload>(attrs_).value = ref_cast<uint8_t>(data);
   term_eof_ = false;
 
   // ...........................................................................
@@ -266,7 +265,7 @@ bool text_token_stemming_stream::reset(const irs::string_ref& data) {
 
     if (value) {
       static_assert(sizeof(irs::byte_type) == sizeof(sb_symbol), "sizeof(irs::byte_type) != sizeof(sb_symbol)");
-      term_.value = irs::bytes_ref(reinterpret_cast<const irs::byte_type*>(value),
+      term.value = irs::bytes_ref(reinterpret_cast<const irs::byte_type*>(value),
                                    sb_stemmer_length(stemmer_.get()));
 
       return true;
@@ -277,7 +276,7 @@ bool text_token_stemming_stream::reset(const irs::string_ref& data) {
   // use the value of the unstemmed token
   // ...........................................................................
   static_assert(sizeof(irs::byte_type) == sizeof(char), "sizeof(irs::byte_type) != sizeof(char)");
-  term_.value = irs::ref_cast<irs::byte_type>(term_buf_);
+  term.value = irs::ref_cast<irs::byte_type>(term_buf_);
 
   return true;
 }

--- a/core/analysis/text_token_stemming_stream.hpp
+++ b/core/analysis/text_token_stemming_stream.hpp
@@ -54,13 +54,13 @@ class text_token_stemming_stream final
   virtual bool reset(const irs::string_ref& data) override;
 
  private:
-  using attributes_type = std::tuple<
+  using attributes = std::tuple<
     increment,
     offset,
     payload,         // raw token value
     term_attribute>; // token value with evaluated quotes
 
-   attributes_type attrs_;
+   attributes attrs_;
    std::locale locale_;
    std::shared_ptr<sb_stemmer> stemmer_;
    std::string term_buf_; // buffer for the last evaluated term

--- a/core/analysis/text_token_stemming_stream.hpp
+++ b/core/analysis/text_token_stemming_stream.hpp
@@ -44,14 +44,14 @@ class text_token_stemming_stream final
  public:
   static constexpr string_ref type_name() noexcept { return "stem"; }
   static void init(); // for trigering registration in a static build
-  static ptr make(const irs::string_ref& locale);
+  static ptr make(const string_ref& locale);
 
   explicit text_token_stemming_stream(const std::locale& locale);
-  virtual attribute* get_mutable(type_info::type_id type) noexcept override final {
+  virtual attribute* get_mutable(irs::type_info::type_id type) noexcept override final {
     return irs::get_mutable(attrs_, type);
   }
   virtual bool next() override;
-  virtual bool reset(const irs::string_ref& data) override;
+  virtual bool reset(const string_ref& data) override;
 
  private:
   using attributes = std::tuple<

--- a/core/analysis/text_token_stemming_stream.hpp
+++ b/core/analysis/text_token_stemming_stream.hpp
@@ -39,7 +39,7 @@ namespace analysis {
 ///        for supported languages
 ////////////////////////////////////////////////////////////////////////////////
 class text_token_stemming_stream final
-  : public frozen_attributes<4, analyzer>,
+  : public analyzer,
     private util::noncopyable {
  public:
   static constexpr string_ref type_name() noexcept { return "stem"; }
@@ -47,16 +47,22 @@ class text_token_stemming_stream final
   static ptr make(const irs::string_ref& locale);
 
   explicit text_token_stemming_stream(const std::locale& locale);
+  virtual attribute* get_mutable(type_info::type_id type) noexcept override final {
+    return irs::get_mutable(attrs_, type);
+  }
   virtual bool next() override;
   virtual bool reset(const irs::string_ref& data) override;
 
-  private:
-   increment inc_;
+ private:
+  using attributes_type = std::tuple<
+    increment,
+    offset,
+    payload,         // raw token value
+    term_attribute>; // token value with evaluated quotes
+
+   attributes_type attrs_;
    std::locale locale_;
-   offset offset_;
-   payload payload_; // raw token value
    std::shared_ptr<sb_stemmer> stemmer_;
-   term_attribute term_; // token value with evaluated quotes
    std::string term_buf_; // buffer for the last evaluated term
    bool term_eof_;
 };

--- a/core/analysis/text_token_stream.cpp
+++ b/core/analysis/text_token_stream.cpp
@@ -950,10 +950,9 @@ bool text_token_stream::reset(const string_ref& data) {
   std::get<term_attribute>(attrs_).value = bytes_ref::NIL;
 
   // reset offset attribute
-  std::get<offset>(attrs_) = {
-    .start = integer_traits<uint32_t>::const_max,
-    .end = integer_traits<uint32_t>::const_max
-  };
+  auto& offset = std::get<irs::offset>(attrs_);
+  offset.start = integer_traits<uint32_t>::const_max;
+  offset.end = integer_traits<uint32_t>::const_max;
 
   if (state_->icu_locale.isBogus()) {
     state_->icu_locale = icu::Locale(
@@ -1073,10 +1072,10 @@ bool text_token_stream::next() {
     }
   } else if (next_word()) {
     std::get<term_attribute>(attrs_).value = state_->term;
-    std::get<offset>(attrs_) = {
-      .start = state_->start,
-      .end = state_->end
-    };
+
+    auto& offset = std::get<irs::offset>(attrs_);
+    offset.start = state_->start;
+    offset.end = state_->end;
 
     return true;
   }
@@ -1165,10 +1164,10 @@ bool text_token_stream::next_ngram() {
     auto size = static_cast<uint32_t>(std::distance(begin, state_->ngram.it));
     term_buf_.assign(state_->term.c_str(), size);
     std::get<term_attribute>(attrs_).value = term_buf_;
-    std::get<offset>(attrs_) = {
-      .start = state_->start,
-      .end = state_->start + size
-    };
+
+    auto& offset = std::get<irs::offset>(attrs_);
+    offset.start = state_->start;
+    offset.end = state_->start + size;
 
     return true;
   }

--- a/core/analysis/text_token_stream.hpp
+++ b/core/analysis/text_token_stream.hpp
@@ -36,7 +36,7 @@ namespace iresearch {
 namespace analysis {
 
 class text_token_stream final
-  : public frozen_attributes<3, analyzer>,
+  : public analyzer,
     private util::noncopyable {
  public:
   typedef std::unordered_set<std::string> stopwords_t;
@@ -72,6 +72,9 @@ class text_token_stream final
   static void clear_cache();
 
   text_token_stream(const options_t& options, const stopwords_t& stopwords);
+  virtual attribute* get_mutable(type_info::type_id type) noexcept override final {
+    return irs::get_mutable(attrs_, type);
+  }
   virtual bool next() override;
   virtual bool reset(const string_ref& data) override;
 
@@ -80,11 +83,14 @@ class text_token_stream final
   bool next_ngram();
 
  private:
+  using attributes_type = std::tuple<
+    increment,
+    offset,
+    term_attribute>;
+
   std::shared_ptr<state_t> state_;
   bstring term_buf_; // buffer for value if value cannot be referenced directly
-  offset offs_;
-  increment inc_;
-  term_attribute term_;
+  attributes_type attrs_;
 };
 
 } // analysis

--- a/core/analysis/text_token_stream.hpp
+++ b/core/analysis/text_token_stream.hpp
@@ -83,14 +83,14 @@ class text_token_stream final
   bool next_ngram();
 
  private:
-  using attributes_type = std::tuple<
+  using attributes = std::tuple<
     increment,
     offset,
     term_attribute>;
 
   std::shared_ptr<state_t> state_;
   bstring term_buf_; // buffer for value if value cannot be referenced directly
-  attributes_type attrs_;
+  attributes attrs_;
 };
 
 } // analysis

--- a/core/analysis/text_token_stream.hpp
+++ b/core/analysis/text_token_stream.hpp
@@ -68,11 +68,11 @@ class text_token_stream final
 
   static constexpr string_ref type_name() noexcept { return "text"; }
   static void init(); // for triggering registration in a static build
-  static ptr make(const irs::string_ref& locale);
+  static ptr make(const string_ref& locale);
   static void clear_cache();
 
   text_token_stream(const options_t& options, const stopwords_t& stopwords);
-  virtual attribute* get_mutable(type_info::type_id type) noexcept override final {
+  virtual attribute* get_mutable(irs::type_info::type_id type) noexcept override final {
     return irs::get_mutable(attrs_, type);
   }
   virtual bool next() override;

--- a/core/analysis/token_masking_stream.cpp
+++ b/core/analysis/token_masking_stream.cpp
@@ -228,9 +228,10 @@ bool token_masking_stream::next() {
 }
 
 bool token_masking_stream::reset(const string_ref& data) {
-  std::get<offset>(attrs_) = {
-    .start = 0,
-    .end = uint32_t(data.size()) };
+  auto& offset = std::get<irs::offset>(attrs_);
+  offset.start = 0;
+  offset.end = uint32_t(data.size());
+
   std::get<payload>(attrs_).value = ref_cast<uint8_t>(data);
 
   auto& term = std::get<term_attribute>(attrs_);

--- a/core/analysis/token_masking_stream.hpp
+++ b/core/analysis/token_masking_stream.hpp
@@ -52,14 +52,14 @@ class token_masking_stream final
   virtual bool reset(const string_ref& data) override;
 
  private:
-  using attributes_type = std::tuple<
+  using attributes = std::tuple<
     increment,
     offset,
     payload,         // raw token value
     term_attribute>; // token value with evaluated quotes
 
   std::unordered_set<irs::bstring> mask_;
-  attributes_type attrs_;
+  attributes attrs_;
   bool term_eof_;
 };
 

--- a/core/analysis/token_masking_stream.hpp
+++ b/core/analysis/token_masking_stream.hpp
@@ -45,7 +45,7 @@ class token_masking_stream final
   static ptr make(const string_ref& mask);
 
   explicit token_masking_stream(std::unordered_set<irs::bstring>&& mask);
-  virtual attribute* get_mutable(type_info::type_id type) noexcept override {
+  virtual attribute* get_mutable(irs::type_info::type_id type) noexcept override {
     return irs::get_mutable(attrs_, type);
   }
   virtual bool next() override;

--- a/core/analysis/token_streams.cpp
+++ b/core/analysis/token_streams.cpp
@@ -28,20 +28,6 @@
 namespace iresearch {
 
 // -----------------------------------------------------------------------------
-// --SECTION--                                 basic_token_stream implementation
-// -----------------------------------------------------------------------------
-
-attribute* basic_token_stream::get_mutable(type_info::type_id type) noexcept {
-  if (irs::type<increment>::id() == type) {
-    return &inc_;
-  }
-
-  return irs::type<term_attribute>::id() == type
-    ? &term_
-    : nullptr;
-}
-
-// -----------------------------------------------------------------------------
 // --SECTION--                               boolean_token_stream implementation
 // -----------------------------------------------------------------------------
 
@@ -53,7 +39,7 @@ boolean_token_stream::boolean_token_stream(bool value /*= false*/) noexcept
 bool boolean_token_stream::next() noexcept {
   const auto in_use = in_use_;
   in_use_ = true;
-  term_.value = ref_cast<byte_type>(value(value_));
+  std::get<term_attribute>(attrs_).value = ref_cast<byte_type>(value(value_));
   return !in_use;
 }
 
@@ -62,19 +48,16 @@ bool boolean_token_stream::next() noexcept {
 // -----------------------------------------------------------------------------
 
 string_token_stream::string_token_stream() noexcept
-  : attributes{{
-      { type<increment>::id(),      &inc_   },
-      { type<term_attribute>::id(), &term_  },
-      { type<offset>::id(),         &offset_}
-    }},
-    in_use_(false) {
+   : in_use_(false) {
 }
 
 bool string_token_stream::next() noexcept {
   const auto in_use = in_use_;
-  term_.value = value_;
-  offset_.start = 0;
-  offset_.end = static_cast<uint32_t>(value_.size());
+  std::get<term_attribute>(attrs_).value = value_;
+  std::get<offset>(attrs_) = {
+    .start = 0,
+    .end = static_cast<uint32_t>(value_.size())
+  };
   value_ = irs::bytes_ref::NIL;
   in_use_ = true;
   return !in_use;
@@ -139,7 +122,9 @@ bool numeric_token_stream::numeric_term::next(increment& inc, bytes_ref& out) {
 // -----------------------------------------------------------------------------
 
 bool numeric_token_stream::next() {
-  return num_.next(inc_, term_.value);
+  return num_.next(
+    std::get<increment>(attrs_),
+    std::get<term_attribute>(attrs_).value);
 }
 
 void numeric_token_stream::reset(
@@ -193,7 +178,7 @@ void numeric_token_stream::reset(
 bool null_token_stream::next() noexcept {
   const auto in_use = in_use_;
   in_use_ = true;
-  term_.value = irs::ref_cast<byte_type>(value_null());
+  std::get<term_attribute>(attrs_).value = irs::ref_cast<byte_type>(value_null());
   return !in_use;
 }
 

--- a/core/analysis/token_streams.cpp
+++ b/core/analysis/token_streams.cpp
@@ -54,10 +54,9 @@ string_token_stream::string_token_stream() noexcept
 bool string_token_stream::next() noexcept {
   const auto in_use = in_use_;
   std::get<term_attribute>(attrs_).value = value_;
-  std::get<offset>(attrs_) = {
-    .start = 0,
-    .end = static_cast<uint32_t>(value_.size())
-  };
+  auto& offset = std::get<irs::offset>(attrs_);
+  offset.start = 0;
+  offset.end = static_cast<uint32_t>(value_.size());
   value_ = irs::bytes_ref::NIL;
   in_use_ = true;
   return !in_use;

--- a/core/analysis/token_streams.hpp
+++ b/core/analysis/token_streams.hpp
@@ -37,11 +37,12 @@ namespace iresearch {
 //////////////////////////////////////////////////////////////////////////////
 class IRESEARCH_API basic_token_stream : public token_stream {
  public:
-  virtual attribute* get_mutable(type_info::type_id type) noexcept final;
+  virtual attribute* get_mutable(type_info::type_id type) noexcept final {
+    return irs::get_mutable(attrs_, type);
+  }
 
  protected:
-  term_attribute term_;
-  increment inc_;
+  std::tuple<term_attribute, increment> attrs_;
 }; // basic_token_stream
 
 //////////////////////////////////////////////////////////////////////////////
@@ -85,12 +86,16 @@ class IRESEARCH_API boolean_token_stream final
 ///        on initial string length 
 //////////////////////////////////////////////////////////////////////////////
 class IRESEARCH_API string_token_stream final
-    : public frozen_attributes<3, token_stream>,
+    : public token_stream,
       private util::noncopyable {
  public:
   string_token_stream() noexcept;
 
   virtual bool next() noexcept override;
+
+  virtual attribute* get_mutable(type_info::type_id id) noexcept {
+    return irs::get_mutable(attrs_, id);
+  }
 
   void reset(const bytes_ref& value) noexcept {
     value_ = value;
@@ -103,9 +108,7 @@ class IRESEARCH_API string_token_stream final
   }
 
  private:
-  offset offset_;
-  increment inc_;
-  term_attribute term_;
+  std::tuple<offset, increment, term_attribute> attrs_;
   bytes_ref value_;
   bool in_use_;
 }; // string_token_stream 

--- a/core/analysis/token_streams.hpp
+++ b/core/analysis/token_streams.hpp
@@ -37,7 +37,7 @@ namespace iresearch {
 //////////////////////////////////////////////////////////////////////////////
 class IRESEARCH_API basic_token_stream : public token_stream {
  public:
-  virtual attribute* get_mutable(type_info::type_id type) noexcept final {
+  virtual attribute* get_mutable(irs::type_info::type_id type) noexcept final {
     return irs::get_mutable(attrs_, type);
   }
 

--- a/core/formats/formats_10.cpp
+++ b/core/formats/formats_10.cpp
@@ -1608,7 +1608,7 @@ class doc_iterator final : public irs::doc_iterator {
       assert(!doc_in_->eof());
     }
 
-    std::get<cost>(attrs_).value(term_state_.docs_count); // estimate iterator
+    std::get<cost>(attrs_).reset(term_state_.docs_count); // estimate iterator
 
     if constexpr (IteratorTraits::frequency()) {
       assert(irs::get<frequency>(attrs));
@@ -4330,7 +4330,7 @@ class column_iterator final : public irs::doc_iterator {
       seek_origin_(begin),
       end_(end),
       column_(&column) {
-    std::get<cost>(attrs_).value(column.size());
+    std::get<cost>(attrs_).reset(column.size());
   }
 
   virtual attribute* get_mutable(type_info::type_id type) noexcept override {
@@ -4886,7 +4886,7 @@ class dense_fixed_offset_column<dense_mask_block> final : public column {
     explicit column_iterator(const column_t& column) noexcept
       : min_(1 + column.min_),
         max_(column.max()) {
-      std::get<cost>(attrs_).value(column.size());
+      std::get<cost>(attrs_).reset(column.size());
     }
 
     virtual attribute* get_mutable(type_info::type_id type) noexcept override final {

--- a/core/formats/formats_10.cpp
+++ b/core/formats/formats_10.cpp
@@ -1644,7 +1644,7 @@ class doc_iterator final : public irs::doc_iterator {
     }
   }
 
-  virtual attribute* get_mutable(type_info::type_id type) noexcept override {
+  virtual attribute* get_mutable(irs::type_info::type_id type) noexcept override {
     return irs::get_mutable(attrs_, type);
   }
 
@@ -4333,7 +4333,7 @@ class column_iterator final : public irs::doc_iterator {
     std::get<cost>(attrs_).reset(column.size());
   }
 
-  virtual attribute* get_mutable(type_info::type_id type) noexcept override {
+  virtual attribute* get_mutable(irs::type_info::type_id type) noexcept override {
     return irs::get_mutable(attrs_, type);
   }
 
@@ -4889,7 +4889,7 @@ class dense_fixed_offset_column<dense_mask_block> final : public column {
       std::get<cost>(attrs_).reset(column.size());
     }
 
-    virtual attribute* get_mutable(type_info::type_id type) noexcept override final {
+    virtual attribute* get_mutable(irs::type_info::type_id type) noexcept override final {
       return irs::get_mutable(attrs_, type);
     }
 

--- a/core/formats/formats_10.cpp
+++ b/core/formats/formats_10.cpp
@@ -1547,7 +1547,7 @@ struct position<IteratorTraits, false> : attribute {
 template<typename IteratorTraits>
 class doc_iterator final : public irs::doc_iterator {
  private:
-  using attributes_type = std::conditional_t<
+  using attributes = std::conditional_t<
     IteratorTraits::frequency() && IteratorTraits::position(),
       std::tuple<document, frequency, cost, score, position<IteratorTraits>>,
       std::conditional_t<IteratorTraits::frequency(),
@@ -1849,7 +1849,7 @@ class doc_iterator final : public irs::doc_iterator {
   index_input::ptr doc_in_;
   version10::term_meta term_state_;
   features features_; // field features
-  attributes_type attrs_;
+  attributes attrs_;
 }; // doc_iterator
 
 template<typename IteratorTraits>
@@ -4314,7 +4314,7 @@ class column
 template<typename Column>
 class column_iterator final : public irs::doc_iterator {
  private:
-  using attributes_type = std::tuple<
+  using attributes = std::tuple<
     document, cost, score, payload>;
 
  public:
@@ -4408,7 +4408,7 @@ class column_iterator final : public irs::doc_iterator {
   }
 
   block_iterator_t block_;
-  attributes_type attrs_;
+  attributes attrs_;
   const typename column_t::block_ref* begin_;
   const typename column_t::block_ref* seek_origin_;
   const typename column_t::block_ref* end_;
@@ -4879,7 +4879,7 @@ class dense_fixed_offset_column<dense_mask_block> final : public column {
  private:
   class column_iterator final : public irs::doc_iterator {
    private:
-    using attributes_type = std::tuple<
+    using attributes = std::tuple<
       document, cost, score>;
 
    public:
@@ -4930,7 +4930,7 @@ class dense_fixed_offset_column<dense_mask_block> final : public column {
     }
 
    private:
-    attributes_type attrs_;
+    attributes attrs_;
     doc_id_t min_{ doc_limits::invalid() };
     doc_id_t max_{ doc_limits::invalid() };
   }; // column_iterator

--- a/core/formats/formats_burst_trie.cpp
+++ b/core/formats/formats_burst_trie.cpp
@@ -1810,7 +1810,7 @@ class term_iterator_base : public seek_term_iterator {
   }
 
  protected:
-  using attributes_type = std::tuple<
+  using attributes = std::tuple<
     version10::term_meta,
     attribute_ptr<frequency>,
     attribute_ptr<payload>>;
@@ -1826,7 +1826,7 @@ class term_iterator_base : public seek_term_iterator {
     return *field_;
   }
 
-  mutable attributes_type attrs_;
+  mutable attributes attrs_;
   const field_meta* field_;
   postings_reader* postings_;
   const index_input* terms_in_source_;

--- a/core/formats/formats_burst_trie.cpp
+++ b/core/formats/formats_burst_trie.cpp
@@ -1748,15 +1748,15 @@ class term_iterator_base : public seek_term_iterator {
       const index_input& terms_in,
       irs::encryption::stream* terms_cipher,
       payload* pay = nullptr)
-    : attrs_(
-        {},
-        (field.features.check<frequency>()
-          ? freq_ : attribute_ptr<frequency>()),
-        pay),
-      field_(&field),
+    : field_(&field),
       postings_(&postings),
       terms_in_source_(&terms_in),
       terms_cipher_(terms_cipher) {
+    if (field.features.check<frequency>()) {
+      std::get<attribute_ptr<frequency>>(attrs_) = freq_;
+    }
+
+    std::get<attribute_ptr<payload>>(attrs_) = pay;
   }
 
   // read attributes
@@ -1811,7 +1811,9 @@ class term_iterator_base : public seek_term_iterator {
 
  protected:
   using attributes_type = std::tuple<
-    version10::term_meta, attribute_ptr<frequency>, attribute_ptr<payload>>;
+    version10::term_meta,
+    attribute_ptr<frequency>,
+    attribute_ptr<payload>>;
 
   void copy(const byte_type* suffix, size_t prefix_size, size_t suffix_size) {
     const auto size = prefix_size + suffix_size;

--- a/core/formats/formats_burst_trie.cpp
+++ b/core/formats/formats_burst_trie.cpp
@@ -1740,8 +1740,7 @@ void block_iterator::reset() {
 /// @class term_iterator_base
 /// @brief base class for term_iterator and automaton_term_iterator
 ///////////////////////////////////////////////////////////////////////////////
-class term_iterator_base
-    : public frozen_attributes<3, seek_term_iterator> {
+class term_iterator_base : public seek_term_iterator {
  public:
   explicit term_iterator_base(
       const field_meta& field,
@@ -1749,11 +1748,11 @@ class term_iterator_base
       const index_input& terms_in,
       irs::encryption::stream* terms_cipher,
       payload* pay = nullptr)
-    : attributes{{
-        { type<version10::term_meta>::id(), &state_ },
-        { type<frequency>::id(), field.features.check<frequency>() ? &freq_ : nullptr },
-        { type<payload>::id(), pay }
-      }},
+    : attrs_(
+        {},
+        (field.features.check<frequency>()
+          ? freq_ : attribute_ptr<frequency>()),
+        pay),
       field_(&field),
       postings_(&postings),
       terms_in_source_(&terms_in),
@@ -1762,11 +1761,15 @@ class term_iterator_base
 
   // read attributes
   void read(block_iterator& it) {
-    it.load_data(*field_, *this, state_, *postings_);
+    it.load_data(*field_, *this, std::get<version10::term_meta>(attrs_), *postings_);
+  }
+
+  virtual attribute* get_mutable(irs::type_info::type_id type) noexcept override final {
+    return irs::get_mutable(attrs_, type);
   }
 
   virtual seek_term_iterator::seek_cookie::ptr cookie() const final {
-    return ::cookie::make(state_, freq_.value);
+    return ::cookie::make(std::get<version10::term_meta>(attrs_), freq_.value);
   }
 
   virtual const bytes_ref& value() const noexcept final { return term_; }
@@ -1781,7 +1784,7 @@ class term_iterator_base
 #endif // IRESEARCH_DEBUG
 
     // copy state
-    state_ = state.meta;
+    std::get<version10::term_meta>(attrs_) = state.meta;
     freq_.value = state.term_freq;
 
     // copy term
@@ -1793,7 +1796,9 @@ class term_iterator_base
 
   doc_iterator::ptr postings(block_iterator* it, const flags& features) const {
     if (it) {
-      it->load_data(*field_, const_cast<term_iterator_base&>(*this), state_, *postings_); // read attributes
+      it->load_data(
+        *field_, const_cast<term_iterator_base&>(*this),
+        std::get<version10::term_meta>(attrs_), *postings_); // read attributes
     }
     return postings_->iterator(field_->features, *this, features);
   }
@@ -1805,6 +1810,9 @@ class term_iterator_base
   }
 
  protected:
+  using attributes_type = std::tuple<
+    version10::term_meta, attribute_ptr<frequency>, attribute_ptr<payload>>;
+
   void copy(const byte_type* suffix, size_t prefix_size, size_t suffix_size) {
     const auto size = prefix_size + suffix_size;
     term_.oversize(size);
@@ -1816,11 +1824,11 @@ class term_iterator_base
     return *field_;
   }
 
+  mutable attributes_type attrs_;
   const field_meta* field_;
   postings_reader* postings_;
   const index_input* terms_in_source_;
   irs::encryption::stream* terms_cipher_;
-  mutable version10::term_meta state_;
   frequency freq_;
   mutable index_input::ptr terms_in_;
   bytes_builder term_;
@@ -2009,7 +2017,7 @@ bool term_iterator<FST>::next() {
     } else {
       const uint64_t start = cur_block_->start();
       cur_block_ = pop_block();
-      state_ = cur_block_->state();
+      std::get<version10::term_meta>(attrs_) = cur_block_->state();
       if (cur_block_->dirty() || cur_block_->block_start() != start) {
         // here we're currently at non block that was not loaded yet
         assert(cur_block_->prefix() < term_.size());
@@ -2555,7 +2563,7 @@ bool automaton_term_iterator<FST>::next() {
       } else {
         const uint64_t start = cur_block_->start();
         cur_block_ = pop_block();
-        state_ = cur_block_->state();
+        std::get<version10::term_meta>(attrs_) = cur_block_->state();
         if (cur_block_->dirty() || cur_block_->block_start() != start) {
           // here we're currently at non block that was not loaded yet
           assert(cur_block_->prefix() < term_.size());

--- a/core/index/field_data.cpp
+++ b/core/index/field_data.cpp
@@ -186,7 +186,7 @@ class pos_iterator final : public irs::position {
     prox_in_ = prox;
   }
 
-  virtual attribute* get_mutable(type_info::type_id id) noexcept override final {
+  virtual attribute* get_mutable(irs::type_info::type_id id) noexcept override final {
     return irs::get_mutable(attrs_, id);
   }
 
@@ -316,7 +316,7 @@ class doc_iterator final : public irs::doc_iterator {
     return posting_->size;
   }
 
-  virtual attribute* get_mutable(type_info::type_id type) noexcept override final {
+  virtual attribute* get_mutable(irs::type_info::type_id type) noexcept override final {
     return irs::get_mutable(attrs_, type);
   }
 
@@ -440,7 +440,7 @@ class sorting_doc_iterator final : public irs::doc_iterator {
     it_ = docs_.begin();
   }
 
-  virtual attribute* get_mutable(type_info::type_id type) noexcept override final {
+  virtual attribute* get_mutable(irs::type_info::type_id type) noexcept override final {
     return irs::get_mutable(attrs_, type);
   }
 
@@ -600,7 +600,7 @@ class term_iterator : public irs::term_iterator {
     return it_->first;
   }
 
-  virtual attribute* get_mutable(type_info::type_id) noexcept override {
+  virtual attribute* get_mutable(irs::type_info::type_id) noexcept override {
     return nullptr;
   }
 
@@ -718,7 +718,7 @@ class term_reader final : public irs::basic_term_reader,
     return memory::to_managed<irs::term_iterator, false>(&it_);
   }
 
-  virtual attribute* get_mutable(type_info::type_id) noexcept override {
+  virtual attribute* get_mutable(irs::type_info::type_id) noexcept override {
     return nullptr;
   }
 

--- a/core/index/field_data.cpp
+++ b/core/index/field_data.cpp
@@ -171,11 +171,11 @@ class pos_iterator final : public irs::position {
 
     freq_ = &freq;
 
-    std::get<attribute_ptr<offset>>(attrs_).ptr = features.check<offset>()
+    std::get<attribute_ptr<offset>>(attrs_) = features.check<offset>()
       ? &offs_
       : nullptr;
 
-    std::get<attribute_ptr<payload>>(attrs_).ptr = features.check<payload>()
+    std::get<attribute_ptr<payload>>(attrs_) = features.check<payload>()
       ? &pay_
       : nullptr;
   }
@@ -272,17 +272,17 @@ class doc_iterator final : public irs::doc_iterator {
     field_ = &field;
     auto& freq = std::get<attribute_ptr<frequency>>(attrs_);
     auto& pos = std::get<attribute_ptr<position>>(attrs_);
-    freq.ptr = nullptr;
-    pos.ptr = nullptr;
+    freq = nullptr;
+    pos = nullptr;
     has_cookie_ = false;
 
     auto& features = field.meta().features;
     if (features.check<frequency>()) {
-      freq.ptr = &freq_;
+      freq = &freq_;
 
       if (features.check<position>()) {
         pos_.reset(features, freq_);
-        pos.ptr = &pos_;
+        pos = &pos_;
         has_cookie_ = field.prox_random_access();
       }
     }
@@ -399,16 +399,16 @@ class sorting_doc_iterator final : public irs::doc_iterator {
 
     auto& pfreq = std::get<attribute_ptr<frequency>>(attrs_);
     auto& ppos = std::get<attribute_ptr<position>>(attrs_);
-    pfreq.ptr = nullptr;
-    ppos.ptr = nullptr;
+    pfreq = nullptr;
+    ppos = nullptr;
 
     auto& features = field.meta().features;
     if (features.check<frequency>()) {
-      pfreq.ptr = &freq_;
+      pfreq = &freq_;
 
       if (features.check<position>()) {
         pos_.reset(features, freq_);
-        ppos.ptr = &pos_;
+        ppos = &pos_;
       }
     }
   }

--- a/core/index/field_data.cpp
+++ b/core/index/field_data.cpp
@@ -226,14 +226,14 @@ class pos_iterator final : public irs::position {
   }
 
  private:
-  using attributes_type = std::tuple<attribute_ptr<offset>, attribute_ptr<payload>>;
+  using attributes = std::tuple<attribute_ptr<offset>, attribute_ptr<payload>>;
 
   Reader prox_in_;
   bstring payload_value_;
   const frequency* freq_{}; // number of term positions in a document
   payload pay_;
   offset offs_;
-  attributes_type attrs_;
+  attributes attrs_;
   uint32_t pos_{}; // current position
 }; // pos_iterator
 
@@ -373,7 +373,7 @@ class doc_iterator final : public irs::doc_iterator {
   }
 
  private:
-  using attributes_type = std::tuple<
+  using attributes = std::tuple<
     attribute_ptr<frequency>, attribute_ptr<position>>;
 
   const field_data* field_{};
@@ -383,7 +383,7 @@ class doc_iterator final : public irs::doc_iterator {
   pos_iterator<byte_block_pool::sliced_reader> pos_;
   byte_block_pool::sliced_reader freq_in_;
   const posting* posting_{};
-  attributes_type attrs_;
+  attributes attrs_;
   bool has_cookie_{false}; // FIXME remove
 };
 
@@ -483,7 +483,7 @@ class sorting_doc_iterator final : public irs::doc_iterator {
   }
 
  private:
-  using attributes_type = std::tuple<
+  using attributes = std::tuple<
     document, attribute_ptr<frequency>, attribute_ptr<position>>;
 
   struct doc_entry {
@@ -559,7 +559,7 @@ class sorting_doc_iterator final : public irs::doc_iterator {
   std::vector<doc_entry> docs_;
   pos_iterator<byte_block_pool::sliced_greedy_reader> pos_;
   frequency freq_;
-  attributes_type attrs_;
+  attributes attrs_;
 }; // sorting_doc_iterator
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/index/iterators.cpp
+++ b/core/index/iterators.cpp
@@ -36,8 +36,8 @@ namespace {
 //////////////////////////////////////////////////////////////////////////////
 struct empty_doc_iterator final : irs::doc_iterator {
   empty_doc_iterator() noexcept
-    : doc{irs::doc_limits::eof()} {
-    cost.value(0);
+    : cost(0),
+      doc{irs::doc_limits::eof()} {
   }
 
   virtual irs::doc_id_t value() const override {

--- a/core/search/all_iterator.cpp
+++ b/core/search/all_iterator.cpp
@@ -31,21 +31,20 @@ all_iterator::all_iterator(
     const order::prepared& order,
     uint64_t docs_count,
     boost_t boost)
-  : attributes{{
-      { type<document>::id(), &doc_   },
-      { type<cost>::id(),     &cost_  },
-      { type<score>::id(),    &score_ },
-    }},
-    score_(order),
-    max_doc_(doc_id_t(doc_limits::min() + docs_count - 1)),
-    cost_(max_doc_) {
+  : max_doc_(doc_id_t(doc_limits::min() + docs_count - 1)) {
+  std::get<cost>(attrs_).value(max_doc_);
+
   if (!order.empty()) {
+    auto& score = std::get<irs::score>(attrs_);
+
+    score.realloc(order);
+
     order::prepared::scorers scorers(
       order, reader, irs::empty_term_reader(docs_count),
-      query_stats, score_.data(),
+      query_stats, score.data(),
       *this, boost);
 
-    irs::reset(score_, std::move(scorers));
+    irs::reset(score, std::move(scorers));
   }
 }
 

--- a/core/search/all_iterator.cpp
+++ b/core/search/all_iterator.cpp
@@ -32,7 +32,7 @@ all_iterator::all_iterator(
     uint64_t docs_count,
     boost_t boost)
   : max_doc_(doc_id_t(doc_limits::min() + docs_count - 1)) {
-  std::get<cost>(attrs_).value(max_doc_);
+  std::get<cost>(attrs_).reset(max_doc_);
 
   if (!order.empty()) {
     auto& score = std::get<irs::score>(attrs_);

--- a/core/search/all_iterator.hpp
+++ b/core/search/all_iterator.hpp
@@ -73,10 +73,10 @@ class all_iterator final : public doc_iterator {
   }
 
  private:
-  using attributes_type = std::tuple<document, cost, score>;
+  using attributes = std::tuple<document, cost, score>;
 
   doc_id_t max_doc_; // largest valid doc_id
-  attributes_type attrs_;
+  attributes attrs_;
 }; // all_iterator
 
 } // ROOT

--- a/core/search/all_iterator.hpp
+++ b/core/search/all_iterator.hpp
@@ -42,7 +42,7 @@ class all_iterator final : public doc_iterator {
     uint64_t docs_count,
     boost_t boost);
 
-  virtual attribute* get_mutable(type_info::type_id id) noexcept override {
+  virtual attribute* get_mutable(irs::type_info::type_id id) noexcept override {
     return irs::get_mutable(attrs_, id);
   }
 

--- a/core/search/all_iterator.hpp
+++ b/core/search/all_iterator.hpp
@@ -33,8 +33,7 @@
 
 namespace iresearch {
 
-class all_iterator final
-    : public frozen_attributes<3, doc_iterator> {
+class all_iterator final : public doc_iterator {
  public:
   all_iterator(
     const irs::sub_reader& reader,
@@ -43,33 +42,41 @@ class all_iterator final
     uint64_t docs_count,
     boost_t boost);
 
+  virtual attribute* get_mutable(type_info::type_id id) noexcept override {
+    return irs::get_mutable(attrs_, id);
+  }
+
   virtual bool next() noexcept override {
-    if (doc_.value >= max_doc_) {
-      doc_.value = doc_limits::eof();
+    auto& doc = std::get<document>(attrs_);
+
+    if (doc.value >= max_doc_) {
+      doc.value = doc_limits::eof();
       return false;
     } else {
-      doc_.value++;
+      doc.value++;
       return true;
     }
   }
 
   virtual irs::doc_id_t seek(irs::doc_id_t target) noexcept override {
-    doc_.value = target <= max_doc_
+    auto& doc = std::get<document>(attrs_);
+
+    doc.value = target <= max_doc_
       ? target
       : doc_limits::eof();
 
-    return doc_.value;
+    return doc.value;
   }
 
   virtual irs::doc_id_t value() const noexcept override {
-    return doc_.value;
+    return std::get<document>(attrs_).value;
   }
 
  private:
-  document doc_;
-  score score_;
+  using attributes_type = std::tuple<document, cost, score>;
+
   doc_id_t max_doc_; // largest valid doc_id
-  cost cost_;
+  attributes_type attrs_;
 }; // all_iterator
 
 } // ROOT

--- a/core/search/bitset_doc_iterator.cpp
+++ b/core/search/bitset_doc_iterator.cpp
@@ -27,7 +27,7 @@
 
 namespace iresearch {
 
-attribute* bitset_doc_iterator::get_mutable(type_info::type_id id) noexcept {
+attribute* bitset_doc_iterator::get_mutable(irs::type_info::type_id id) noexcept {
   if (type<document>::id() == id) {
     return &doc_;
   }

--- a/core/search/bitset_doc_iterator.hpp
+++ b/core/search/bitset_doc_iterator.hpp
@@ -51,7 +51,7 @@ class bitset_doc_iterator
   virtual bool next() noexcept override final;
   virtual doc_id_t seek(doc_id_t target) noexcept override final;
   virtual doc_id_t value() const noexcept override final { return doc_.value; }
-  virtual attribute* get_mutable(type_info::type_id id) noexcept override;
+  virtual attribute* get_mutable(irs::type_info::type_id id) noexcept override;
 
  protected:
   explicit bitset_doc_iterator(cost::cost_t cost) noexcept

--- a/core/search/conjunction.hpp
+++ b/core/search/conjunction.hpp
@@ -54,11 +54,11 @@ struct score_iterator_adapter {
     return it.get();
   }
 
-  const attribute* get(type_info::type_id type) const noexcept {
+  const attribute* get(irs::type_info::type_id type) const noexcept {
     return it->get(type);
   }
 
-  attribute* get_mutable(type_info::type_id type) noexcept {
+  attribute* get_mutable(irs::type_info::type_id type) noexcept {
     return it->get_mutable(type);
   }
 
@@ -142,7 +142,7 @@ class conjunction : public doc_iterator, private score_ctx {
   // size of conjunction
   size_t size() const noexcept { return itrs_.size(); }
 
-  virtual attribute* get_mutable(type_info::type_id type) noexcept override final {
+  virtual attribute* get_mutable(irs::type_info::type_id type) noexcept override final {
     return irs::get_mutable(attrs_, type);
   }
 

--- a/core/search/conjunction.hpp
+++ b/core/search/conjunction.hpp
@@ -167,7 +167,7 @@ class conjunction : public doc_iterator, private score_ctx {
   }
 
  private:
-  using attributes_type = std::tuple<
+  using attributes = std::tuple<
     attribute_ptr<document>,
     attribute_ptr<cost>,
     score>;
@@ -271,7 +271,7 @@ class conjunction : public doc_iterator, private score_ctx {
     return target;
   }
 
-  attributes_type attrs_;
+  attributes attrs_;
   doc_iterators_t itrs_;
   std::vector<const irs::score*> scores_; // valid sub-scores
   mutable std::vector<const irs::byte_type*> score_vals_;

--- a/core/search/cost.hpp
+++ b/core/search/cost.hpp
@@ -74,7 +74,7 @@ class IRESEARCH_API cost final : public attribute {
   //////////////////////////////////////////////////////////////////////////////
   /// @brief sets the estimation value 
   //////////////////////////////////////////////////////////////////////////////
-  void value(cost_t value) noexcept {
+  void reset(cost_t value) noexcept {
     value_ = value;
     init_ = true;
   }
@@ -82,7 +82,7 @@ class IRESEARCH_API cost final : public attribute {
   //////////////////////////////////////////////////////////////////////////////
   /// @brief sets the estimation rule
   //////////////////////////////////////////////////////////////////////////////
-  void rule(cost_f&& eval) {
+  void reset(cost_f&& eval) noexcept(std::is_nothrow_move_assignable_v<cost_f>) {
     assert(eval);
     func_ = std::move(eval);
     init_ = false;

--- a/core/search/disjunction.hpp
+++ b/core/search/disjunction.hpp
@@ -216,7 +216,7 @@ class unary_disjunction final : public compound_doc_iterator<Adapter> {
 template<typename DocIterator,
          typename Adapter = score_iterator_adapter<DocIterator>>
 class basic_disjunction final
-    : public frozen_attributes<3, compound_doc_iterator<Adapter>>,
+    : public compound_doc_iterator<Adapter>,
       private score_ctx {
  public:
   using adapter = Adapter;
@@ -244,37 +244,49 @@ class basic_disjunction final
         resolve_overload_tag{}) {
   }
 
+  virtual attribute* get_mutable(type_info::type_id type) noexcept override final {
+    return irs::get_mutable(attrs_, type);
+  }
+
   virtual doc_id_t value() const noexcept override {
-    return doc_.value;
+    return std::get<document>(attrs_).value;
   }
 
   virtual bool next() override {
     next_iterator_impl(lhs_);
     next_iterator_impl(rhs_);
-    return !doc_limits::eof(doc_.value = std::min(lhs_.value(), rhs_.value()));
+
+    auto& doc = std::get<document>(attrs_);
+    return !doc_limits::eof(doc.value = std::min(lhs_.value(), rhs_.value()));
   }
 
   virtual doc_id_t seek(doc_id_t target) override {
-    if (target <= doc_.value) {
-      return doc_.value;
+    auto& doc = std::get<document>(attrs_);
+
+    if (target <= doc.value) {
+      return doc.value;
     }
 
     if (seek_iterator_impl(lhs_, target) || seek_iterator_impl(rhs_, target)) {
-      return doc_.value = target;
+      return doc.value = target;
     }
 
-    return (doc_.value = std::min(lhs_.value(), rhs_.value()));
+    return (doc.value = std::min(lhs_.value(), rhs_.value()));
   }
 
   virtual void visit(void* ctx, bool (*visitor)(void*, Adapter&)) override {
     assert(ctx);
     assert(visitor);
-    assert(lhs_.doc->value >= doc_.value); // assume that seek or next has been called
-    if (lhs_.value() == doc_.value && !visitor(ctx, lhs_)) {
+
+    auto& doc = std::get<document>(attrs_);
+    assert(lhs_.doc->value >= doc.value); // assume that seek or next has been called
+
+    if (lhs_.value() == doc.value && !visitor(ctx, lhs_)) {
       return;
     }
-    seek_iterator_impl(rhs_, doc_.value);
-    if (rhs_.value() == doc_.value) {
+
+    seek_iterator_impl(rhs_, doc.value);
+    if (rhs_.value() == doc.value) {
       visitor(ctx, rhs_);
     }
   }
@@ -290,17 +302,12 @@ class basic_disjunction final
       sort::MergeType merge_type,
       Estimation&& estimation,
       resolve_overload_tag)
-    : frozen_attributes<3, compound_doc_iterator<Adapter>>{{
-        { type<document>::id(), &doc_   },
-        { type<cost>::id(),     &cost_  },
-        { type<score>::id(),    &score_ },
-      }},
-      lhs_(std::move(lhs)),
+    : lhs_(std::move(lhs)),
       rhs_(std::move(rhs)),
-      score_(ord),
       no_score_value_(ord.score_size(), 0),
-      cost_(std::forward<Estimation>(estimation)),
       merger_(ord.prepare_merger(merge_type)) {
+    std::get<cost>(attrs_).reset(std::forward<Estimation>(estimation));
+
     prepare_score(ord);
   }
 
@@ -311,37 +318,40 @@ class basic_disjunction final
 
     assert(lhs_.score && rhs_.score); // must be ensure by the adapter
 
+    auto& score = std::get<irs::score>(attrs_);
+    score.realloc(ord);
+
     const bool lhs_score_empty = lhs_.score->is_default();
     const bool rhs_score_empty = rhs_.score->is_default();
 
     if (!lhs_score_empty && !rhs_score_empty) {
       // both sub-iterators have score
-      score_.reset(this, [](score_ctx* ctx) -> const byte_type* {
+      score.reset(this, [](score_ctx* ctx) -> const byte_type* {
         auto& self = *static_cast<basic_disjunction*>(ctx);
 
         const byte_type* score_values[2] {
           self.score_iterator_impl(self.lhs_),
           self.score_iterator_impl(self.rhs_) };
 
-        auto* score_buf = self.score_.data();
+        auto* score_buf = std::get<irs::score>(self.attrs_).data();
         self.merger_(score_buf, score_values, 2);
 
         return score_buf;
       });
     } else if (!lhs_score_empty) {
       // only left sub-iterator has score
-      score_.reset(this, [](score_ctx* ctx) -> const byte_type* {
+      score.reset(this, [](score_ctx* ctx) -> const byte_type* {
         auto& self = *static_cast<basic_disjunction*>(ctx);
         return self.score_iterator_impl(self.lhs_);
       });
     } else if (!rhs_score_empty) {
       // only right sub-iterator has score
-      score_.reset(this, [](score_ctx* ctx) -> const byte_type* {
+      score.reset(this, [](score_ctx* ctx) -> const byte_type* {
         auto& self = *static_cast<basic_disjunction*>(ctx);
         return self.score_iterator_impl(self.rhs_);
       });
     } else {
-      assert(score_.is_default());
+      assert(score.is_default());
     }
   }
 
@@ -350,35 +360,37 @@ class basic_disjunction final
   }
 
   void next_iterator_impl(adapter& it) {
-    const auto doc = it.value();
+    auto& doc = std::get<document>(attrs_);
+    const auto value = it.value();
 
-    if (doc_.value == doc) {
+    if (doc.value == value) {
       it->next();
-    } else if (doc < doc_.value) {
-      it->seek(doc_.value + doc_id_t(!doc_limits::eof(doc_.value)));
+    } else if (value < doc.value) {
+      it->seek(doc.value + doc_id_t(!doc_limits::eof(doc.value)));
     }
   }
 
   const byte_type* score_iterator_impl(adapter& it) const {
-    auto doc = it.value();
+    auto& doc = std::get<document>(attrs_);
+    auto value = it.value();
 
-    if (doc < doc_.value) {
-      doc = it->seek(doc_.value);
+    if (value < doc.value) {
+      value = it->seek(doc.value);
     }
 
-    if (doc == doc_.value) {
+    if (value == doc.value) {
       return it.score->evaluate();
     }
 
     return no_score_value_.c_str();
   }
 
+  using attributes_type = std::tuple<document, score, cost>;
+
   mutable adapter lhs_;
   mutable adapter rhs_;
-  document doc_;
-  score score_;
+  attributes_type attrs_;
   bstring no_score_value_; // empty score value
-  cost cost_;
   order::prepared::merger merger_;
 }; // basic_disjunction
 
@@ -396,7 +408,7 @@ class basic_disjunction final
 ////////////////////////////////////////////////////////////////////////////////
 template<typename DocIterator, typename Adapter = score_iterator_adapter<DocIterator>>
 class small_disjunction final
-    : public frozen_attributes<3, compound_doc_iterator<Adapter>>,
+    : public compound_doc_iterator<Adapter>,
       private score_ctx {
  public:
   using adapter = Adapter;
@@ -426,24 +438,31 @@ class small_disjunction final
         resolve_overload_tag()) {
   }
 
+  virtual attribute* get_mutable(type_info::type_id type) noexcept override final {
+    return irs::get_mutable(attrs_, type);
+  }
+
   virtual doc_id_t value() const noexcept override {
-    return doc_.value;
+    return std::get<document>(attrs_).value;
   }
 
   bool next_iterator_impl(adapter& it) {
-    const auto doc = it.value();
+    auto& doc = std::get<document>(attrs_);
+    const auto value = it.value();
 
-    if (doc == doc_.value) {
+    if (value == doc.value) {
       return it->next();
-    } else if (doc < doc_.value) {
-      return !doc_limits::eof(it->seek(doc_.value+1));
+    } else if (value < doc.value) {
+      return !doc_limits::eof(it->seek(doc.value+1));
     }
 
     return true;
   }
 
   virtual bool next() override {
-    if (doc_limits::eof(doc_.value)) {
+    auto& doc = std::get<document>(attrs_);
+
+    if (doc_limits::eof(doc.value)) {
       return false;
     }
 
@@ -453,7 +472,7 @@ class small_disjunction final
       auto& it = *begin;
       if (!next_iterator_impl(it)) {
         if (!remove_iterator(begin)) {
-          doc_.value = doc_limits::eof();
+          doc.value = doc_limits::eof();
           return false;
         }
 #if defined(_MSC_VER) && defined(IRESEARCH_DEBUG)
@@ -466,13 +485,15 @@ class small_disjunction final
       }
     }
 
-    doc_.value = min;
+    doc.value = min;
     return true;
   }
 
   virtual doc_id_t seek(doc_id_t target) override {
-    if (doc_limits::eof(doc_.value)) {
-      return doc_.value;
+    auto& doc = std::get<document>(attrs_);
+
+    if (doc_limits::eof(doc.value)) {
+      return doc.value;
     }
 
     doc_id_t min = doc_limits::eof();
@@ -481,14 +502,14 @@ class small_disjunction final
       auto& it = *begin;
 
       if (it.value() < target) {
-        const auto doc = it->seek(target);
+        const auto value = it->seek(target);
 
-        if (doc == target) {
-          return doc_.value = doc;
-        } else if (doc_limits::eof(doc)) {
+        if (value == target) {
+          return doc.value = value;
+        } else if (doc_limits::eof(value)) {
           if (!remove_iterator(begin)) {
             // exhausted
-            return doc_.value = doc_limits::eof();
+            return doc.value = doc_limits::eof();
           }
 #if defined(_MSC_VER) && defined(IRESEARCH_DEBUG)
           // workaround for Microsoft checked iterators
@@ -502,16 +523,17 @@ class small_disjunction final
       ++begin;
     }
 
-    return (doc_.value = min);
+    return (doc.value = min);
   }
 
   virtual void visit(void* ctx, bool (*visitor)(void*, Adapter&)) override {
     assert(ctx);
     assert(visitor);
+    auto& doc = std::get<document>(attrs_);
     hitch_all_iterators();
     for (auto begin = begin_; begin != end_; ++begin) {
       auto& it = *begin;
-      if (it->value() == doc_.value && !visitor(ctx, it)) {
+      if (it->value() == doc.value && !visitor(ctx, it)) {
         return;
       }
     }
@@ -527,21 +549,17 @@ class small_disjunction final
       sort::MergeType merge_type,
       Estimation&& estimation,
       resolve_overload_tag)
-    : frozen_attributes<3, compound_doc_iterator<Adapter>>{{
-        { type<document>::id(), &doc_   },
-        { type<cost>::id(),     &cost_  },
-        { type<score>::id(),    &score_ },
-      }},
-      itrs_(itrs.size()),
+    : itrs_(itrs.size()),
       scored_begin_(itrs_.begin()),
       begin_(scored_begin_),
       end_(itrs_.end()),
-      doc_(itrs_.empty()
-        ? doc_limits::eof()
-        : doc_limits::invalid()),
-      score_(ord),
-      cost_(std::forward<Estimation>(estimation)),
       merger_(ord.prepare_merger(merge_type)) {
+    std::get<cost>(attrs_).reset(std::forward<Estimation>(estimation));
+
+    if (itrs_.empty()) {
+      std::get<document>(attrs_).value = doc_limits::eof();
+    }
+
     auto rbegin = itrs_.rbegin();
     for (auto& it : itrs) {
       if (it.score->is_default()) {
@@ -561,22 +579,26 @@ class small_disjunction final
       return;
     }
 
+    auto& score = std::get<irs::score>(attrs_);
+    score.realloc(ord);
+
     // prepare score
     if (scored_begin_ != end_) {
       scores_vals_.resize(size_t(std::distance(scored_begin_, end_)));
 
-      score_.reset(this, [](irs::score_ctx* ctx) -> const byte_type* {
+      score.reset(this, [](irs::score_ctx* ctx) -> const byte_type* {
         auto& self = *static_cast<small_disjunction*>(ctx);
-        auto* score_buf = self.score_.data();
+        auto* score_buf = std::get<irs::score>(self.attrs_).data();
+        auto& doc = std::get<document>(self.attrs_);
         const irs::byte_type** pVal = self.scores_vals_.data();
         for (auto begin = self.scored_begin_, end = self.end_; begin != end; ++begin) {
-          auto doc = begin->value();
+          auto value = begin->value();
 
-          if (doc < self.doc_.value) {
-            doc = (*begin)->seek(self.doc_.value);
+          if (value < doc.value) {
+            value = (*begin)->seek(doc.value);
           }
 
-          if (doc == self.doc_.value) {
+          if (value == doc.value) {
             *pVal++ = begin->score->evaluate();
           }
         }
@@ -588,7 +610,7 @@ class small_disjunction final
         return score_buf;
       });
     } else {
-      assert(score_.is_default());
+      assert(score.is_default());
     }
   }
 
@@ -604,12 +626,14 @@ class small_disjunction final
   }
 
   void hitch_all_iterators() {
-    if (last_hitched_doc_ == doc_.value) {
+    auto& doc = std::get<document>(attrs_);
+
+    if (last_hitched_doc_ == doc.value) {
       return; // nothing to do
     }
     for (auto begin = begin_; begin != end_;++begin) {
       auto& it = *begin;
-      if (it.value() < doc_.value && doc_limits::eof(it->seek(doc_.value))) {
+      if (it.value() < doc.value && doc_limits::eof(it->seek(doc.value))) {
         #ifdef IRESEARCH_DEBUG
           assert(remove_iterator(begin));
         #else
@@ -617,9 +641,10 @@ class small_disjunction final
         #endif
       }
     }
-    last_hitched_doc_ = doc_.value;
+    last_hitched_doc_ = doc.value;
   }
 
+  using attributes_type = std::tuple<document, score, cost>;
   using iterator = typename doc_iterators_t::iterator;
 
   doc_id_t last_hitched_doc_{ doc_limits::invalid() };
@@ -627,9 +652,7 @@ class small_disjunction final
   iterator scored_begin_; // beginning of scored doc iterator range
   iterator begin_; // beginning of unscored doc iterators range
   iterator end_; // end of scored doc iterator range
-  document doc_;
-  score score_;
-  cost cost_;
+  attributes_type attrs_;
   mutable std::vector<const irs::byte_type*> scores_vals_;
   order::prepared::merger merger_;
 }; // small_disjunction
@@ -648,7 +671,7 @@ class small_disjunction final
 ////////////////////////////////////////////////////////////////////////////////
 template<typename DocIterator, typename Adapter = score_iterator_adapter<DocIterator>, bool EnableUnary = false>
 class disjunction final
-    : public frozen_attributes<3, compound_doc_iterator<Adapter>>,
+    : public compound_doc_iterator<Adapter>,
       private score_ctx {
  public:
   using unary_disjunction_t = unary_disjunction<DocIterator, Adapter>;
@@ -687,49 +710,57 @@ class disjunction final
         resolve_overload_tag()) {
   }
 
+  virtual attribute* get_mutable(type_info::type_id type) noexcept override final {
+    return irs::get_mutable(attrs_, type);
+  }
+
   virtual doc_id_t value() const noexcept override {
-    return doc_.value;
+    return std::get<document>(attrs_).value;
   }
 
   virtual bool next() override {
-    if (doc_limits::eof(doc_.value)) {
+    auto& doc = std::get<document>(attrs_);
+
+    if (doc_limits::eof(doc.value)) {
       return false;
     }
 
-    while (lead().value() <= doc_.value) {
-      bool const exhausted = lead().value() == doc_.value
+    while (lead().value() <= doc.value) {
+      bool const exhausted = lead().value() == doc.value
         ? !lead()->next()
-        : doc_limits::eof(lead()->seek(doc_.value + 1));
+        : doc_limits::eof(lead()->seek(doc.value + 1));
 
       if (exhausted && !remove_lead()) {
-        doc_.value = doc_limits::eof();
+        doc.value = doc_limits::eof();
         return false;
       } else {
         refresh_lead();
       }
     }
 
-    doc_.value = lead().value();
+    doc.value = lead().value();
 
     return true;
   }
 
   virtual doc_id_t seek(doc_id_t target) override {
-    if (doc_limits::eof(doc_.value)) {
-      return doc_.value;
+    auto& doc = std::get<document>(attrs_);
+
+    if (doc_limits::eof(doc.value)) {
+      return doc.value;
     }
 
     while (lead().value() < target) {
-      const auto doc = lead()->seek(target);
+      const auto value = lead()->seek(target);
 
-      if (doc_limits::eof(doc) && !remove_lead()) {
-        return doc_.value = doc_limits::eof();
-      } else if (doc != target) {
+      if (doc_limits::eof(value) && !remove_lead()) {
+        return doc.value = doc_limits::eof();
+      } else if (value != target) {
         refresh_lead();
       }
     }
 
-    return doc_.value = lead().value();
+    return doc.value = lead().value();
   }
 
   virtual void visit(void* ctx, bool (*visitor)(void*, Adapter&)) override {
@@ -757,6 +788,8 @@ class disjunction final
  private:
   struct resolve_overload_tag{};
 
+  using attributes_type = std::tuple<document, score, cost>;
+
   template<typename Estimation>
   disjunction(
       doc_iterators_t&& itrs,
@@ -764,22 +797,17 @@ class disjunction final
       sort::MergeType merge_type,
       Estimation&& estimation,
       resolve_overload_tag)
-    : frozen_attributes<3, compound_doc_iterator<Adapter>>{{
-        { type<document>::id(), &doc_   },
-        { type<cost>::id(),     &cost_  },
-        { type<score>::id(),    &score_ },
-      }},
-      itrs_(std::move(itrs)),
-      doc_(itrs_.empty()
-        ? doc_limits::eof()
-        : doc_limits::invalid()),
-      score_(ord),
-      cost_(std::forward<Estimation>(estimation)),
+    : itrs_(std::move(itrs)),
       merger_(ord.prepare_merger(merge_type)) {
     // since we are using heap in order to determine next document,
     // in order to avoid useless make_heap call we expect that all
     // iterators are equal here */
     //assert(irstd::all_equal(itrs_.begin(), itrs_.end()));
+    std::get<cost>(attrs_).reset(std::forward<Estimation>(estimation));
+
+    if (itrs_.empty()) {
+      std::get<document>(attrs_).value = doc_limits::eof();
+    }
 
     // prepare external heap
     heap_.resize(itrs_.size());
@@ -793,21 +821,25 @@ class disjunction final
       return;
     }
 
+    auto& score = std::get<irs::score>(attrs_);
+    score.realloc(ord);
+
     scores_vals_.resize(itrs_.size(), nullptr);
-    score_.reset(this, [](score_ctx* ctx) -> const byte_type* {
+    score.reset(this, [](score_ctx* ctx) -> const byte_type* {
       auto& self = *static_cast<disjunction*>(ctx);
       assert(!self.heap_.empty());
-      auto* score_buf = self.score_.data();
+      auto* score_buf = std::get<irs::score>(self.attrs_).data();
+      auto& doc = std::get<document>(self.attrs_);
 
       const auto its = self.hitch_all_iterators();
       const irs::byte_type** pVal = self.scores_vals_.data();
       detail::evaluate_score_iter(pVal, self.lead());
-      if (self.top().value() == self.doc_.value) {
+      if (self.top().value() == doc.value) {
         irstd::heap::for_each_if(
           its.first, its.second,
-          [&self](const size_t it) {
+          [&self, &doc](const size_t it) noexcept {
             assert(it < self.itrs_.size());
-            return self.itrs_[it].value() == self.doc_.value;
+            return self.itrs_[it].value() == doc.value;
           },
           [&self, &pVal](size_t it) {
             assert(it < self.itrs_.size());
@@ -879,10 +911,11 @@ class disjunction final
     // hitch all iterators in head to the lead (current doc_)
     auto begin = heap_.begin(), end = heap_.end()-1;
 
-    while (begin != end && top().value() < doc_.value) {
-      const auto doc = top()->seek(doc_.value);
+    auto& doc = std::get<document>(attrs_);
+    while (begin != end && top().value() < doc.value) {
+      const auto value = top()->seek(doc.value);
 
-      if (doc_limits::eof(doc)) {
+      if (doc_limits::eof(value)) {
         // remove top
         pop(begin,end);
         std::swap(*--end, heap_.back());
@@ -899,9 +932,7 @@ class disjunction final
   doc_iterators_t itrs_;
   heap_container heap_;
   mutable std::vector<const irs::byte_type*> scores_vals_;
-  document doc_;
-  score score_;
-  cost cost_;
+  attributes_type attrs_;
   order::prepared::merger merger_;
 }; // disjunction
 
@@ -959,9 +990,7 @@ struct block_disjunction_traits {
 template<typename DocIterator,
          typename Traits,
          typename Adapter = score_iterator_adapter<DocIterator>>
-class block_disjunction final
-    : public frozen_attributes<3, doc_iterator>,
-      private score_ctx {
+class block_disjunction final : public doc_iterator, private score_ctx {
  public:
   using traits_type = Traits;
   using adapter  = Adapter;
@@ -1022,11 +1051,17 @@ class block_disjunction final
     return match_count_;
   }
 
+  virtual attribute* get_mutable(type_info::type_id type) noexcept override final {
+    return irs::get_mutable(attrs_, type);
+  }
+
   virtual doc_id_t value() const noexcept override {
-    return doc_.value;
+    return std::get<document>(attrs_).value;
   }
 
   virtual bool next() override {
+    auto& doc = std::get<document>(attrs_);
+
     do {
       while (!cur_) {
         if (begin_ >= std::end(mask_)) {
@@ -1035,7 +1070,7 @@ class block_disjunction final
             break;
           }
 
-          doc_.value = doc_limits::eof();
+          doc.value = doc_limits::eof();
           match_count_ = 0;
 
           return false;
@@ -1061,7 +1096,7 @@ class block_disjunction final
         }
       }
 
-      doc_.value = doc_base_ + doc_id_t(offset);
+      doc.value = doc_base_ + doc_id_t(offset);
       if constexpr (traits_type::score()) {
         score_value_ = score_buf_.get(buf_offset);
       }
@@ -1074,8 +1109,10 @@ class block_disjunction final
   }
 
   virtual doc_id_t seek(doc_id_t target) override {
-    if (target <= doc_.value) {
-      return doc_.value;
+    auto& doc = std::get<document>(attrs_);
+
+    if (target <= doc.value) {
+      return doc.value;
     } else if (target < max_) {
       const doc_id_t block_base = (max_ - window());
 
@@ -1090,27 +1127,27 @@ class block_disjunction final
 
       next();
     } else {
-      doc_.value = doc_limits::eof();
+      doc.value = doc_limits::eof();
 
       if constexpr (traits_type::min_match()) {
         match_count_ = 0;
       }
 
-      visit_and_purge([this, target](auto& it) mutable {
-        const auto doc = it->seek(target);
+      visit_and_purge([this, target, &doc](auto& it) mutable {
+        const auto value = it->seek(target);
 
-        if (doc_limits::eof(doc)) {
+        if (doc_limits::eof(value)) {
           // exhausted
           return false;
         }
 
-        if (doc < doc_.value) {
-          doc_.value = doc;
+        if (value < doc.value) {
+          doc.value = value;
           if constexpr (traits_type::min_match()) {
             match_count_ = 1;
           }
         } else if constexpr (traits_type::min_match()) {
-          if (target == doc) {
+          if (target == value) {
             ++match_count_;
           }
         }
@@ -1119,35 +1156,35 @@ class block_disjunction final
       });
 
       if (itrs_.empty()) {
-        doc_.value = doc_limits::eof();
+        doc.value = doc_limits::eof();
         match_count_ = 0;
 
         return doc_limits::eof();
       }
 
-      assert(!doc_limits::eof(doc_.value));
+      assert(!doc_limits::eof(doc.value));
       cur_ = 0;
       begin_ = std::end(mask_); // enforce "refill()" for upcoming "next()"
-      max_ = doc_.value;
+      max_ = doc.value;
 
       if constexpr (traits_type::seek_readahead()) {
-        min_ = doc_.value;
+        min_ = doc.value;
         next();
       } else {
-        min_ = doc_.value + 1;
+        min_ = doc.value + 1;
         buf_offset_ = 0;
 
         if constexpr (traits_type::min_match()) {
           if (match_count_ < match_buf_.min_match_count()) {
             next();
-            return doc_.value;
+            return doc.value;
           }
         }
 
         if constexpr (traits_type::score()) {
           std::memset(score_buf_.data(), 0, score_buf_.bucket_size());
           for (auto& it : itrs_) {
-            if (!it.score->is_default() && doc_.value == it->value()) {
+            if (!it.score->is_default() && doc.value == it->value()) {
               assert(it.score);
               merger_(score_buf_.data(), it.score->evaluate());
             }
@@ -1158,7 +1195,7 @@ class block_disjunction final
       }
     }
 
-    return doc_.value;
+    return doc.value;
   }
 
  private:
@@ -1183,6 +1220,8 @@ class block_disjunction final
   using min_match_buffer_type = detail::min_match_buffer<
     traits_type::min_match() ? window() : 0>;
 
+  using attributes_type = std::tuple<document, score, cost>;
+
   struct resolve_overload_tag{};
 
   template<typename Estimation>
@@ -1193,24 +1232,24 @@ class block_disjunction final
       sort::MergeType merge_type,
       Estimation&& estimation,
       resolve_overload_tag)
-    : frozen_attributes<3, doc_iterator>{{
-        { type<document>::id(), &doc_   },
-        { type<cost>::id(),     &cost_  },
-        { type<score>::id(),    &score_ },
-      }},
-      itrs_(std::move(itrs)),
-      doc_(itrs_.empty()
-        ? doc_limits::eof()
-        : doc_limits::invalid()),
+    : itrs_(std::move(itrs)),
       match_count_(itrs_.empty()
         ? size_t(0)
         : static_cast<size_t>(!traits_type::min_match())),
-      cost_(std::forward<Estimation>(estimation)),
       score_buf_(ord, window()),
       match_buf_(min_match_count),
       merger_(ord.prepare_merger(merge_type)) {
+    std::get<cost>(attrs_).reset(std::forward<Estimation>(estimation));
+
+    if (itrs_.empty()) {
+      std::get<document>(attrs_).value = doc_limits::eof();
+    }
+
     if (traits_type::score() && !ord.empty()) {
-      score_.reset(this, [](score_ctx* ctx) noexcept -> const byte_type* {
+      auto& score = std::get<irs::score>(attrs_);
+      score.realloc(ord);
+
+      score.reset(this, [](score_ctx* ctx) noexcept -> const byte_type* {
         return static_cast<block_disjunction*>(ctx)->score_value_;
       });
     }
@@ -1380,13 +1419,11 @@ class block_disjunction final
   uint64_t mask_[num_blocks()]{};
   uint64_t* begin_{std::end(mask_)};
   uint64_t cur_{};
-  document doc_;
   doc_id_t doc_base_{doc_limits::invalid()};
   doc_id_t min_{doc_limits::min()}; // base doc id for the next mask
   doc_id_t max_{doc_limits::invalid()}; // max doc id in the current mask
-  score score_;
+  attributes_type attrs_;
   size_t match_count_;
-  cost cost_;
   size_t buf_offset_{}; // offset within a buffer
   score_buffer_type score_buf_;
   min_match_buffer_type match_buf_;

--- a/core/search/disjunction.hpp
+++ b/core/search/disjunction.hpp
@@ -385,11 +385,11 @@ class basic_disjunction final
     return no_score_value_.c_str();
   }
 
-  using attributes_type = std::tuple<document, score, cost>;
+  using attributes = std::tuple<document, score, cost>;
 
   mutable adapter lhs_;
   mutable adapter rhs_;
-  attributes_type attrs_;
+  attributes attrs_;
   bstring no_score_value_; // empty score value
   order::prepared::merger merger_;
 }; // basic_disjunction
@@ -644,7 +644,7 @@ class small_disjunction final
     last_hitched_doc_ = doc.value;
   }
 
-  using attributes_type = std::tuple<document, score, cost>;
+  using attributes = std::tuple<document, score, cost>;
   using iterator = typename doc_iterators_t::iterator;
 
   doc_id_t last_hitched_doc_{ doc_limits::invalid() };
@@ -652,7 +652,7 @@ class small_disjunction final
   iterator scored_begin_; // beginning of scored doc iterator range
   iterator begin_; // beginning of unscored doc iterators range
   iterator end_; // end of scored doc iterator range
-  attributes_type attrs_;
+  attributes attrs_;
   mutable std::vector<const irs::byte_type*> scores_vals_;
   order::prepared::merger merger_;
 }; // small_disjunction
@@ -788,7 +788,7 @@ class disjunction final
  private:
   struct resolve_overload_tag{};
 
-  using attributes_type = std::tuple<document, score, cost>;
+  using attributes = std::tuple<document, score, cost>;
 
   template<typename Estimation>
   disjunction(
@@ -932,7 +932,7 @@ class disjunction final
   doc_iterators_t itrs_;
   heap_container heap_;
   mutable std::vector<const irs::byte_type*> scores_vals_;
-  attributes_type attrs_;
+  attributes attrs_;
   order::prepared::merger merger_;
 }; // disjunction
 
@@ -1220,7 +1220,7 @@ class block_disjunction final : public doc_iterator, private score_ctx {
   using min_match_buffer_type = detail::min_match_buffer<
     traits_type::min_match() ? window() : 0>;
 
-  using attributes_type = std::tuple<document, score, cost>;
+  using attributes = std::tuple<document, score, cost>;
 
   struct resolve_overload_tag{};
 
@@ -1422,7 +1422,7 @@ class block_disjunction final : public doc_iterator, private score_ctx {
   doc_id_t doc_base_{doc_limits::invalid()};
   doc_id_t min_{doc_limits::min()}; // base doc id for the next mask
   doc_id_t max_{doc_limits::invalid()}; // max doc id in the current mask
-  attributes_type attrs_;
+  attributes attrs_;
   size_t match_count_;
   size_t buf_offset_{}; // offset within a buffer
   score_buffer_type score_buf_;

--- a/core/search/min_match_disjunction.hpp
+++ b/core/search/min_match_disjunction.hpp
@@ -84,7 +84,7 @@ class min_match_disjunction
         return cost::extract(lhs, 0) < cost::extract(rhs, 0);
     });
 
-    std::get<cost>(attrs_).rule([this](){
+    std::get<cost>(attrs_).reset([this](){
       return std::accumulate(
         itrs_.begin(), itrs_.end(), cost::cost_t(0),
         [](cost::cost_t lhs, const doc_iterator_t& rhs) {

--- a/core/search/min_match_disjunction.hpp
+++ b/core/search/min_match_disjunction.hpp
@@ -43,7 +43,7 @@ namespace iresearch {
 ////////////////////////////////////////////////////////////////////////////////
 template<typename DocIterator>
 class min_match_disjunction
-    : public frozen_attributes<3, doc_iterator>,
+    : public doc_iterator,
       private score_ctx {
  public:
   struct cost_iterator_adapter : score_iterator_adapter<DocIterator> {
@@ -69,23 +69,10 @@ class min_match_disjunction
       size_t min_match_count = 1,
       const order::prepared& ord = order::prepared::unordered(),
       sort::MergeType merge_type = sort::MergeType::AGGREGATE)
-    : attributes{{
-        { type<document>::id(), &doc_   },
-        { type<cost>::id(),     &cost_  },
-        { type<score>::id(),    &score_ }
-      }},
-      itrs_(std::move(itrs)),
+    : itrs_(std::move(itrs)),
       min_match_count_(
         std::min(itrs_.size(), std::max(size_t(1), min_match_count))),
-      lead_(itrs_.size()), doc_(doc_limits::invalid()),
-      score_(ord),
-      cost_([this](){
-        return std::accumulate(
-          itrs_.begin(), itrs_.end(), cost::cost_t(0),
-          [](cost::cost_t lhs, const doc_iterator_t& rhs) {
-            return lhs + cost::extract(rhs, 0);
-          });
-      }),
+      lead_(itrs_.size()),
       merger_(ord.prepare_merger(merge_type)) {
     assert(!itrs_.empty());
     assert(min_match_count_ >= 1 && min_match_count_ <= itrs_.size());
@@ -97,6 +84,14 @@ class min_match_disjunction
         return cost::extract(lhs, 0) < cost::extract(rhs, 0);
     });
 
+    std::get<cost>(attrs_).rule([this](){
+      return std::accumulate(
+        itrs_.begin(), itrs_.end(), cost::cost_t(0),
+        [](cost::cost_t lhs, const doc_iterator_t& rhs) {
+          return lhs + cost::extract(rhs, 0);
+        });
+    });
+
     // prepare external heap
     heap_.resize(itrs_.size());
     std::iota(heap_.begin(), heap_.end(), size_t(0));
@@ -104,11 +99,17 @@ class min_match_disjunction
     prepare_score(ord);
   }
 
+  virtual attribute* get_mutable(type_info::type_id id) noexcept override {
+    return irs::get_mutable(attrs_, id);
+  }
+
   virtual doc_id_t value() const override {
-    return doc_.value;
+    return std::get<document>(attrs_).value;
   }
 
   virtual bool next() override {
+    auto& doc_ = std::get<document>(attrs_);
+
     if (doc_limits::eof(doc_.value)) {
       return false;
     }
@@ -151,6 +152,8 @@ class min_match_disjunction
   }
 
   virtual doc_id_t seek(doc_id_t target) override {
+    auto& doc_ = std::get<document>(attrs_);
+
     if (target <= doc_.value) {
       return doc_.value;
     }
@@ -242,15 +245,21 @@ class min_match_disjunction
   }
 
  private:
+  using attributes_type = std::tuple<document, cost, score>;
+
   void prepare_score(const order::prepared& ord) {
     if (ord.empty()) {
       return;
     }
 
+    auto& score = std::get<irs::score>(attrs_);
+
+    score.realloc(ord);
+
     scores_vals_.resize(itrs_.size());
-    score_.reset(this, [](score_ctx* ctx) -> const byte_type* {
+    score.reset(this, [](score_ctx* ctx) -> const byte_type* {
       auto& self = *static_cast<min_match_disjunction*>(ctx);
-      auto* score_buf = self.score_.data();
+      auto* score_buf = std::get<irs::score>(self.attrs_).data();
       assert(!self.heap_.empty());
 
       self.push_valid_to_lead();
@@ -275,6 +284,8 @@ class min_match_disjunction
   /// @brief push all valid iterators to lead
   //////////////////////////////////////////////////////////////////////////////
   inline void push_valid_to_lead() {
+    auto& doc_ = std::get<document>(attrs_);
+
     for(auto lead = this->lead(), begin = heap_.begin();
       lead != begin && top().value() <= doc_.value;) {
       // hitch head
@@ -441,9 +452,7 @@ class min_match_disjunction
   mutable std::vector<const irs::byte_type*> scores_vals_;
   size_t min_match_count_; // minimum number of hits
   size_t lead_; // number of iterators in lead group
-  document doc_; // current doc
-  score score_;
-  cost cost_;
+  attributes_type attrs_;
   order::prepared::merger merger_;
 }; // min_match_disjunction
 

--- a/core/search/min_match_disjunction.hpp
+++ b/core/search/min_match_disjunction.hpp
@@ -245,7 +245,7 @@ class min_match_disjunction
   }
 
  private:
-  using attributes_type = std::tuple<document, cost, score>;
+  using attributes = std::tuple<document, cost, score>;
 
   void prepare_score(const order::prepared& ord) {
     if (ord.empty()) {
@@ -452,7 +452,7 @@ class min_match_disjunction
   mutable std::vector<const irs::byte_type*> scores_vals_;
   size_t min_match_count_; // minimum number of hits
   size_t lead_; // number of iterators in lead group
-  attributes_type attrs_;
+  attributes attrs_;
   order::prepared::merger merger_;
 }; // min_match_disjunction
 

--- a/core/search/ngram_similarity_filter.cpp
+++ b/core/search/ngram_similarity_filter.cpp
@@ -69,9 +69,7 @@ class ngram_similarity_doc_iterator final
       min_match_count_(min_match_count),
       total_terms_count_(static_cast<boost_t>(total_terms_count)), // avoid runtime conversion
       empty_order_(ord.empty()) {
-    auto& doc = std::get<attribute_ptr<document>>(attrs_);
-    doc.ptr = irs::get_mutable<document>(&approx_);
-    assert(doc.ptr);
+    std::get<attribute_ptr<document>>(attrs_) = irs::get_mutable<document>(&approx_);
 
     // FIXME find a better estimation
     std::get<cost>(attrs_).reset(

--- a/core/search/ngram_similarity_filter.cpp
+++ b/core/search/ngram_similarity_filter.cpp
@@ -153,7 +153,7 @@ class ngram_similarity_doc_iterator final
 
   using search_states_t = std::map<uint32_t, std::shared_ptr<search_state>, std::greater<uint32_t>>;
   using pos_temp_t = std::vector<std::pair<uint32_t, std::shared_ptr<search_state>>>;
-  using attributes_type = std::tuple<
+  using attributes = std::tuple<
     attribute_ptr<document>,
     frequency,
     cost,
@@ -164,7 +164,7 @@ class ngram_similarity_doc_iterator final
 
   std::vector<position_t> pos_;
   approximation approx_;
-  attributes_type attrs_;
+  attributes attrs_;
   std::set<size_t> used_pos_; // longest sequence positions overlaping detector
   std::vector<const score*> longest_sequence_;
   std::vector<size_t> pos_sequence_;

--- a/core/search/ngram_similarity_filter.cpp
+++ b/core/search/ngram_similarity_filter.cpp
@@ -74,7 +74,7 @@ class ngram_similarity_doc_iterator final
     assert(doc.ptr);
 
     // FIXME find a better estimation
-    std::get<cost>(attrs_).rule(
+    std::get<cost>(attrs_).reset(
       [this](){ return cost::extract(approx_); });
 
     if (!empty_order_) {

--- a/core/search/ngram_similarity_filter.cpp
+++ b/core/search/ngram_similarity_filter.cpp
@@ -66,32 +66,32 @@ class ngram_similarity_doc_iterator final
       const order::prepared& ord = order::prepared::unordered())
     : pos_(itrs.begin(), itrs.end()),
       approx_(std::move(itrs), min_match_count), // we are not interested in disjunction`s scoring
-      doc_(irs::get_mutable<document>(&approx_)),
-      attrs_{{
-        { type<document>::id(),     doc_           },
-        { type<frequency>::id(),    &seq_freq_     },
-        { type<cost>::id(),         &cost_         },
-        { type<score>::id(),        &score_        },
-        { type<filter_boost>::id(), &filter_boost_ },
-      }},
       min_match_count_(min_match_count),
       total_terms_count_(static_cast<boost_t>(total_terms_count)), // avoid runtime conversion
-      cost_([this](){ return cost::extract(approx_); }), // FIXME find a better estimation
-      score_(ord),
       empty_order_(ord.empty()) {
-    assert(doc_);
+    auto& doc = std::get<attribute_ptr<document>>(attrs_);
+    doc.ptr = irs::get_mutable<document>(&approx_);
+    assert(doc.ptr);
+
+    // FIXME find a better estimation
+    std::get<cost>(attrs_).rule(
+      [this](){ return cost::extract(approx_); });
 
     if (!empty_order_) {
+      auto& score = std::get<irs::score>(attrs_);
+
+      score.realloc(ord);
+
       order::prepared::scorers scorers(
         ord, segment, field, stats,
-        score_.data(), *this, boost);
+        score.data(), *this, boost);
 
-      irs::reset(score_, std::move(scorers));
+      irs::reset(score, std::move(scorers));
     }
   }
 
   virtual attribute* get_mutable(type_info::type_id type) noexcept override {
-    return attrs_.get_mutable(type);
+    return irs::get_mutable(attrs_, type);
   }
 
   virtual bool next() override {
@@ -101,10 +101,12 @@ class ngram_similarity_doc_iterator final
   }
 
   virtual doc_id_t value() const override {
-    return doc_->value;
+    return std::get<attribute_ptr<document>>(attrs_).ptr->value;
   }
 
   virtual doc_id_t seek(doc_id_t target) override {
+    auto* doc_ = std::get<attribute_ptr<document>>(attrs_).ptr;
+
     if (doc_->value >= target) {
       return doc_->value;
     }
@@ -153,23 +155,24 @@ class ngram_similarity_doc_iterator final
 
   using search_states_t = std::map<uint32_t, std::shared_ptr<search_state>, std::greater<uint32_t>>;
   using pos_temp_t = std::vector<std::pair<uint32_t, std::shared_ptr<search_state>>>;
+  using attributes_type = std::tuple<
+    attribute_ptr<document>,
+    frequency,
+    cost,
+    score,
+    filter_boost>;
 
   bool check_serial_positions();
 
   std::vector<position_t> pos_;
   approximation approx_;
-  document* doc_;
-  frozen_attributes<5, attribute_provider> attrs_;
+  attributes_type attrs_;
   std::set<size_t> used_pos_; // longest sequence positions overlaping detector
   std::vector<const score*> longest_sequence_;
   std::vector<size_t> pos_sequence_;
-  frequency seq_freq_; // longest sequence frequency
-  filter_boost filter_boost_;
   size_t min_match_count_;
   search_states_t search_buf_;
   boost_t total_terms_count_;
-  cost cost_;
-  score score_;
   bool empty_order_;
 };
 
@@ -177,6 +180,10 @@ bool ngram_similarity_doc_iterator::check_serial_positions() {
   size_t potential = approx_.match_count(); // how long max sequence could be in the best case
   search_buf_.clear();
   size_t longest_sequence_len = 0;
+
+  auto* doc_ = std::get<attribute_ptr<document>>(attrs_).ptr;
+  auto& seq_freq_ = std::get<frequency>(attrs_);
+
   seq_freq_.value = 0;
   for (const auto& pos_iterator : pos_) {
     if (pos_iterator.doc->value == doc_->value) {
@@ -348,7 +355,8 @@ bool ngram_similarity_doc_iterator::check_serial_positions() {
     }
     seq_freq_.value = freq;
     assert(!pos_.empty());
-    filter_boost_.value = static_cast<boost_t>(longest_sequence_len) / total_terms_count_;
+    std::get<filter_boost>(attrs_).value
+      = static_cast<boost_t>(longest_sequence_len) / total_terms_count_;
   }
   return longest_sequence_len >= min_match_count_;
 }

--- a/core/search/phrase_iterator.hpp
+++ b/core/search/phrase_iterator.hpp
@@ -444,11 +444,9 @@ class phrase_iterator final : public doc_iterator {
       boost_t boost)
     : approx_(std::move(itrs)),
       freq_(std::move(pos), ord) {
-    auto& doc = std::get<attribute_ptr<document>>(attrs_);
-    doc.ptr = irs::get_mutable<document>(&approx_);;
-    assert(doc.ptr);
-    std::get<attribute_ptr<frequency>>(attrs_).ptr = freq_.freq();
-    std::get<attribute_ptr<filter_boost>>(attrs_).ptr = freq_.boost();
+    std::get<attribute_ptr<document>>(attrs_) = irs::get_mutable<document>(&approx_);
+    std::get<attribute_ptr<frequency>>(attrs_) = freq_.freq();
+    std::get<attribute_ptr<filter_boost>>(attrs_) = freq_.boost();
 
     // FIXME find a better estimation
     std::get<irs::cost>(attrs_).reset(

--- a/core/search/phrase_iterator.hpp
+++ b/core/search/phrase_iterator.hpp
@@ -451,7 +451,7 @@ class phrase_iterator final : public doc_iterator {
     std::get<attribute_ptr<filter_boost>>(attrs_).ptr = freq_.boost();
 
     // FIXME find a better estimation
-    std::get<irs::cost>(attrs_).rule(
+    std::get<irs::cost>(attrs_).reset(
       [this](){ return cost::extract(approx_); });
 
     if (!ord.empty()) {

--- a/core/search/phrase_iterator.hpp
+++ b/core/search/phrase_iterator.hpp
@@ -499,7 +499,7 @@ class phrase_iterator final : public doc_iterator {
 
  private:
   // FIXME can store only 4 attrbiutes for non-volatile boost case
-  using attributes_type = std::tuple<
+  using attributes = std::tuple<
     attribute_ptr<document>,
     cost,
     score,
@@ -508,7 +508,7 @@ class phrase_iterator final : public doc_iterator {
 
   Conjunction approx_; // first approximation (conjunction over all words in a phrase)
   Frequency freq_;
-  attributes_type attrs_;
+  attributes attrs_;
 }; // phrase_iterator
 
 } // ROOT

--- a/core/search/phrase_iterator.hpp
+++ b/core/search/phrase_iterator.hpp
@@ -443,34 +443,36 @@ class phrase_iterator final : public doc_iterator {
       const order::prepared& ord,
       boost_t boost)
     : approx_(std::move(itrs)),
-      freq_(std::move(pos), ord),
-      doc_(irs::get_mutable<document>(&approx_)),
-      attrs_{{
-        { type<document>::id(),     doc_          },
-        { type<cost>::id(),         &cost_        },
-        { type<score>::id(),        &score_       },
-        { type<frequency>::id(),    freq_.freq()  },
-        { type<filter_boost>::id(), freq_.boost() },
-      }},
-      score_(ord),
-      cost_([this](){ return cost::extract(approx_); }) { // FIXME find a better estimation
-    assert(doc_);
+      freq_(std::move(pos), ord) {
+    auto& doc = std::get<attribute_ptr<document>>(attrs_);
+    doc.ptr = irs::get_mutable<document>(&approx_);;
+    assert(doc.ptr);
+    std::get<attribute_ptr<frequency>>(attrs_).ptr = freq_.freq();
+    std::get<attribute_ptr<filter_boost>>(attrs_).ptr = freq_.boost();
+
+    // FIXME find a better estimation
+    std::get<irs::cost>(attrs_).rule(
+      [this](){ return cost::extract(approx_); });
 
     if (!ord.empty()) {
+      auto& score = std::get<irs::score>(attrs_);
+
+      score.realloc(ord);
+
       order::prepared::scorers scorers(
         ord, segment, field, stats,
-        score_.data(), *this, boost);
+        score.data(), *this, boost);
 
-      irs::reset(score_, std::move(scorers));
+      irs::reset(score, std::move(scorers));
     }
   }
 
   virtual attribute* get_mutable(type_info::type_id type) noexcept override {
-    return attrs_.get_mutable(type);
+    return irs::get_mutable(attrs_, type);
   }
 
   virtual doc_id_t value() const override final {
-    return doc_->value;
+    return std::get<attribute_ptr<document>>(attrs_).ptr->value;
   }
 
   virtual bool next() override {
@@ -481,9 +483,11 @@ class phrase_iterator final : public doc_iterator {
   }
 
   virtual doc_id_t seek(doc_id_t target) override {
+    auto* pdoc = std::get<attribute_ptr<document>>(attrs_).ptr;
+
     // important to call freq_() in order
     // to set attribute values
-    const auto prev = doc_->value;
+    const auto prev = pdoc->value;
     const auto doc = approx_.seek(target);
 
     if (prev == doc || freq_()) {
@@ -492,16 +496,21 @@ class phrase_iterator final : public doc_iterator {
 
     next();
 
-    return doc_->value;
+    return pdoc->value;
   }
 
  private:
+  // FIXME can store only 4 attrbiutes for non-volatile boost case
+  using attributes_type = std::tuple<
+    attribute_ptr<document>,
+    cost,
+    score,
+    attribute_ptr<frequency>,
+    attribute_ptr<filter_boost>>;
+
   Conjunction approx_; // first approximation (conjunction over all words in a phrase)
   Frequency freq_;
-  document* doc_{}; // document itself
-  frozen_attributes<5, attribute_provider> attrs_; // FIXME can store only 4 attrbiutes for non-volatile boost case
-  score score_;
-  cost cost_;
+  attributes_type attrs_;
 }; // phrase_iterator
 
 } // ROOT

--- a/core/search/score.hpp
+++ b/core/search/score.hpp
@@ -51,7 +51,7 @@ class IRESEARCH_API score : public attribute {
 
   bool is_default() const noexcept;
 
-  [[nodiscard]] const byte_type* evaluate() const {
+  [[nodiscard]] FORCE_INLINE const byte_type* evaluate() const {
     assert(func_);
     return func_();
   }

--- a/core/utils/frozen_attributes.hpp
+++ b/core/utils/frozen_attributes.hpp
@@ -28,6 +28,28 @@
 #include "attribute_provider.hpp"
 
 namespace iresearch {
+namespace detail {
+
+template<size_t I, typename... T>
+constexpr attribute* get_mutable_helper(std::tuple<T...>& t, type_info::type_id id) noexcept {
+   auto& v = std::get<I>(t);
+   if (type<std::remove_reference_t<decltype(v)>>::id() == id) {
+     return &v;
+   }
+
+   if constexpr (I < std::tuple_size<std::tuple<T...>>::value - 1) {
+     return get_mutable_helper<I+1>(t, id);
+   } else {
+     return nullptr;
+   }
+}
+
+}
+
+template<typename... T>
+constexpr attribute* get_mutable(std::tuple<T...>& t, type_info::type_id id) noexcept {
+  return detail::get_mutable_helper<0>(t, id);
+}
 
 template<
   size_t Size,

--- a/core/utils/frozen_attributes.hpp
+++ b/core/utils/frozen_attributes.hpp
@@ -28,19 +28,34 @@
 #include "attribute_provider.hpp"
 
 namespace iresearch {
+template<typename T>
+struct attribute_ptr {
+  T* ptr{};
+
+  attribute_ptr() = default;
+  attribute_ptr(T& v) noexcept : ptr(&v) { }
+
+  operator attribute_ptr<attribute>() const noexcept {
+    return attribute_ptr<attribute>{*ptr};
+  }
+};
+
+template<typename T>
+struct type<attribute_ptr<T>> : type<T> { };
+
 namespace detail {
 
 template<size_t I, typename... T>
-constexpr attribute* get_mutable_helper(std::tuple<T...>& t, type_info::type_id id) noexcept {
+constexpr attribute_ptr<attribute> get_mutable_helper(std::tuple<T...>& t, type_info::type_id id) noexcept {
    auto& v = std::get<I>(t);
    if (type<std::remove_reference_t<decltype(v)>>::id() == id) {
-     return &v;
+     return v;
    }
 
    if constexpr (I < std::tuple_size<std::tuple<T...>>::value - 1) {
      return get_mutable_helper<I+1>(t, id);
    } else {
-     return nullptr;
+     return {};
    }
 }
 
@@ -48,7 +63,7 @@ constexpr attribute* get_mutable_helper(std::tuple<T...>& t, type_info::type_id 
 
 template<typename... T>
 constexpr attribute* get_mutable(std::tuple<T...>& t, type_info::type_id id) noexcept {
-  return detail::get_mutable_helper<0>(t, id);
+  return detail::get_mutable_helper<0>(t, id).ptr;
 }
 
 template<

--- a/core/utils/frozen_attributes.hpp
+++ b/core/utils/frozen_attributes.hpp
@@ -34,6 +34,7 @@ struct attribute_ptr {
 
   attribute_ptr() = default;
   attribute_ptr(T& v) noexcept : ptr(&v) { }
+  attribute_ptr(T* v) noexcept : ptr(v) { }
 
   operator attribute_ptr<attribute>() const noexcept {
     return attribute_ptr<attribute>{*ptr};

--- a/core/utils/frozen_attributes.hpp
+++ b/core/utils/frozen_attributes.hpp
@@ -38,7 +38,7 @@ struct attribute_ptr {
   attribute_ptr(T* v) noexcept : ptr(v) { }
 
   operator attribute_ptr<attribute>() const noexcept {
-    return attribute_ptr<attribute>{*ptr};
+    return attribute_ptr<attribute>{ptr};
   }
 }; // attribute_ptr
 

--- a/core/utils/frozen_attributes.hpp
+++ b/core/utils/frozen_attributes.hpp
@@ -28,6 +28,7 @@
 #include "attribute_provider.hpp"
 
 namespace iresearch {
+
 template<typename T>
 struct attribute_ptr {
   T* ptr{};
@@ -39,7 +40,7 @@ struct attribute_ptr {
   operator attribute_ptr<attribute>() const noexcept {
     return attribute_ptr<attribute>{*ptr};
   }
-};
+}; // attribute_ptr
 
 template<typename T>
 struct type<attribute_ptr<T>> : type<T> { };

--- a/tests/index/assert_format.cpp
+++ b/tests/index/assert_format.cpp
@@ -448,7 +448,7 @@ doc_iterator::doc_iterator(const irs::flags& features, const tests::term& data)
     pos_(*this, features) {
   next_ = data_.postings.begin();
 
-  cost_.value(data_.postings.size());
+  cost_.reset(data_.postings.size());
   attrs_[irs::type<irs::cost>::id()] = &cost_;
 
   attrs_[irs::type<irs::document>::id()] = &doc_;

--- a/tests/search/boolean_filter_tests.cpp
+++ b/tests/search/boolean_filter_tests.cpp
@@ -144,7 +144,7 @@ class basic_doc_iterator: public irs::doc_iterator, irs::score_ctx {
       last_(last),
       stats_(stats),
       doc_(irs::doc_limits::invalid()) {
-    est_.value(std::distance(first_, last_));
+    est_.reset(std::distance(first_, last_));
     attrs_[irs::type<irs::cost>::id()] = &est_;
     attrs_[irs::type<irs::document>::id()] = &doc_;
 
@@ -1260,7 +1260,7 @@ DEFINE_FACTORY_DEFAULT(unestimated)
 struct estimated: public irs::filter {
   struct doc_iterator : irs::doc_iterator {
     doc_iterator(irs::cost::cost_t est, bool* evaluated) {
-      cost.rule([est, evaluated]() {
+      cost.reset([est, evaluated]() {
         *evaluated = true;
         return est;
       });

--- a/tests/search/cost_attribute_test.cpp
+++ b/tests/search/cost_attribute_test.cpp
@@ -47,7 +47,7 @@ TEST(cost_attribute_test, estimation) {
 
     // set estimation value and check
     {
-      cost.value(est);
+      cost.reset(est);
       ASSERT_EQ(est, cost.estimate());
     }
   }
@@ -57,7 +57,7 @@ TEST(cost_attribute_test, estimation) {
     auto evaluated = false;
     auto est = 7;
   
-    cost.rule([&evaluated, est]() {
+    cost.reset([&evaluated, est]() {
       evaluated = true;
       return est;
     });
@@ -77,7 +77,7 @@ TEST(cost_attribute_test, lazy_estimation) {
   // set estimation function and evaluate
   {
     evaluated = false;
-    cost.rule([&evaluated, est]() {
+    cost.reset([&evaluated, est]() {
       evaluated = true;
       return est;
     });
@@ -96,7 +96,7 @@ TEST(cost_attribute_test, lazy_estimation) {
   // change estimation func
   {
     evaluated = false;
-    cost.rule([&evaluated, est]() {
+    cost.reset([&evaluated, est]() {
       evaluated = true;
       return est+1;
     });
@@ -108,7 +108,7 @@ TEST(cost_attribute_test, lazy_estimation) {
   // set value directly
   {
     evaluated = false;
-    cost.value(est+2);
+    cost.reset(est+2);
     ASSERT_FALSE(evaluated);
     ASSERT_EQ(est+2, cost.estimate());
     ASSERT_FALSE(evaluated);
@@ -140,7 +140,7 @@ TEST(cost_attribute_test, extract) {
 
   // set estimation function and evaluate
   {
-    cost.rule([&evaluated, est]() {
+    cost.reset([&evaluated, est]() {
       evaluated = true;
       return est;
     });
@@ -152,7 +152,7 @@ TEST(cost_attribute_test, extract) {
   // change estimation func
   {
     evaluated = false;
-    cost.rule([&evaluated, est]() {
+    cost.reset([&evaluated, est]() {
       evaluated = true;
       return est+1;
     });


### PR DESCRIPTION
According to benchmarks building a `frozen::map<...>` takes a noticeable portion of time (3-4%). Given the number of attributes is usually small, an unwinded linear search seems to be the fastest possible solution with no overhead.

http://jenkins01.arangodb.biz:8080/view/PR/job/iresearch_s-pr/167/