### PR TITLE
Bug fix/restore ngram backward compatibility

### DIFF
--- a/cmake/OptimizeForArchitecture.cmake
+++ b/cmake/OptimizeForArchitecture.cmake
@@ -178,7 +178,9 @@ macro(OFA_AutodetectX86)
          endif(_cpu_model GREATER 2)
       endif(_cpu_family EQUAL 6)
    elseif(_vendor_id STREQUAL "AuthenticAMD")
-      if(_cpu_family EQUAL 23)
+      if(_cpu_family EQUAL 25)
+         set(TARGET_ARCHITECTURE "zen3")
+      elseif(_cpu_family EQUAL 23)
          set(TARGET_ARCHITECTURE "zen")
       elseif(_cpu_family EQUAL 22) # 16h
          set(TARGET_ARCHITECTURE "AMD 16h")
@@ -348,6 +350,9 @@ macro(OFA_HandleX86Options)
       list(APPEND _march_flag_list "znver1")
       _skylake()
       list(APPEND _available_vector_units_list "sse4a")
+   elseif(TARGET_ARCHITECTURE STREQUAL "zen3")
+      list(APPEND _march_flag_list "znver3")
+      list(APPEND _available_vector_units_list "bmi" "bmi2" "fma" "avx" "avx2" "sse" "sse2" "sse3" "sse4a" "ssse3" "sse4.1" "sse4.2")
    elseif(TARGET_ARCHITECTURE STREQUAL "piledriver")
       list(APPEND _march_flag_list "bdver2")
       list(APPEND _march_flag_list "bdver1")
@@ -579,7 +584,7 @@ Other supported values are: \"none\", \"generic\", \"core\", \"merom\" (65nm Cor
 \"haswell\", \"broadwell\", \"skylake\", \"skylake-xeon\", \"kaby-lake\", \"cannonlake\", \"silvermont\", \
 \"goldmont\", \"knl\" (Knights Landing), \"atom\", \"k8\", \"k8-sse3\", \"barcelona\", \
 \"istanbul\", \"magny-cours\", \"bulldozer\", \"interlagos\", \"piledriver\", \
-\"AMD 14h\", \"AMD 16h\", \"zen\".")
+\"AMD 14h\", \"AMD 16h\", \"zen\", \"zen3\".")
    elseif("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "(arm|aarch32|aarch64)")
       set(TARGET_ARCHITECTURE "auto" CACHE STRING "CPU architecture to optimize for. \
 Using an incorrect setting here can result in crashes of the resulting binary because of invalid instructions used. \

--- a/core/analysis/ngram_token_stream.cpp
+++ b/core/analysis/ngram_token_stream.cpp
@@ -212,14 +212,9 @@ bool make_vpack_config(
     }
 
     // start_marker
-    if (!options.start_marker.empty()) {
-      builder->add(START_MARKER_PARAM_NAME, VPackValue(irs::ref_cast<char>(options.start_marker)));
-    }
-
+    builder->add(START_MARKER_PARAM_NAME, VPackValue(irs::ref_cast<char>(options.start_marker)));
     // end_marker
-    if (!options.end_marker.empty()) {
-      builder->add(END_MARKER_PARAM_NAME, VPackValue(irs::ref_cast<char>(options.end_marker)));
-    }
+    builder->add(END_MARKER_PARAM_NAME, VPackValue(irs::ref_cast<char>(options.end_marker)));
   }
 
   return true;

--- a/tests/analysis/ngram_token_stream_test.cpp
+++ b/tests/analysis/ngram_token_stream_test.cpp
@@ -1174,7 +1174,8 @@ TEST(ngram_token_stream_test, test_make_config_json) {
     std::string config = "{\"min\":1,\"max\":5,\"preserveOriginal\":false,\"invalid_parameter\":true}";
     std::string actual;
     ASSERT_TRUE(irs::analysis::analyzers::normalize(actual, "ngram", irs::type<irs::text_format::json>::get(), config));
-    ASSERT_EQ(VPackParser::fromJson("{\"min\":1,\"max\":5,\"preserveOriginal\":false,\"streamType\":\"binary\"}")->toString(), actual);
+    ASSERT_EQ(VPackParser::fromJson("{\"min\":1,\"max\":5,\"preserveOriginal\":false,"
+                                    "\"streamType\":\"binary\",\"startMarker\":\"\",\"endMarker\":\"\"}")->toString(), actual);
   }
 
   //with changed values
@@ -1190,14 +1191,16 @@ TEST(ngram_token_stream_test, test_make_config_json) {
     std::string config = "{\"min\":11,\"max\":22,\"preserveOriginal\":true,\"startMarker\":\"$123\"}";
     std::string actual;
     ASSERT_TRUE(irs::analysis::analyzers::normalize(actual, "ngram", irs::type<irs::text_format::json>::get(), config));
-    ASSERT_EQ(VPackParser::fromJson("{\"min\":11,\"max\":22,\"preserveOriginal\":true,\"streamType\":\"binary\",\"startMarker\":\"$123\"}")->toString(), actual);
+    ASSERT_EQ(VPackParser::fromJson("{\"min\":11,\"max\":22,\"preserveOriginal\":true,\"streamType\":\"binary\","
+                                    "\"startMarker\":\"$123\", \"endMarker\":\"\"}")->toString(), actual);
   }
   //with only end marker
   {
     std::string config = "{\"min\":11,\"max\":22,\"preserveOriginal\":true,\"endMarker\":\"#456\"}";
     std::string actual;
     ASSERT_TRUE(irs::analysis::analyzers::normalize(actual, "ngram", irs::type<irs::text_format::json>::get(), config));
-    ASSERT_EQ(VPackParser::fromJson("{\"min\":11,\"max\":22,\"preserveOriginal\":true,\"streamType\":\"binary\",\"endMarker\":\"#456\"}")->toString(), actual);
+    ASSERT_EQ(VPackParser::fromJson("{\"min\":11,\"max\":22,\"preserveOriginal\":true,\"streamType\":\"binary\","
+                                    "\"startMarker\":\"\", \"endMarker\":\"#456\"}")->toString(), actual);
   }
 
   // test vpack
@@ -1209,7 +1212,8 @@ TEST(ngram_token_stream_test, test_make_config_json) {
     std::string out_str;
     ASSERT_TRUE(irs::analysis::analyzers::normalize(out_str, "ngram", irs::type<irs::text_format::vpack>::get(), in_str));
     VPackSlice out_slice(reinterpret_cast<const uint8_t*>(out_str.c_str()));
-    ASSERT_EQ(VPackParser::fromJson("{\"min\":11,\"max\":22,\"preserveOriginal\":true,\"streamType\":\"binary\",\"endMarker\":\"#456\"}")->toString(), out_slice.toString());
+    ASSERT_EQ(VPackParser::fromJson("{\"min\":11,\"max\":22,\"preserveOriginal\":true,\"streamType\":\"binary\","
+                                     "\"startMarker\":\"\", \"endMarker\":\"#456\"}")->toString(), out_slice.toString());
   }
 }
 


### PR DESCRIPTION
We need ngram analyzer vpack config to be backward compatible with existing installations so normalizer should always emit start/endMarker values even if empty.
Also backport cmake utils from downstream