### PR TITLE
added explicit hex encoding

### DIFF
--- a/core/analysis/token_stopwords_stream.cpp
+++ b/core/analysis/token_stopwords_stream.cpp
@@ -118,7 +118,7 @@ irs::analysis::analyzer::ptr make_vpack(const irs::string_ref& args) {
     case arangodb::velocypack::ValueType::Array:
       return construct(arangodb::velocypack::ArrayIterator(slice), false); // arrays are always verbatim
     case arangodb::velocypack::ValueType::Object: {
-      auto hex_slice = slice.get(HEX_PARAM_NAME);
+      auto hex_slice = slice.get(HEX_PARAM_NAME.c_str());
       if (!hex_slice.isBool() && !hex_slice.isNone()) {
         IR_FRMT_ERROR(
           "Invalid vpack while constructing token_stopwords_stream from jSON arguments: %s. %s value should be boolean.",
@@ -126,7 +126,7 @@ irs::analysis::analyzer::ptr make_vpack(const irs::string_ref& args) {
         return nullptr;
       }
       bool hex = hex_slice.isBool() ? hex_slice.getBoolean() : false;
-      auto mask_slice = slice.get(STOPWORDS_PARAM_NAME);
+      auto mask_slice = slice.get(STOPWORDS_PARAM_NAME.c_str());
       if (mask_slice.isArray()) {
         return construct(arangodb::velocypack::ArrayIterator(mask_slice), hex);
       } else {
@@ -179,7 +179,7 @@ bool normalize_vpack_config(const irs::string_ref& args, std::string& definition
     }
     case arangodb::velocypack::ValueType::Object:
     {
-      auto hex_slice = slice.get(HEX_PARAM_NAME);
+      auto hex_slice = slice.get(HEX_PARAM_NAME.c_str());
       if (!hex_slice.isBool() && !hex_slice.isNone()) {
         IR_FRMT_ERROR(
           "Invalid vpack while normalizing token_stopwords_stream from jSON arguments: %s. %s value should be boolean.",

--- a/core/analysis/token_stopwords_stream.cpp
+++ b/core/analysis/token_stopwords_stream.cpp
@@ -66,6 +66,9 @@ bool hex_decode(std::string& buf, arangodb::velocypack::StringRef value) {
     auto lo = HEX_DECODE_MAP[size_t(value[i + 1])];
 
     if (hi >= 16 || lo >= 16) {
+      IR_FRMT_WARN(
+      "Invalid character while HEX decoding masked token: %s",
+      value.data());
       return false;
     }
 
@@ -75,7 +78,7 @@ bool hex_decode(std::string& buf, arangodb::velocypack::StringRef value) {
   return true;
 }
 
-irs::analysis::analyzer::ptr construct(const arangodb::velocypack::ArrayIterator& mask) {
+irs::analysis::analyzer::ptr construct(const arangodb::velocypack::ArrayIterator& mask, bool hex) {
   size_t offset = 0;
   irs::analysis::token_stopwords_stream::stopwords_set tokens;
 
@@ -87,22 +90,22 @@ irs::analysis::analyzer::ptr construct(const arangodb::velocypack::ArrayIterator
 
       return nullptr;
     }
-
     std::string token;
     auto value = (*itr).stringRef();
-
-    if (!hex_decode(token, value)) {
+    if (!hex) {
       tokens.emplace(std::string(value.data(), value.length())); // interpret verbatim
-    } else {
+    } else if (hex_decode(token, value)) {
       tokens.emplace(std::move(token));
+    } else {
+      return nullptr; // hex-decoding failed
     }
   }
-
   return irs::memory::make_shared<irs::analysis::token_stopwords_stream>(
     std::move(tokens));
 }
 
 constexpr irs::string_ref STOPWORDS_PARAM_NAME = "stopwords";
+constexpr irs::string_ref HEX_PARAM_NAME = "hex";
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief args is a jSON encoded object with the following attributes:
@@ -113,15 +116,26 @@ irs::analysis::analyzer::ptr make_vpack(const irs::string_ref& args) {
   arangodb::velocypack::Slice slice(reinterpret_cast<uint8_t const*>(args.c_str()));
   switch (slice.type()) {
     case arangodb::velocypack::ValueType::Array:
-      return construct(arangodb::velocypack::ArrayIterator(slice));
-    case arangodb::velocypack::ValueType::Object:
-    {
-      auto maskSlice = slice.get(STOPWORDS_PARAM_NAME.c_str());
-      if (maskSlice.isArray()) {
-        return construct(arangodb::velocypack::ArrayIterator(maskSlice));
+      return construct(arangodb::velocypack::ArrayIterator(slice), false); // arrays are always verbatim
+    case arangodb::velocypack::ValueType::Object: {
+      auto hex_slice = slice.get(HEX_PARAM_NAME);
+      if (!hex_slice.isBool() && !hex_slice.isNone()) {
+        IR_FRMT_ERROR(
+          "Invalid vpack while constructing token_stopwords_stream from jSON arguments: %s. %s value should be boolean.",
+          slice.toString().c_str(), HEX_PARAM_NAME.c_str());
+        return nullptr;
+      }
+      bool hex = hex_slice.isBool() ? hex_slice.getBoolean() : false;
+      auto mask_slice = slice.get(STOPWORDS_PARAM_NAME);
+      if (mask_slice.isArray()) {
+        return construct(arangodb::velocypack::ArrayIterator(mask_slice), hex);
+      } else {
+        IR_FRMT_ERROR(
+          "Invalid vpack while constructing token_stopwords_stream from jSON arguments: %s. %s value should be array.",
+          slice.toString().c_str(), STOPWORDS_PARAM_NAME.c_str());
+        return nullptr;
       }
     }
-    [[fallthrough]];
     default: {
       IR_FRMT_ERROR(
         "Invalid vpack while constructing token_stopwords_stream from jSON arguments: %s. Array or Object was expected. Got %s",
@@ -158,23 +172,37 @@ bool normalize_vpack_config(const irs::string_ref& args, std::string& definition
       arangodb::velocypack::Builder builder;
       builder.openObject();
       builder.add(STOPWORDS_PARAM_NAME.c_str(), slice);
+      builder.add(HEX_PARAM_NAME.c_str(), arangodb::velocypack::Value(false));
       builder.close();
       definition.assign(builder.slice().startAs<char>(), builder.slice().byteSize());
       return true;
     }
     case arangodb::velocypack::ValueType::Object:
     {
-      auto maskSlice = slice.get(STOPWORDS_PARAM_NAME.c_str());
-      if (maskSlice.isArray()) {
+      auto hex_slice = slice.get(HEX_PARAM_NAME);
+      if (!hex_slice.isBool() && !hex_slice.isNone()) {
+        IR_FRMT_ERROR(
+          "Invalid vpack while normalizing token_stopwords_stream from jSON arguments: %s. %s value should be boolean.",
+          slice.toString().c_str(), HEX_PARAM_NAME.c_str());
+        return false;
+      }
+      bool hex = hex_slice.isBool() ? hex_slice.getBoolean() : false;
+      auto mask_slice = slice.get(STOPWORDS_PARAM_NAME.c_str());
+      if (mask_slice.isArray()) {
         arangodb::velocypack::Builder builder;
         builder.openObject();
-        builder.add(STOPWORDS_PARAM_NAME.c_str(), maskSlice);
+        builder.add(STOPWORDS_PARAM_NAME.c_str(), mask_slice);
+        builder.add(HEX_PARAM_NAME.c_str(), arangodb::velocypack::Value(hex));
         builder.close();
         definition.assign(builder.slice().startAs<char>(), builder.slice().byteSize());
         return true;
+      } else {
+        IR_FRMT_ERROR(
+          "Invalid vpack while constructing token_stopwords_stream from jSON arguments: %s. %s value should be array.",
+          slice.toString().c_str(), STOPWORDS_PARAM_NAME.c_str());
+        return false;
       }
     }
-    [[fallthrough]];
     default: {
       IR_FRMT_ERROR(
         "Invalid vpack while normalizing token_stopwords_stream from jSON arguments: %s. Array or Object was expected. Got %s",
@@ -244,7 +272,6 @@ bool token_stopwords_stream::reset(const string_ref& data) {
   auto& term = std::get<term_attribute>(attrs_);
   term.value = irs::ref_cast<irs::byte_type>(data);
   term_eof_ = stopwords_.contains(data);
-
   return true;
 }
 

--- a/tests/analysis/token_stopwords_stream_tests.cpp
+++ b/tests/analysis/token_stopwords_stream_tests.cpp
@@ -109,16 +109,18 @@ TEST(token_stopwords_stream_tests, test_load) {
     auto stream = irs::analysis::analyzers::get("stopwords", irs::type<irs::text_format::json>::get(), "[ \"abc\", \"646566\", \"6D6e6F\" ]");
     testFunc(data0, data1, stream);
 
+    // check with another order of mask
+    auto stream2 = irs::analysis::analyzers::get("stopwords", irs::type<irs::text_format::json>::get(), "[ \"6D6e6F\", \"abc\", \"646566\" ]");
+    testFunc(data0, data1, stream2);
+
     auto streamFromJsonObjest = irs::analysis::analyzers::get("stopwords", irs::type<irs::text_format::json>::get(), "{\"stopwords\":[ \"abc\", \"646566\", \"6D6e6F\" ]}");
     testFunc(data0, data1, streamFromJsonObjest);
-
   }
 
   // load jSON object (mask string hex)
   {
     irs::string_ref data0("abc");
     irs::string_ref data1("646566");
- 
 
     auto testFunc = [](const irs::string_ref& data0, const irs::string_ref& data1, irs::analysis::analyzer::ptr stream) {
       ASSERT_NE(nullptr, stream);
@@ -135,14 +137,9 @@ TEST(token_stopwords_stream_tests, test_load) {
       ASSERT_EQ("646566", irs::ref_cast<char>(term->value));
       ASSERT_FALSE(stream->next());
     };
-
-    auto stream = irs::analysis::analyzers::get("stopwords", irs::type<irs::text_format::json>::get(), "[ \"abc\", \"646566\", \"6D6e6F\" ]");
-    testFunc(data0, data1, stream);
-
-
-    auto streamFromJsonObjest = irs::analysis::analyzers::get("stopwords", irs::type<irs::text_format::json>::get(), "{\"stopwords\":[ \"abc\", \"646566\", \"6D6e6F\" ]}");
+    auto streamFromJsonObjest = irs::analysis::analyzers::get("stopwords", irs::type<irs::text_format::json>::get(), "{\"stopwords\":[ \"616263\", \"6D6e6F\" ], \"hex\":true}");
+    ASSERT_TRUE(streamFromJsonObjest);
     testFunc(data0, data1, streamFromJsonObjest);
-
   }
 
   // load jSON invalid
@@ -152,6 +149,9 @@ TEST(token_stopwords_stream_tests, test_load) {
     ASSERT_EQ(nullptr, irs::analysis::analyzers::get("stopwords", irs::type<irs::text_format::json>::get(), "\"abc\""));
     ASSERT_EQ(nullptr, irs::analysis::analyzers::get("stopwords", irs::type<irs::text_format::json>::get(), "{}"));
     ASSERT_EQ(nullptr, irs::analysis::analyzers::get("stopwords", irs::type<irs::text_format::json>::get(), "{\"stopwords\":1}"));
+    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("stopwords", irs::type<irs::text_format::json>::get(), "{\"stopwords\":1, \"hex\":\"text\"}"));
+    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("stopwords", irs::type<irs::text_format::json>::get(), "{\"stopwords\":[\"aa\", \"bb\"], \"hex\":1}"));
+    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("stopwords", irs::type<irs::text_format::json>::get(), "{\"stopwords\":[\"1aa\", \"bb\"], \"hex\":true}"));
   }
 }
 
@@ -165,18 +165,42 @@ TEST(token_stopwords_stream_tests, normalize_invalid) {
     irs::type<irs::text_format::json>::get(), "\"abc\""));
   ASSERT_FALSE(irs::analysis::analyzers::normalize(actual, "stopwords",
     irs::type<irs::text_format::json>::get(), "{\"case\":1}"));
+  ASSERT_FALSE(irs::analysis::analyzers::normalize(actual, "stopwords",
+    irs::type<irs::text_format::json>::get(), "{\"stopwords\":[\"aa\", \"bb\"], \"hex\":1}"));
 }
 
 TEST(token_stopwords_stream_tests, normalize_valid_array) {
   std::string actual;
   ASSERT_TRUE(irs::analysis::analyzers::normalize(actual, "stopwords",
     irs::type<irs::text_format::json>::get(), "[\"QWRT\", \"qwrt\"]"));
-  ASSERT_EQ(actual, "{\n  \"stopwords\" : [\n    \"QWRT\",\n    \"qwrt\"\n  ]\n}");
+  ASSERT_EQ(actual, "{\n  \"hex\" : false,\n  \"stopwords\" : [\n    \"QWRT\",\n    \"qwrt\"\n  ]\n}");
 }
 
 TEST(token_stopwords_stream_tests, normalize_valid_object) {
   std::string actual;
   ASSERT_TRUE(irs::analysis::analyzers::normalize(actual, "stopwords",
     irs::type<irs::text_format::json>::get(), "{\"stopwords\":[\"QWRT\", \"qwrt\"]}"));
-  ASSERT_EQ(actual, "{\n  \"stopwords\" : [\n    \"QWRT\",\n    \"qwrt\"\n  ]\n}");
+  ASSERT_EQ(actual, "{\n  \"hex\" : false,\n  \"stopwords\" : [\n    \"QWRT\",\n    \"qwrt\"\n  ]\n}");
 }
+
+TEST(token_stopwords_stream_tests, normalize_valid_object_unknown) {
+  std::string actual;
+  ASSERT_TRUE(irs::analysis::analyzers::normalize(actual, "stopwords",
+    irs::type<irs::text_format::json>::get(), "{\"stopwords\":[\"QWRT\", \"qwrt\"], \"unknown_field\":1}"));
+  ASSERT_EQ(actual, "{\n  \"hex\" : false,\n  \"stopwords\" : [\n    \"QWRT\",\n    \"qwrt\"\n  ]\n}");
+}
+
+TEST(token_stopwords_stream_tests, normalize_valid_object_hex) {
+  std::string actual;
+  ASSERT_TRUE(irs::analysis::analyzers::normalize(actual, "stopwords",
+    irs::type<irs::text_format::json>::get(), "{\"stopwords\":[\"01aB\", \"02Cd\"], \"hex\": true}"));
+  ASSERT_EQ(actual, "{\n  \"hex\" : true,\n  \"stopwords\" : [\n    \"01aB\",\n    \"02Cd\"\n  ]\n}");
+}
+
+TEST(token_stopwords_stream_tests, normalize_valid_object_nohex) {
+  std::string actual;
+  ASSERT_TRUE(irs::analysis::analyzers::normalize(actual, "stopwords",
+    irs::type<irs::text_format::json>::get(), "{\"stopwords\":[\"01aB\", \"02Cd\"], \"hex\": false}"));
+  ASSERT_EQ(actual, "{\n  \"hex\" : false,\n  \"stopwords\" : [\n    \"01aB\",\n    \"02Cd\"\n  ]\n}");
+}
+

--- a/tests/analysis/token_stopwords_stream_tests.cpp
+++ b/tests/analysis/token_stopwords_stream_tests.cpp
@@ -152,6 +152,7 @@ TEST(token_stopwords_stream_tests, test_load) {
     ASSERT_EQ(nullptr, irs::analysis::analyzers::get("stopwords", irs::type<irs::text_format::json>::get(), "{\"stopwords\":1, \"hex\":\"text\"}"));
     ASSERT_EQ(nullptr, irs::analysis::analyzers::get("stopwords", irs::type<irs::text_format::json>::get(), "{\"stopwords\":[\"aa\", \"bb\"], \"hex\":1}"));
     ASSERT_EQ(nullptr, irs::analysis::analyzers::get("stopwords", irs::type<irs::text_format::json>::get(), "{\"stopwords\":[\"1aa\", \"bb\"], \"hex\":true}"));
+    ASSERT_EQ(nullptr, irs::analysis::analyzers::get("stopwords", irs::type<irs::text_format::json>::get(), "{\"stopwords\":[\"aaia\", \"bb\"], \"hex\":true}"));
   }
 }
 


### PR DESCRIPTION
Added explicit option 'hex' to stopwords analyzer.
If hex is present and set to true - all members of stopwords array must have even length and be valid hex symbols. And treated like hex codes for symbols.
if hex is absent or set to false( default)  - all members of stopwords array are treated as strings verbatim.
If constructed from array hex=false is assumed.