### PR TITLE
make clang happy

### DIFF
--- a/core/search/disjunction.hpp
+++ b/core/search/disjunction.hpp
@@ -1138,6 +1138,7 @@ class block_disjunction final : public doc_iterator, private score_ctx {
       }
 
       visit_and_purge([this, target, &doc](auto& it) mutable {
+        UNUSED(this);
         const auto value = it->seek(target);
 
         if (doc_limits::eof(value)) {


### PR DESCRIPTION
Fixes a compile warning in disjunction.hpp with newer versions of clang.
It complains about `this` being captured unconditionally, but not being used in all template instantiations.