### PR TITLE
Bug fix/fix asan issue pipeline

### DIFF
--- a/tests/analysis/pipeline_stream_tests.cpp
+++ b/tests/analysis/pipeline_stream_tests.cpp
@@ -647,10 +647,11 @@ TEST(pipeline_token_stream_test, normalize_json) {
 }
 
 TEST(pipeline_token_stream_test, analyzers_with_payload_offset) {
-  irs::bytes_ref test_payload{ { 0x1, 0x2, 0x3 }, 3 };
-  irs::bytes_ref test_payload2{ { 0x11, 0x22, 0x33 }, 3 };
-  pipeline_test_analyzer payload_offset(true, test_payload);
-  pipeline_test_analyzer only_payload(false, test_payload2);
+  // store as separate arrays to meke asan happy
+  iresearch::byte_type p1[] = { 0x1, 0x2, 0x3 };
+  iresearch::byte_type p2[] = { 0x11, 0x22, 0x33 };
+  pipeline_test_analyzer payload_offset(true, p1);
+  pipeline_test_analyzer only_payload(false, p2);
   pipeline_test_analyzer only_offset(true, irs::bytes_ref::NIL);
   pipeline_test_analyzer no_payload_no_offset(false, irs::bytes_ref::NIL);
 
@@ -669,7 +670,7 @@ TEST(pipeline_token_stream_test, analyzers_with_payload_offset) {
     ASSERT_TRUE(pay);
     ASSERT_TRUE(pipe.reset("A"));
     ASSERT_TRUE(pipe.next());
-    ASSERT_EQ(test_payload, pay->value);
+    ASSERT_EQ(p1, pay->value);
   }
   {
     irs::analysis::pipeline_token_stream::options_t pipeline_options;
@@ -686,7 +687,7 @@ TEST(pipeline_token_stream_test, analyzers_with_payload_offset) {
     ASSERT_TRUE(pay);
     ASSERT_TRUE(pipe.reset("A"));
     ASSERT_TRUE(pipe.next());
-    ASSERT_EQ(test_payload, pay->value);
+    ASSERT_EQ(p1, pay->value);
   }
   {
     irs::analysis::pipeline_token_stream::options_t pipeline_options;
@@ -703,7 +704,7 @@ TEST(pipeline_token_stream_test, analyzers_with_payload_offset) {
     ASSERT_TRUE(pay);
     ASSERT_TRUE(pipe.reset("A"));
     ASSERT_TRUE(pipe.next());
-    ASSERT_EQ(test_payload2, pay->value);
+    ASSERT_EQ(p2, pay->value);
   }
   {
     irs::analysis::pipeline_token_stream::options_t pipeline_options;
@@ -720,7 +721,7 @@ TEST(pipeline_token_stream_test, analyzers_with_payload_offset) {
     ASSERT_TRUE(pay);
     ASSERT_TRUE(pipe.reset("A"));
     ASSERT_TRUE(pipe.next());
-    ASSERT_EQ(test_payload, pay->value);
+    ASSERT_EQ(p1, pay->value);
   }
   {
     irs::analysis::pipeline_token_stream::options_t pipeline_options;
@@ -737,7 +738,7 @@ TEST(pipeline_token_stream_test, analyzers_with_payload_offset) {
     ASSERT_TRUE(pay);
     ASSERT_TRUE(pipe.reset("A"));
     ASSERT_TRUE(pipe.next());
-    ASSERT_EQ(test_payload2, pay->value);
+    ASSERT_EQ(p2, pay->value);
   }
 }
 

--- a/tests/analysis/pipeline_stream_tests.cpp
+++ b/tests/analysis/pipeline_stream_tests.cpp
@@ -647,7 +647,7 @@ TEST(pipeline_token_stream_test, normalize_json) {
 }
 
 TEST(pipeline_token_stream_test, analyzers_with_payload_offset) {
-  // store as separate arrays to meke asan happy
+  // store as separate arrays to make asan happy
   iresearch::byte_type p1[] = { 0x1, 0x2, 0x3 };
   iresearch::byte_type p2[] = { 0x11, 0x22, 0x33 };
   pipeline_test_analyzer payload_offset(true, p1);
@@ -670,7 +670,7 @@ TEST(pipeline_token_stream_test, analyzers_with_payload_offset) {
     ASSERT_TRUE(pay);
     ASSERT_TRUE(pipe.reset("A"));
     ASSERT_TRUE(pipe.next());
-    ASSERT_EQ(p1, pay->value);
+    ASSERT_EQ(p1, pay->value.c_str());
   }
   {
     irs::analysis::pipeline_token_stream::options_t pipeline_options;
@@ -687,7 +687,7 @@ TEST(pipeline_token_stream_test, analyzers_with_payload_offset) {
     ASSERT_TRUE(pay);
     ASSERT_TRUE(pipe.reset("A"));
     ASSERT_TRUE(pipe.next());
-    ASSERT_EQ(p1, pay->value);
+    ASSERT_EQ(p1, pay->value.c_str());
   }
   {
     irs::analysis::pipeline_token_stream::options_t pipeline_options;
@@ -704,7 +704,7 @@ TEST(pipeline_token_stream_test, analyzers_with_payload_offset) {
     ASSERT_TRUE(pay);
     ASSERT_TRUE(pipe.reset("A"));
     ASSERT_TRUE(pipe.next());
-    ASSERT_EQ(p2, pay->value);
+    ASSERT_EQ(p2, pay->value.c_str());
   }
   {
     irs::analysis::pipeline_token_stream::options_t pipeline_options;
@@ -721,7 +721,7 @@ TEST(pipeline_token_stream_test, analyzers_with_payload_offset) {
     ASSERT_TRUE(pay);
     ASSERT_TRUE(pipe.reset("A"));
     ASSERT_TRUE(pipe.next());
-    ASSERT_EQ(p1, pay->value);
+    ASSERT_EQ(p1, pay->value.c_str());
   }
   {
     irs::analysis::pipeline_token_stream::options_t pipeline_options;
@@ -738,7 +738,7 @@ TEST(pipeline_token_stream_test, analyzers_with_payload_offset) {
     ASSERT_TRUE(pay);
     ASSERT_TRUE(pipe.reset("A"));
     ASSERT_TRUE(pipe.next());
-    ASSERT_EQ(p2, pay->value);
+    ASSERT_EQ(p2, pay->value.c_str());
   }
 }
 


### PR DESCRIPTION
adress ASAN reported issue - byte refs were compered like strings in tests. store array explicitly and check just pointers

https://jenkins.arangodb.biz/view/iResearch/job/iresearch-release-s/1233/