### PR TITLE
Feature/convert primitive streams to analyzers

### DIFF
--- a/core/analysis/token_streams.cpp
+++ b/core/analysis/token_streams.cpp
@@ -32,7 +32,7 @@ namespace iresearch {
 // -----------------------------------------------------------------------------
 
 boolean_token_stream::boolean_token_stream(bool value /*= false*/) noexcept
-  : in_use_(false),
+  : basic_token_stream(irs::type<boolean_token_stream>::get()), in_use_(false),
     value_(value) {
 }
 
@@ -48,7 +48,7 @@ bool boolean_token_stream::next() noexcept {
 // -----------------------------------------------------------------------------
 
 string_token_stream::string_token_stream() noexcept
-   : in_use_(false) {
+   : analysis::analyzer(irs::type<string_token_stream>::get()), in_use_(false) {
 }
 
 bool string_token_stream::next() noexcept {

--- a/core/index/field_data.hpp
+++ b/core/index/field_data.hpp
@@ -43,13 +43,16 @@ namespace iresearch {
 
 struct field_writer;
 class token_stream;
-class analyzer;
 struct offset;
 struct payload;
 class format;
 struct directory;
 class comparer;
 struct flush_state;
+
+namespace analysis {
+class analyzer;
+}
 
 typedef block_pool<size_t, 8192> int_block_pool;
 

--- a/core/utils/object_pool.hpp
+++ b/core/utils/object_pool.hpp
@@ -124,7 +124,7 @@ class concurrent_stack : private util::noncopyable {
 
   node_type* pop() noexcept {
     VALGRIND_ONLY(auto lock = make_lock_guard(mutex_);) // suppress valgrind false-positives related to std::atomic_*
-    concurrent_node head = head_.load();
+    concurrent_node head = head_.load(std::memory_order_relaxed);
     concurrent_node new_head;
 
     do {
@@ -134,14 +134,14 @@ class concurrent_stack : private util::noncopyable {
 
       new_head.node = head.node->next.load(std::memory_order_relaxed);
       new_head.version = head.version + 1;
-    } while (!head_.compare_exchange_weak(head, new_head));
+    } while (!head_.compare_exchange_weak(head, new_head, std::memory_order_relaxed));
 
     return head.node;
   }
 
   void push(node_type& new_node) noexcept {
     VALGRIND_ONLY(auto lock = make_lock_guard(mutex_);) // suppress valgrind false-positives related to std::atomic_*
-    concurrent_node head = head_.load();
+    concurrent_node head = head_.load(std::memory_order_relaxed);
     concurrent_node new_head;
 
     do {
@@ -149,7 +149,7 @@ class concurrent_stack : private util::noncopyable {
 
       new_head.node = &new_node;
       new_head.version = head.version + 1;
-    } while (!head_.compare_exchange_weak(head, new_head));
+    } while (!head_.compare_exchange_weak(head, new_head, std::memory_order_relaxed));
   }
 
  private:
@@ -518,6 +518,8 @@ class unbounded_object_pool : public unbounded_object_pool_base<T> {
   /////////////////////////////////////////////////////////////////////////////
   class ptr : util::noncopyable {
    public:
+
+    ptr() noexcept : owner_(nullptr) {}
     ptr(typename T::ptr&& value,
         unbounded_object_pool& owner
     ) : value_(std::move(value)),
@@ -532,13 +534,14 @@ class unbounded_object_pool : public unbounded_object_pool_base<T> {
 
     ptr& operator=(ptr&& rhs) noexcept {
       if (this != &rhs) {
+        reset();
         value_ = std::move(rhs.value_);
         owner_ = rhs.owner_;
         rhs.owner_ = nullptr;
       }
       return *this;
     }
-
+   
     ~ptr() noexcept {
       reset();
     }

--- a/tests/utils/object_pool_tests.cpp
+++ b/tests/utils/object_pool_tests.cpp
@@ -34,7 +34,7 @@ namespace tests {
 struct test_slow_sobject {
   using ptr = std::shared_ptr<test_slow_sobject>;
   int id;
-  test_slow_sobject (int i): id(i) {
+  explicit test_slow_sobject(int i): id(i) {
     ++TOTAL_COUNT;
   }
   static std::atomic<size_t> TOTAL_COUNT; // # number of objects created
@@ -49,7 +49,7 @@ std::atomic<size_t> test_slow_sobject::TOTAL_COUNT{};
 struct test_sobject {
   using ptr = std::shared_ptr<test_sobject>;
   int id;
-  test_sobject(int i): id(i) { }
+  explicit test_sobject(int i): id(i) { }
   static ptr make(int i) { ++make_count; return ptr(new test_sobject(i)); }
   static std::atomic<size_t> make_count;
 };
@@ -67,7 +67,7 @@ struct test_sobject_nullptr {
 struct test_uobject {
   using ptr = std::unique_ptr<test_uobject>;
   int id;
-  test_uobject(int i): id(i) {}
+  explicit test_uobject(int i): id(i) {}
   static ptr make(int i) { return ptr(new test_uobject(i)); }
 };
 
@@ -79,7 +79,7 @@ struct test_uobject_nullptr {
 
 /*static*/ size_t test_uobject_nullptr::make_count = 0;
 
-}
+} // namespace tests
 
 using namespace tests;
 
@@ -164,7 +164,7 @@ TEST(bounded_object_pool_tests, test_sobject_pool) {
       auto result = cond.wait_for(lock, 1000ms); // assume thread blocks in 1000ms
 
       // As declaration for wait_for contains "It may also be unblocked spuriously." for all platforms
-      while(!emplace && result == std::cv_status::no_timeout) result = cond.wait_for(lock, 1000ms);
+      while (!emplace && result == std::cv_status::no_timeout) result = cond.wait_for(lock, 1000ms);
 
       ASSERT_EQ(std::cv_status::timeout, result);
       // ^^^ expecting timeout because pool should block indefinitely
@@ -237,7 +237,7 @@ TEST(bounded_object_pool_tests, test_sobject_pool) {
     auto result = cond.wait_for(lock, 1000ms); // assume thread finishes in 1000ms
 
     // As declaration for wait_for contains "It may also be unblocked spuriously." for all platforms
-    while(!visit && result == std::cv_status::no_timeout) result = cond.wait_for(lock, 1000ms);
+    while (!visit && result == std::cv_status::no_timeout) result = cond.wait_for(lock, 1000ms);
 
     obj.reset();
     ASSERT_FALSE(obj);
@@ -273,7 +273,7 @@ TEST(bounded_object_pool_tests, test_uobject_pool) {
       auto result = cond.wait_for(lock, 1000ms); // assume thread blocks in 1000ms
 
       // As declaration for wait_for contains "It may also be unblocked spuriously." for all platforms
-      while(!emplace && result == std::cv_status::no_timeout) result = cond.wait_for(lock, 1000ms);
+      while (!emplace && result == std::cv_status::no_timeout) result = cond.wait_for(lock, 1000ms);
 
       ASSERT_EQ(std::cv_status::timeout, result);
       // ^^^ expecting timeout because pool should block indefinitely
@@ -345,7 +345,7 @@ TEST(bounded_object_pool_tests, test_uobject_pool) {
     auto result = cond.wait_for(lock, 1000ms); // assume thread finishes in 1000ms
 
     // As declaration for wait_for contains "It may also be unblocked spuriously." for all platforms
-    while(!visit && result == std::cv_status::no_timeout) result = cond.wait_for(lock, 1000ms);
+    while (!visit && result == std::cv_status::no_timeout) result = cond.wait_for(lock, 1000ms);
 
     obj.reset();
 
@@ -1352,8 +1352,7 @@ TEST(concurrent_linked_list_test, concurrent_push) {
 
   ASSERT_TRUE(
     results.front() == THREADS
-    && irs::irstd::all_equal(results.begin(), results.end())
-  );
+    && irs::irstd::all_equal(results.begin(), results.end()));
 }
 
 TEST(concurrent_linked_list_test, concurrent_pop_push) {
@@ -1435,7 +1434,7 @@ TEST(concurrent_linked_list_test, concurrent_pop_push) {
 
   ASSERT_TRUE(list.empty());
 
-  size_t i =0;
+  size_t i = 0;
   for (auto& node : nodes) {
     ASSERT_EQ(1, node.value.value);
     ASSERT_EQ(true, node.value.visited);


### PR DESCRIPTION
Make primitive token streams (null, numeric, bool, string) also "analyzers" to enable common handling in user code.
Fix issue in unbounded_object_pool::ptr move assignment operator - existing value was not returned to the pool but just destoryed.
Make push/pop in concurrent stack relaxed.
