### PR TITLE
fix error token printing

### DIFF
--- a/core/analysis/token_stopwords_stream.cpp
+++ b/core/analysis/token_stopwords_stream.cpp
@@ -54,7 +54,7 @@ bool hex_decode(std::string& buf, arangodb::velocypack::StringRef value) {
   if (value.length() & 1) {
     IR_FRMT_WARN(
       "Invalid size for hex-encoded value while HEX decoding masked token: %s",
-      value.data());
+      value.toString().c_str());
 
     return false;
   }
@@ -68,7 +68,7 @@ bool hex_decode(std::string& buf, arangodb::velocypack::StringRef value) {
     if (hi >= 16 || lo >= 16) {
       IR_FRMT_WARN(
       "Invalid character while HEX decoding masked token: %s",
-      value.data());
+      value.toString().c_str());
       return false;
     }
 


### PR DESCRIPTION
velocypack::StringRef::data doesn not provide null-terminated string. Moved to StringRef::toString::c_str