### PR TITLE
Bug fix/restore utf8 path

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -166,6 +166,7 @@ set(IResearch_core_sources
   ./utils/memory.cpp
   ./utils/timer_utils.cpp
   ./utils/version_utils.cpp
+  ./utils/utf8_path.cpp
   ./utils/locale_utils.cpp
   ./utils/icu_locale_utils.cpp
   ./utils/log.cpp

--- a/core/analysis/text_token_stream.cpp
+++ b/core/analysis/text_token_stream.cpp
@@ -47,6 +47,7 @@
 #include "utils/runtime_utils.hpp"
 #include "utils/thread_utils.hpp"
 #include "utils/utf8_utils.hpp"
+#include "utils/utf8_path.hpp"
 #include "utils/file_utils.hpp"
 #include "utils/vpack_utils.hpp"
 
@@ -71,8 +72,6 @@
 #if defined(_MSC_VER)
   #pragma warning(default: 4229)
 #endif
-
-namespace fs = std::filesystem;
 
 namespace iresearch {
 namespace analysis {
@@ -172,7 +171,7 @@ bool get_stopwords(
     const std::locale& locale,
     const string_ref& path = string_ref::NIL) {
   auto language = locale_utils::language(locale);
-  fs::path stopword_path;
+  utf8_path stopword_path;
 
   auto* custom_stopword_path = !path.null()
     ? path.c_str()
@@ -182,7 +181,7 @@ bool get_stopwords(
     stopword_path.assign(custom_stopword_path);
     file_utils::ensure_absolute(stopword_path);
   } else {
-    fs::path::string_type cwd;
+    utf8_path::string_type cwd;
     file_utils::read_cwd(cwd);
 
     // use CWD if the environment variable STOPWORD_PATH_ENV_VARIABLE is undefined

--- a/core/store/fs_directory.cpp
+++ b/core/store/fs_directory.cpp
@@ -77,7 +77,7 @@ MSVC_ONLY(__pragma(warning(disable: 4996))) // the compiler encountered a deprec
 
 class fs_lock : public index_lock {
  public:
-  fs_lock(const fs::path& dir, const std::string& file)
+  fs_lock(const irs::utf8_path& dir, const std::string& file)
     : dir_{dir}, file_{file} {
   }
 
@@ -150,7 +150,7 @@ class fs_lock : public index_lock {
   }
 
  private:
-  fs::path dir_;
+  irs::utf8_path dir_;
   std::string file_;
   file_utils::lock_handle_t handle_;
 }; // fs_lock
@@ -172,10 +172,10 @@ class fs_index_output : public buffered_index_output {
     if (nullptr == handle) {
 #ifdef _WIN32
       IR_FRMT_ERROR("Failed to open output file, error: %d, path: %s",
-                    GetLastError(), fs::path{name}.c_str());
+                    GetLastError(), irs::utf8_path{name}.c_str());
 #else
       IR_FRMT_ERROR("Failed to open output file, error: %d, path: %s",
-                    errno, fs::path{name}.c_str());
+                    errno, irs::utf8_path{name}.c_str());
 #endif
 
       return nullptr;
@@ -269,10 +269,10 @@ class fs_index_input : public buffered_index_input {
     if (nullptr == handle->handle) {
 #ifdef _WIN32
       IR_FRMT_ERROR("Failed to open input file, error: %d, path: %s",
-                    GetLastError(), fs::path{name}.c_str());
+                    GetLastError(), irs::utf8_path{name}.c_str());
 #else
       IR_FRMT_ERROR("Failed to open input file, error: %d, path: %s",
-                    errno, fs::path{name}.c_str());
+                    errno, irs::utf8_path{name}.c_str());
 #endif
 
       return nullptr;
@@ -287,7 +287,7 @@ class fs_index_input : public buffered_index_input {
       #endif
 
       IR_FRMT_ERROR("Failed to get stat for input file, error: %d, path: %s",
-                    error, fs::path{name}.c_str());
+                    error, irs::utf8_path{name}.c_str());
 
       return nullptr;
     }
@@ -483,7 +483,7 @@ fs_index_input::file_handle::ptr pooled_fs_index_input::reopen(const file_handle
 // -----------------------------------------------------------------------------
 
 fs_directory::fs_directory(
-    fs::path dir,
+    irs::utf8_path dir,
     directory_attributes attrs,
     size_t fd_pool_size)
   : attrs_{std::move(attrs)},
@@ -493,7 +493,7 @@ fs_directory::fs_directory(
 
 index_output::ptr fs_directory::create(const std::string& name) noexcept {
   try {
-    const fs::path path = dir_ / name;
+    const irs::utf8_path path = dir_ / name;
 
     auto out = fs_index_output::open(path.c_str());
 
@@ -508,7 +508,7 @@ index_output::ptr fs_directory::create(const std::string& name) noexcept {
   return nullptr;
 }
 
-const fs::path& fs_directory::directory() const noexcept {
+const irs::utf8_path& fs_directory::directory() const noexcept {
   return dir_;
 }
 
@@ -584,7 +584,7 @@ bool fs_directory::visit(const directory::visitor_f& visitor) const {
   }
 
 #ifdef _WIN32
-  fs::path path;
+  irs::utf8_path path;
   auto dir_visitor = [&path, &visitor](const file_path_t name) {
     path = name;
 

--- a/core/store/fs_directory.hpp
+++ b/core/store/fs_directory.hpp
@@ -26,12 +26,9 @@
 #include "store/directory.hpp"
 #include "store/directory_attributes.hpp"
 #include "utils/string.hpp"
-
-#include <filesystem>
+#include "utils/utf8_path.hpp"
 
 namespace iresearch {
-
-namespace fs = std::filesystem;
 
 //////////////////////////////////////////////////////////////////////////////
 /// @class fs_directory
@@ -41,7 +38,7 @@ class IRESEARCH_API fs_directory : public directory {
   static constexpr size_t DEFAULT_POOL_SIZE = 8;
 
   explicit fs_directory(
-    fs::path dir,
+    utf8_path dir,
     directory_attributes attrs = directory_attributes{},
     size_t fd_pool_size = DEFAULT_POOL_SIZE);
 
@@ -52,7 +49,7 @@ class IRESEARCH_API fs_directory : public directory {
 
   virtual index_output::ptr create(const std::string& name) noexcept override;
 
-  const fs::path& directory() const noexcept;
+  const utf8_path& directory() const noexcept;
 
   virtual bool exists(
     bool& result,
@@ -87,7 +84,7 @@ class IRESEARCH_API fs_directory : public directory {
  private:
   IRESEARCH_API_PRIVATE_VARIABLES_BEGIN
   directory_attributes attrs_;
-  fs::path dir_;
+  utf8_path dir_;
   size_t fd_pool_size_;
   IRESEARCH_API_PRIVATE_VARIABLES_END
 }; // fs_directory

--- a/core/store/mmap_directory.cpp
+++ b/core/store/mmap_directory.cpp
@@ -141,7 +141,7 @@ namespace iresearch {
 // -----------------------------------------------------------------------------
 
 mmap_directory::mmap_directory(
-    fs::path path,
+    irs::utf8_path path,
     directory_attributes attrs /* = {} */)
   : fs_directory{std::move(path), std::move(attrs)} {
 }

--- a/core/store/mmap_directory.hpp
+++ b/core/store/mmap_directory.hpp
@@ -33,7 +33,7 @@ namespace iresearch {
 class IRESEARCH_API mmap_directory : public fs_directory {
  public:
   explicit mmap_directory(
-    fs::path dir,
+    utf8_path dir,
     directory_attributes attrs = directory_attributes{});
 
   virtual index_input::ptr open(

--- a/core/utils/file_utils.hpp
+++ b/core/utils/file_utils.hpp
@@ -27,11 +27,11 @@
 #include <memory>
 #include <cstdio>
 #include <functional>
-#include <filesystem>
 #include <fcntl.h> // open/_wopen
 
 #include "shared.hpp"
 #include "string.hpp"
+#include "utils/utf8_path.hpp"
 
 #ifdef _WIN32  
   #include <tchar.h>
@@ -86,7 +86,7 @@
 #endif
 #endif
 
-using path_char_t = std::filesystem::path::value_type;
+using path_char_t = irs::utf8_path::value_type;
 #define file_path_t path_char_t*
 
 namespace iresearch {
@@ -167,7 +167,7 @@ path_parts_t path_parts(const file_path_t path) noexcept;
 
 bool read_cwd(std::basic_string<path_char_t>& result) noexcept;
 
-void ensure_absolute(std::filesystem::path& path);
+void ensure_absolute(utf8_path& path);
 
 bool remove(const file_path_t path) noexcept;
 

--- a/core/utils/so_utils.cpp
+++ b/core/utils/so_utils.cpp
@@ -25,8 +25,6 @@
 #include "utils/utf8_path.hpp"
 #include "so_utils.hpp"
 
-
-
 #if defined(_MSC_VER) // Microsoft compiler
   #define NOMINMAX
   #include <windows.h>

--- a/core/utils/so_utils.cpp
+++ b/core/utils/so_utils.cpp
@@ -22,10 +22,10 @@
 
 #include "log.hpp"
 #include "utils/file_utils.hpp"
-
+#include "utils/utf8_path.hpp"
 #include "so_utils.hpp"
 
-#include <filesystem>
+
 
 #if defined(_MSC_VER) // Microsoft compiler
   #define NOMINMAX
@@ -89,15 +89,13 @@ namespace {
 
 namespace iresearch {
 
-namespace fs = std::filesystem;
-
 void* load_library(const char* soname, int mode /* = 2 */) {
   if (!soname) {
     return nullptr;
   }
 
-  fs::path name{soname};
-  name.append(FILENAME_EXTENSION);
+  irs::utf8_path name{soname};
+  name += FILENAME_EXTENSION;
 
 #if defined(_MSC_VER) // Microsoft compiler
   UNUSED(mode);
@@ -137,7 +135,7 @@ void load_libraries(
     const std::string& path,
     const std::string& prefix,
     const std::string& suffix) {
-  fs::path plugin_path{path};
+  irs::utf8_path plugin_path{path};
   bool result;
 
   if (!file_utils::exists_directory(result, plugin_path.c_str()) || !result) {
@@ -167,7 +165,7 @@ void load_libraries(
       return true; // skip non-library extensions
     }
 
-    auto stem = fs::path{fs::path::string_type(path_parts.stem)}.u8string();
+    auto stem = irs::utf8_path{irs::utf8_path::string_type(path_parts.stem)}.u8string();
 
     if (stem.size() < prefix.size() + suffix.size() ||
         strncmp(stem.c_str(), prefix.c_str(), prefix.size()) != 0 ||

--- a/core/utils/utf8_path.cpp
+++ b/core/utils/utf8_path.cpp
@@ -1,0 +1,348 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2016 by EMC Corporation, All Rights Reserved
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is EMC Corporation
+///
+/// @author Andrey Abramov
+/// @author Vasiliy Nabatchikov
+////////////////////////////////////////////////////////////////////////////////
+
+#include "file_utils.hpp"
+#include "locale_utils.hpp"
+#include "log.hpp"
+#include "error/error.hpp"
+#include "utf8_path.hpp"
+
+namespace {
+
+typedef irs::basic_string_ref<wchar_t> wstring_ref;
+
+/**
+ * @param encoding the output encoding of the converter
+ * @param forceUnicodeSystem force the internal system encoding to be unicode
+ * @return the converter capable of outputing in the specified target encoding
+ **/
+template<typename Internal>
+const std::codecvt<Internal, char, std::mbstate_t>& utf8_codecvt() {
+  // always use UTF-8 locale for reading/writing filesystem paths
+  // forceUnicodeSystem since using UCS2
+  static const auto utf8 =
+    irs::locale_utils::locale(irs::string_ref::NIL, "utf8", true);
+
+  return irs::locale_utils::codecvt<Internal>(utf8);
+}
+
+#if defined (__GNUC__)
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wunused-function"
+#endif
+
+// use inline to avoid GCC warning
+inline bool append_path(std::string& buf, const irs::string_ref& value) {
+  buf.append(value.c_str(), value.size());
+
+  return true;
+}
+
+// use inline to avoid GCC warning
+inline bool append_path(std::string& buf, const wstring_ref& value) {
+  static auto& fs_cvt = utf8_codecvt<wchar_t>();
+  auto size = value.size() * 4; // same ratio as boost::filesystem
+  auto start = buf.size();
+
+  buf.resize(start + size); // allocate enough space for the converted value
+
+  std::mbstate_t state = std::mbstate_t(); // RHS required for MSVC
+  const wchar_t* from_next;
+  char* to_next;
+  auto result = fs_cvt.out(
+    state,
+    value.c_str(),
+    value.c_str() + value.size(),
+    from_next,
+    const_cast<char*>(buf.c_str() + start),
+    const_cast<char*>(buf.c_str() + buf.size()),
+    to_next);
+
+  if (std::codecvt_base::ok != result) {
+    buf.resize(start); // resize to the original buffer size
+
+    return false;
+  }
+
+  buf.resize(to_next - &buf[0]); // resize to the appended value end
+
+  return true;
+}
+
+// use inline to avoid GCC warning
+inline bool append_path(std::wstring& buf, const irs::string_ref& value) {
+  static auto& fs_cvt = utf8_codecvt<wchar_t>();
+  auto size = value.size() * 3; // same ratio as boost::filesystem
+  auto start = buf.size();
+
+  buf.resize(start + size); // allocate enough space for the converted value
+
+  std::mbstate_t state = std::mbstate_t(); // RHS required for MSVC
+  const char* from_next;
+  wchar_t* to_next;
+  auto result = fs_cvt.in(
+    state,
+    value.c_str(),
+    value.c_str() + value.size(),
+    from_next,
+    const_cast<wchar_t*>(buf.c_str() + start),
+    const_cast<wchar_t*>(buf.c_str() + buf.size()),
+    to_next);
+
+  if (std::codecvt_base::ok != result) {
+    buf.resize(start); // resize to the original buffer size
+
+    return false;
+  }
+
+  buf.resize(to_next - &buf[0]); // resize to the appended value end
+
+  return true;
+}
+
+// use inline to avoid GCC warning
+inline bool append_path(std::wstring& buf, const wstring_ref& value) {
+  buf.append(value.c_str(), value.size());
+
+  return true;
+}
+
+#if defined (__GNUC__)
+  #pragma GCC diagnostic pop
+#endif
+
+} // namespace
+
+namespace iresearch {
+
+utf8_path::utf8_path(bool current_working_path /*= false*/) {
+  if (current_working_path) {
+    std::basic_string<native_char_t> buf;
+
+    // emulate boost::filesystem behaviour by leaving path_ unset in case of error
+    if (irs::file_utils::read_cwd(buf)) {
+      *this += buf;
+    }
+  }
+}
+
+utf8_path::utf8_path(const char* utf8_path)
+  : irs::utf8_path(irs::string_ref(utf8_path)) {
+}
+
+utf8_path::utf8_path(const std::string& utf8_path) {
+  if (!append_path(path_, string_ref(utf8_path))) {
+    // emulate boost::filesystem behaviour by throwing an exception
+    throw io_error("path conversion failure");
+  }
+}
+
+utf8_path::utf8_path(const irs::string_ref& utf8_path) {
+  if (utf8_path.null()) {
+    std::basic_string<native_char_t> buf;
+
+    // emulate boost::filesystem behaviour by leaving path_ unset in case of error
+    if (irs::file_utils::read_cwd(buf)) {
+      *this += buf;
+    }
+
+    return;
+  }
+
+  if (!append_path(path_, utf8_path)) {
+    // emulate boost::filesystem behaviour by throwing an exception
+    throw io_error("path conversion failure");
+  }
+}
+
+utf8_path::utf8_path(const wchar_t* ucs2_path)
+  : utf8_path(irs::basic_string_ref<wchar_t>(ucs2_path)) {
+}
+
+utf8_path::utf8_path(const irs::basic_string_ref<wchar_t>& ucs2_path) {
+  if (ucs2_path.null()) {
+    std::basic_string<native_char_t> buf;
+
+    // emulate boost::filesystem behaviour by leaving path_ unset in case of error
+    if (irs::file_utils::read_cwd(buf)) {
+      *this += buf;
+    }
+
+    return;
+  }
+
+  if (!append_path(path_, ucs2_path)) {
+    // emulate boost::filesystem behaviour by throwing an exception
+    throw io_error("path conversion failure");
+  }
+}
+
+utf8_path::utf8_path(const std::wstring& ucs2_path) {
+  if (!append_path(path_, wstring_ref(ucs2_path))) {
+    // emulate boost::filesystem behaviour by throwing an exception
+    throw io_error("path conversion failure");
+  }
+}
+
+utf8_path& utf8_path::operator+=(const char* utf8_name) {
+  return (*this) += irs::string_ref(utf8_name);
+}
+
+utf8_path& utf8_path::operator+=(const std::string &utf8_name) {
+  if (!append_path(path_, string_ref(utf8_name))) {
+    // emulate boost::filesystem behaviour by throwing an exception
+    throw io_error("path conversion failure");
+  }
+
+  return *this;
+}
+
+utf8_path& utf8_path::operator+=(const string_ref& utf8_name) {
+  if (!append_path(path_, utf8_name)) {
+    // emulate boost::filesystem behaviour by throwing an exception
+    throw io_error("path conversion failure");
+  }
+
+  return *this;
+}
+
+utf8_path& utf8_path::operator+=(const wchar_t* ucs2_name) {
+  return (*this) += irs::basic_string_ref<wchar_t>(ucs2_name);
+}
+
+utf8_path& utf8_path::operator+=(const irs::basic_string_ref<wchar_t>& ucs2_name) {
+  if (!append_path(path_, ucs2_name)) {
+    // emulate boost::filesystem behaviour by throwing an exception
+    throw io_error("path conversion failure");
+  }
+
+  return *this;
+}
+
+utf8_path& utf8_path::operator+=(const std::wstring &ucs2_name) {
+  if (!append_path(path_, wstring_ref(ucs2_name))) {
+    // emulate boost::filesystem behaviour by throwing an exception
+    throw io_error("path conversion failure");
+  }
+
+  return *this;
+}
+
+utf8_path& utf8_path::operator/=(const char* utf8_name) {
+  return (*this) /= irs::string_ref(utf8_name);
+}
+
+utf8_path& utf8_path::operator/=(const std::string &utf8_name) {
+  if (!path_.empty()) {
+    path_.append(1, file_path_delimiter);
+  }
+
+  if (!append_path(path_, string_ref(utf8_name))) {
+    // emulate boost::filesystem behaviour by throwing an exception
+    throw io_error("path conversion failure");
+  }
+
+  return *this;
+}
+
+utf8_path& utf8_path::operator/=(const string_ref& utf8_name) {
+  if (!path_.empty()) {
+    path_.append(1, file_path_delimiter);
+  }
+
+  if (!append_path(path_, utf8_name)) {
+    // emulate boost::filesystem behaviour by throwing an exception
+    throw io_error("path conversion failure");
+  }
+
+  return *this;
+}
+
+utf8_path& utf8_path::operator/=(const wchar_t* ucs2_name) {
+  return (*this) /= basic_string_ref<wchar_t>(ucs2_name);
+}
+
+utf8_path& utf8_path::operator/=(const basic_string_ref<wchar_t>& ucs2_name) {
+  if (!path_.empty()) {
+    path_.append(1, file_path_delimiter);
+  }
+
+  if (!append_path(path_, ucs2_name)) {
+    // emulate boost::filesystem behaviour by throwing an exception
+    throw io_error("path conversion failure");
+  }
+
+  return *this;
+}
+
+utf8_path& utf8_path::operator/=(const std::wstring &ucs2_name) {
+  if (!path_.empty()) {
+    path_.append(1, file_path_delimiter);
+  }
+
+  if (!append_path(path_, wstring_ref(ucs2_name))) {
+    // emulate boost::filesystem behaviour by throwing an exception
+    throw io_error("path conversion failure");
+  }
+
+return *this;
+}
+
+bool utf8_path::is_absolute(bool& result) const noexcept {
+  return irs::file_utils::absolute(result, c_str());
+}
+
+void utf8_path::clear() {
+  path_.clear();
+}
+
+const utf8_path::native_char_t* utf8_path::c_str() const noexcept {
+  return path_.c_str();
+}
+
+const utf8_path::native_str_t& utf8_path::native() const noexcept {
+  return path_;
+}
+
+std::string utf8_path::u8string() const {
+  #ifdef _WIN32
+    std::string buf;
+
+    if (!append_path(buf, path_)) {
+      // emulate boost::filesystem behaviour by throwing an exception
+      throw io_error("Path conversion failure");
+    }
+
+    return buf;
+  #else
+    return path_;
+  #endif
+}
+
+utf8_path operator/(const utf8_path& lhs, const utf8_path& rhs) {
+  auto left = lhs;
+  left /= rhs.c_str();
+  return left;
+}
+
+} // namespace iresearch

--- a/core/utils/utf8_path.hpp
+++ b/core/utils/utf8_path.hpp
@@ -66,7 +66,7 @@ class IRESEARCH_API utf8_path {
   bool is_absolute(bool& result) const noexcept;
 
   // std::filesystem::path compliant version
-  bool utf8_path::is_absolute() const noexcept {
+  bool is_absolute() const noexcept {
     bool result;
     return is_absolute(result) && result;
   }

--- a/core/utils/utf8_path.hpp
+++ b/core/utils/utf8_path.hpp
@@ -82,12 +82,6 @@ class IRESEARCH_API utf8_path {
     return *this;
   }
 
-  //////////////////////////////////////////////////////////////////////////////
-  /// @brief IFF absolute(): same as utf8()
-  ///        IFF !absolute(): same as utf8_path(true) /= utf8()
-  //////////////////////////////////////////////////////////////////////////////
-  //std::string utf8_absolute() const;
-
   void clear();
 
  private:
@@ -96,6 +90,7 @@ class IRESEARCH_API utf8_path {
   IRESEARCH_API_PRIVATE_VARIABLES_END
 };
 
+// need this operator to be closer to std::filesystem::path
 utf8_path operator/( const utf8_path& lhs, const utf8_path& rhs );
 
 }

--- a/core/utils/utf8_path.hpp
+++ b/core/utils/utf8_path.hpp
@@ -24,6 +24,14 @@
 #ifndef IRESEARCH_UTF8_PATH_H
 #define IRESEARCH_UTF8_PATH_H
 
+#ifndef __APPLE__
+#include <filesystem>
+namespace iresearch {
+using utf8_path = std::filesystem::path;
+utf8_path current_path();
+}
+#else
+
 #include "string.hpp"
 
 #include <functional>
@@ -43,7 +51,7 @@ class IRESEARCH_API utf8_path {
   typedef std::basic_string<native_char_t> string_type; // to simmplify move to std::filesystem::path
   typedef native_char_t value_type; // to simmplify move to std::filesystem::path
 
-  utf8_path(bool current_working_path = false);
+  utf8_path() = default;
   utf8_path(const char* utf8_path);
   utf8_path(const std::string& utf8_path);
   utf8_path(const irs::string_ref& utf8_path);
@@ -93,6 +101,8 @@ class IRESEARCH_API utf8_path {
 // need this operator to be closer to std::filesystem::path
 utf8_path operator/( const utf8_path& lhs, const utf8_path& rhs );
 
-}
+utf8_path current_path();
 
+}
+#endif
 #endif

--- a/core/utils/utf8_path.hpp
+++ b/core/utils/utf8_path.hpp
@@ -1,0 +1,103 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2016 by EMC Corporation, All Rights Reserved
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is EMC Corporation
+///
+/// @author Andrey Abramov
+/// @author Vasiliy Nabatchikov
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef IRESEARCH_UTF8_PATH_H
+#define IRESEARCH_UTF8_PATH_H
+
+#include "string.hpp"
+
+#include <functional>
+
+namespace iresearch {
+
+class IRESEARCH_API utf8_path {
+ public:
+  #ifdef _WIN32
+    typedef wchar_t native_char_t;
+  #else
+    typedef char native_char_t;
+  #endif
+
+  typedef std::function<bool(const native_char_t* name)> directory_visitor;
+  typedef std::basic_string<native_char_t> native_str_t;
+  typedef std::basic_string<native_char_t> string_type; // to simmplify move to std::filesystem::path
+  typedef native_char_t value_type; // to simmplify move to std::filesystem::path
+
+  utf8_path(bool current_working_path = false);
+  utf8_path(const char* utf8_path);
+  utf8_path(const std::string& utf8_path);
+  utf8_path(const irs::string_ref& utf8_path);
+  utf8_path(const wchar_t* utf8_path);
+  utf8_path(const irs::basic_string_ref<wchar_t>& ucs2_path);
+  utf8_path(const std::wstring& ucs2_path);
+  utf8_path& operator+=(const char* utf8_name);
+  utf8_path& operator+=(const std::string& utf8_name);
+  utf8_path& operator+=(const irs::string_ref& utf8_name);
+  utf8_path& operator+=(const wchar_t* ucs2_name);
+  utf8_path& operator+=(const irs::basic_string_ref<wchar_t>& ucs2_name);
+  utf8_path& operator+=(const std::wstring& ucs2_name);
+  utf8_path& operator/=(const char* utf8_name);
+  utf8_path& operator/=(const std::string& utf8_name);
+  utf8_path& operator/=(const irs::string_ref& utf8_name);
+  utf8_path& operator/=(const wchar_t* ucs2_name);
+  utf8_path& operator/=(const irs::basic_string_ref<wchar_t>& ucs2_name);
+  utf8_path& operator/=(const std::wstring& ucs2_name);
+
+  bool is_absolute(bool& result) const noexcept;
+
+  // std::filesystem::path compliant version
+  bool utf8_path::is_absolute() const noexcept {
+    bool result;
+    return is_absolute(result) && result;
+  }
+
+  const native_char_t* c_str() const noexcept;
+  const native_str_t& native() const noexcept;
+  std::string u8string() const;
+
+  template<typename T>
+  utf8_path& assign(T&& source) {
+    path_.clear();
+    (*this) += source;
+    return *this;
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
+  /// @brief IFF absolute(): same as utf8()
+  ///        IFF !absolute(): same as utf8_path(true) /= utf8()
+  //////////////////////////////////////////////////////////////////////////////
+  //std::string utf8_absolute() const;
+
+  void clear();
+
+ private:
+  IRESEARCH_API_PRIVATE_VARIABLES_BEGIN
+  native_str_t path_;
+  IRESEARCH_API_PRIVATE_VARIABLES_END
+};
+
+utf8_path operator/( const utf8_path& lhs, const utf8_path& rhs );
+
+}
+
+#endif

--- a/core/utils/utf8_path.hpp
+++ b/core/utils/utf8_path.hpp
@@ -55,21 +55,12 @@ class IRESEARCH_API utf8_path {
   utf8_path(const char* utf8_path);
   utf8_path(const std::string& utf8_path);
   utf8_path(const irs::string_ref& utf8_path);
-  utf8_path(const wchar_t* utf8_path);
-  utf8_path(const irs::basic_string_ref<wchar_t>& ucs2_path);
-  utf8_path(const std::wstring& ucs2_path);
   utf8_path& operator+=(const char* utf8_name);
   utf8_path& operator+=(const std::string& utf8_name);
   utf8_path& operator+=(const irs::string_ref& utf8_name);
-  utf8_path& operator+=(const wchar_t* ucs2_name);
-  utf8_path& operator+=(const irs::basic_string_ref<wchar_t>& ucs2_name);
-  utf8_path& operator+=(const std::wstring& ucs2_name);
   utf8_path& operator/=(const char* utf8_name);
   utf8_path& operator/=(const std::string& utf8_name);
   utf8_path& operator/=(const irs::string_ref& utf8_name);
-  utf8_path& operator/=(const wchar_t* ucs2_name);
-  utf8_path& operator/=(const irs::basic_string_ref<wchar_t>& ucs2_name);
-  utf8_path& operator/=(const std::wstring& ucs2_name);
 
   bool is_absolute(bool& result) const noexcept;
 

--- a/core/utils/utf8_path.hpp
+++ b/core/utils/utf8_path.hpp
@@ -48,8 +48,8 @@ class IRESEARCH_API utf8_path {
 
   typedef std::function<bool(const native_char_t* name)> directory_visitor;
   typedef std::basic_string<native_char_t> native_str_t;
-  typedef std::basic_string<native_char_t> string_type; // to simmplify move to std::filesystem::path
-  typedef native_char_t value_type; // to simmplify move to std::filesystem::path
+  typedef std::basic_string<native_char_t> string_type; // to simplify move to std::filesystem::path
+  typedef native_char_t value_type; // to simplify move to std::filesystem::path
 
   utf8_path() = default;
   utf8_path(const char* utf8_path);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -120,6 +120,7 @@ set(IReSearch_tests_sources
   ./utils/thread_pool_test.cpp
   ./utils/type_utils_tests.cpp
   ./utils/utf8_utils_test.cpp
+  ./utils/utf8_path_tests.cpp
   ./utils/fst_builder_test.cpp
   ./utils/fst_utils_test.cpp
   ./utils/fst_string_weight_test.cpp

--- a/tests/analysis/text_analyzer_tests.cpp
+++ b/tests/analysis/text_analyzer_tests.cpp
@@ -818,7 +818,7 @@ TEST_F(TextAnalyzerParserTestSuite, test_load_no_default_stopwords_fallback_cwd)
 
   // no stopwords, but valid CWD
   auto reset_stopword_path = irs::make_finally(
-      [oldCWD = irs::utf8_path(true)]()noexcept{
+      [oldCWD = irs::current_path()]()noexcept{
     EXPECT_TRUE(irs::file_utils::set_cwd(oldCWD.c_str()));
   });
   irs::file_utils::set_cwd(irs::utf8_path(IResearch_test_resource_dir).c_str());
@@ -898,7 +898,7 @@ TEST_F(TextAnalyzerParserTestSuite, test_load_stopwords_path_override) {
 TEST_F(TextAnalyzerParserTestSuite, test_load_stopwords_path_override_emptypath) {
   // no stopwords, but empty stopwords path (we need to shift CWD to our test resources, to be able to load stopwords)
   auto reset_stopword_path = irs::make_finally(
-      [oldCWD = irs::utf8_path(true)]()noexcept{
+      [oldCWD = irs::current_path()]()noexcept{
     EXPECT_TRUE(irs::file_utils::set_cwd(oldCWD.c_str()));
   });
   irs::file_utils::set_cwd(irs::utf8_path(IResearch_test_resource_dir).c_str());
@@ -1003,7 +1003,7 @@ TEST_F(TextAnalyzerParserTestSuite, test_make_config_json) {
   // no stopwords, but empty stopwords path (we need to shift CWD to our test resources, to be able to load stopwords)
   {
     auto reset_stopword_path = irs::make_finally(
-        [oldCWD = irs::utf8_path(true)]()noexcept{
+        [oldCWD = irs::current_path()]()noexcept{
       EXPECT_TRUE(irs::file_utils::set_cwd(oldCWD.c_str()));
     });
     irs::file_utils::set_cwd(irs::utf8_path(IResearch_test_resource_dir).c_str());

--- a/tests/analysis/text_analyzer_tests.cpp
+++ b/tests/analysis/text_analyzer_tests.cpp
@@ -24,8 +24,6 @@
 #include "gtest/gtest.h"
 #include "tests_config.hpp"
 
-#include <filesystem>
-
 #include <velocypack/Parser.h>
 #include <velocypack/velocypack-aliases.h>
 #include <rapidjson/document.h> // for rapidjson::Document, rapidjson::Value
@@ -36,6 +34,7 @@
 #include "utils/locale_utils.hpp"
 #include "utils/runtime_utils.hpp"
 #include "utils/file_utils.hpp"
+#include "utils/utf8_path.hpp"
 
 namespace {
 
@@ -819,10 +818,10 @@ TEST_F(TextAnalyzerParserTestSuite, test_load_no_default_stopwords_fallback_cwd)
 
   // no stopwords, but valid CWD
   auto reset_stopword_path = irs::make_finally(
-      [oldCWD = std::filesystem::current_path()]()noexcept{
+      [oldCWD = irs::utf8_path(true)]()noexcept{
     EXPECT_TRUE(irs::file_utils::set_cwd(oldCWD.c_str()));
   });
-  std::filesystem::current_path({IResearch_test_resource_dir});
+  irs::file_utils::set_cwd(irs::utf8_path(IResearch_test_resource_dir).c_str());
 
   {
     const std::string sDataASCII = "A E I O U";
@@ -899,10 +898,10 @@ TEST_F(TextAnalyzerParserTestSuite, test_load_stopwords_path_override) {
 TEST_F(TextAnalyzerParserTestSuite, test_load_stopwords_path_override_emptypath) {
   // no stopwords, but empty stopwords path (we need to shift CWD to our test resources, to be able to load stopwords)
   auto reset_stopword_path = irs::make_finally(
-      [oldCWD = std::filesystem::current_path()]()noexcept{
+      [oldCWD = irs::utf8_path(true)]()noexcept{
     EXPECT_TRUE(irs::file_utils::set_cwd(oldCWD.c_str()));
   });
-  std::filesystem::current_path({IResearch_test_resource_dir});
+  irs::file_utils::set_cwd(irs::utf8_path(IResearch_test_resource_dir).c_str());
 
   std::string config = "{\"locale\":\"en_US.UTF-8\",\"case\":\"lower\",\"accent\":false,\"stemming\":true,\"stopwordsPath\":\"\"}";
   auto stream = irs::analysis::analyzers::get("text", irs::type<irs::text_format::json>::get(), config);
@@ -1004,10 +1003,10 @@ TEST_F(TextAnalyzerParserTestSuite, test_make_config_json) {
   // no stopwords, but empty stopwords path (we need to shift CWD to our test resources, to be able to load stopwords)
   {
     auto reset_stopword_path = irs::make_finally(
-        [oldCWD = std::filesystem::current_path()]()noexcept{
+        [oldCWD = irs::utf8_path(true)]()noexcept{
       EXPECT_TRUE(irs::file_utils::set_cwd(oldCWD.c_str()));
     });
-    std::filesystem::current_path({IResearch_test_resource_dir});
+    irs::file_utils::set_cwd(irs::utf8_path(IResearch_test_resource_dir).c_str());
 
     std::string config = "{\"locale\":\"en_US.utf-8\",\"case\":\"lower\",\"accent\":false,\"stemming\":true,\"stopwordsPath\":\"\"}";
     std::string actual;

--- a/tests/formats/formats_10_tests.cpp
+++ b/tests/formats/formats_10_tests.cpp
@@ -780,7 +780,7 @@ TEST_P(format_10_test_case, postings_seek) {
     std::vector<irs::doc_id_t> docs;
     {
       std::string buf;
-      std::ifstream in(resource("postings.txt"));
+      std::ifstream in(resource("postings.txt").c_str());
       char* pend;
       while (std::getline(in, buf)) {
         docs.push_back(strtol(buf.c_str(), &pend, 10));

--- a/tests/formats/formats_test_case_base.cpp
+++ b/tests/formats/formats_test_case_base.cpp
@@ -1604,7 +1604,7 @@ TEST_P(format_test_case, columns_rw_big_document) {
     char buf[65536];
   } field;
 
-  std::fstream stream(resource("simple_two_column.csv"));
+  std::fstream stream(resource("simple_two_column.csv").c_str());
   ASSERT_FALSE(!stream);
 
   irs::field_id id;

--- a/tests/index/doc_generator.cpp
+++ b/tests/index/doc_generator.cpp
@@ -272,7 +272,7 @@ void particle::remove(const irs::string_ref& name) {
 // -----------------------------------------------------------------------------
 
 delim_doc_generator::delim_doc_generator(
-    const fs::path& file,
+    const irs::utf8_path& file,
     doc_template& doc,
     uint32_t delim /* = 0x0009 */)
   : ifs_(file.native(), std::ifstream::in | std::ifstream::binary),
@@ -317,7 +317,7 @@ void delim_doc_generator::reset() {
 // -----------------------------------------------------------------------------
 
 csv_doc_generator::csv_doc_generator(
-    const fs::path& file,
+    const irs::utf8_path& file,
     doc_template& doc)
   : doc_(doc),
     ifs_(file.native(), std::ifstream::in | std::ifstream::binary),
@@ -478,9 +478,9 @@ class parse_json_handler : irs::util::noncopyable {
 }; // parse_json_handler
 
 json_doc_generator::json_doc_generator(
-    const fs::path& file,
+    const irs::utf8_path& file,
     const json_doc_generator::factory_f& factory) {
-  std::ifstream input(fs::path(file).u8string().c_str(), std::ios::in | std::ios::binary);
+  std::ifstream input(irs::utf8_path(file).u8string().c_str(), std::ios::in | std::ios::binary);
   assert(input);
 
   rapidjson::IStreamWrapper stream(input);

--- a/tests/index/doc_generator.hpp
+++ b/tests/index/doc_generator.hpp
@@ -27,13 +27,14 @@
 #include "analysis/analyzer.hpp"
 #include "analysis/token_streams.hpp"
 #include "utils/iterator.hpp"
+#include "utils/utf8_path.hpp"
 #include "store/store_utils.hpp"
 #include "index/index_writer.hpp"
 
 #include <fstream>
 #include <atomic>
 #include <functional>
-#include <filesystem>
+
 
 namespace iresearch {
 
@@ -362,7 +363,7 @@ class delim_doc_generator : public doc_generator_base {
   }; // doc_template
 
   delim_doc_generator(
-    const fs::path& file,
+    const irs::utf8_path& file,
     doc_template& doc,
     uint32_t delim = 0x0009);
 
@@ -386,7 +387,7 @@ class csv_doc_generator: public doc_generator_base {
     virtual void reset() {}
   }; // doc_template
 
-  csv_doc_generator(const fs::path& file, doc_template& doc);
+  csv_doc_generator(const irs::utf8_path& file, doc_template& doc);
   virtual const tests::document* next() override;
   virtual void reset() override;
   bool skip(); // skip a single document, return if anything was skiped, false == EOF
@@ -492,7 +493,7 @@ class json_doc_generator: public doc_generator_base {
   )> factory_f;
 
   json_doc_generator(
-    const fs::path& file,
+    const irs::utf8_path& file,
     const factory_f& factory);
 
   json_doc_generator(

--- a/tests/index/doc_generator.hpp
+++ b/tests/index/doc_generator.hpp
@@ -45,8 +45,6 @@ class token_stream;
 
 namespace tests {
 
-namespace fs = std::filesystem;
-
 //////////////////////////////////////////////////////////////////////////////
 /// @class ifield
 /// @brief base interface for all fields

--- a/tests/store/directory_test_case.cpp
+++ b/tests/store/directory_test_case.cpp
@@ -35,6 +35,7 @@
 #include "utils/directory_utils.hpp"
 #include "utils/process_utils.hpp"
 #include "utils/network_utils.hpp"
+#include "utils/file_utils.hpp"
 
 #include <cstdio>
 #include <vector>
@@ -1363,18 +1364,18 @@ class fs_directory_test : public test_base {
     test_base::SetUp();
     path_ = test_case_dir() / name_;
 
-    fs::create_directory(path_);
+    irs::file_utils::mkdir(path_.c_str(), false);
     dir_ = std::make_shared<fs_directory>(path_);
   }
 
   virtual void TearDown() override {
     dir_ = nullptr;
-    fs::remove_all(path_);
+    irs::file_utils::remove(path_.c_str());
     test_base::TearDown();
   }
 
  protected:
-  static void check_files(const directory& dir, const fs::path& path) {
+  static void check_files(const directory& dir, const irs::utf8_path& path) {
     const std::string file_name = "abcd";
 
     // create empty file
@@ -1396,7 +1397,7 @@ class fs_directory_test : public test_base {
   }
 
   std::string name_;
-  fs::path path_;
+  irs::utf8_path path_;
   std::shared_ptr<fs_directory> dir_;
 }; // fs_directory_test
 

--- a/tests/tests_param.cpp
+++ b/tests/tests_param.cpp
@@ -26,6 +26,7 @@
 #include "store/fs_directory.hpp"
 #include "store/mmap_directory.hpp"
 #include "store/memory_directory.hpp"
+#include "utils/file_utils.hpp"
 
 namespace tests {
 
@@ -44,12 +45,12 @@ std::shared_ptr<irs::directory> fs_directory(
     auto dir = test->test_dir();
 
     dir /= "index";
-    std::filesystem::create_directory(dir);
+    irs::file_utils::mkdir(dir.c_str(), false);
 
     impl = std::shared_ptr<irs::fs_directory>(
       new irs::fs_directory(dir, std::move(attrs)),
       [dir](irs::fs_directory* p) {
-        std::filesystem::remove_all(dir);
+        irs::file_utils::remove(dir.c_str());
         delete p;
     });
   }
@@ -66,12 +67,12 @@ std::shared_ptr<irs::directory> mmap_directory(
     auto dir = test->test_dir();
 
     dir /= "index";
-    std::filesystem::create_directory(dir);
+    irs::file_utils::mkdir(dir.c_str(), false);
 
     impl = std::shared_ptr<irs::mmap_directory>(
       new irs::mmap_directory(dir, std::move(attrs)),
       [dir](irs::mmap_directory* p) {
-        std::filesystem::remove_all(dir);
+        irs::file_utils::remove(dir.c_str());
         delete p;
     });
   }

--- a/tests/tests_shared.hpp
+++ b/tests/tests_shared.hpp
@@ -25,14 +25,13 @@
 #define IRESEARCH_TESTS_SHARED_H
 
 #include <memory>
-#include <filesystem>
 #include <cstdio>
 
 #include <gtest/gtest.h>
 
 #include "shared.hpp"
+#include "utils/utf8_path.hpp"
 
-namespace fs = std::filesystem;
 
 namespace cmdline {
 class parser;
@@ -43,14 +42,14 @@ class test_env {
   static const std::string test_results;
 
   static int initialize( int argc, char* argv[] );
-  static const fs::path& exec_path() { return exec_path_; }
-  static const fs::path& exec_dir() { return exec_dir_; }
-  static const fs::path& exec_file() { return exec_file_; }
-  static const fs::path& resource_dir() { return resource_dir_; }
-  static const fs::path& test_results_dir() { return res_dir_; }
+  static const irs::utf8_path& exec_path() { return exec_path_; }
+  static const irs::utf8_path& exec_dir() { return exec_dir_; }
+  static const irs::utf8_path& exec_file() { return exec_file_; }
+  static const irs::utf8_path& resource_dir() { return resource_dir_; }
+  static const irs::utf8_path& test_results_dir() { return res_dir_; }
 
   // returns path to resource with the specified name
-  static fs::path resource(const std::string& name);
+  static irs::utf8_path resource(const std::string& name);
 
   static uint32_t iteration();
 
@@ -63,30 +62,30 @@ class test_env {
   static char** argv_;
   static std::string argv_ires_output_; // argv_ for ires_output
   static std::string test_name_; // name of the current test //
-  static fs::path exec_path_; // path where executable resides
-  static fs::path exec_dir_; // directory where executable resides
-  static fs::path exec_file_; // executable file name
-  static fs::path out_dir_; // output directory, default: exec_dir_
+  static irs::utf8_path exec_path_; // path where executable resides
+  static irs::utf8_path exec_dir_; // directory where executable resides
+  static irs::utf8_path exec_file_; // executable file name
+  static irs::utf8_path out_dir_; // output directory, default: exec_dir_
 
   //TODO: set path from CMAKE!!!
-  static fs::path resource_dir_; // resource directory
+  static irs::utf8_path resource_dir_; // resource directory
 
-  static fs::path res_dir_; // output_dir_/test_name_YYYY_mm_dd_HH_mm_ss_XXXXXX
-  static fs::path res_path_; // res_dir_/test_detail.xml
+  static irs::utf8_path res_dir_; // output_dir_/test_name_YYYY_mm_dd_HH_mm_ss_XXXXXX
+  static irs::utf8_path res_path_; // res_dir_/test_detail.xml
 };
 
 class test_base : public test_env, public ::testing::Test {
  public:
-  const fs::path& test_dir() const { return test_dir_; }
-  const fs::path& test_case_dir() const { return test_case_dir_; }
+  const irs::utf8_path& test_dir() const { return test_dir_; }
+  const irs::utf8_path& test_case_dir() const { return test_case_dir_; }
 
  protected:
   test_base() = default;
   virtual void SetUp() override;
 
  private:
-  fs::path test_dir_; // res_dir_/<test-name>
-  fs::path test_case_dir_; // test_dir/<test-case-name>
+  irs::utf8_path test_dir_; // res_dir_/<test-name>
+  irs::utf8_path test_case_dir_; // test_dir/<test-case-name>
   bool artifacts_;
 }; // test_info
 

--- a/tests/utils/crc_test.cpp
+++ b/tests/utils/crc_test.cpp
@@ -62,7 +62,7 @@ TEST(crc_test, check) {
 
   char buf[65536];
 
-  std::fstream stream(test_base::resource("simple_two_column.csv"));
+  std::fstream stream(test_base::resource("simple_two_column.csv").c_str());
   ASSERT_FALSE(!stream);
 
   while (stream) {

--- a/tests/utils/fst_builder_test.cpp
+++ b/tests/utils/fst_builder_test.cpp
@@ -64,7 +64,7 @@ using fst_byte_builder = irs::fst_builder<irs::byte_type, irs::vector_byte_fst, 
 // first - prefix
 // second - payload
 std::vector<std::pair<irs::bstring, irs::bstring>> read_fst_input(
-    const fs::path& filename) {
+    const irs::utf8_path& filename) {
   auto read_size = [](std::istream& stream) {
     size_t size;
     stream.read(reinterpret_cast<char*>(&size), sizeof(size_t));
@@ -77,7 +77,7 @@ std::vector<std::pair<irs::bstring, irs::bstring>> read_fst_input(
   std::vector<std::pair<irs::bstring, irs::bstring>> data;
 
   std::ifstream in;
-  in.open(filename, std::ios_base::in | std::ios_base::binary);
+  in.open(filename.c_str(), std::ios_base::in | std::ios_base::binary);
 
   data.resize(read_size(in));
 

--- a/tests/utils/icu_locale_utils_tests.cpp
+++ b/tests/utils/icu_locale_utils_tests.cpp
@@ -449,9 +449,9 @@ TEST(icu_locale_utils_test_suite, test_locale_to_vpack) {
     Unicode unicode = Unicode::UTF8;
     ASSERT_TRUE(locale_to_vpack(icu_locale, &builder, &unicode));
 
-    auto expected_config = VPackParser::fromJson(R"({"language":"uk","encoding":"utf-8"})")->slice();
+    auto expected_config = VPackParser::fromJson(R"({"language":"uk","encoding":"utf-8"})");
     auto actual_config = builder.slice();
-    ASSERT_EQ(expected_config.toString(), actual_config.toString());
+    ASSERT_EQ(expected_config->toString(), actual_config.toString());
   }
 
   {
@@ -460,9 +460,9 @@ TEST(icu_locale_utils_test_suite, test_locale_to_vpack) {
     Unicode unicode = Unicode::UTF8;
     ASSERT_TRUE(locale_to_vpack(icu_locale, &builder, &unicode));
 
-    auto expected_config = VPackParser::fromJson(R"({"language":"de","country":"DE","encoding":"utf-8"})")->slice();
+    auto expected_config = VPackParser::fromJson(R"({"language":"de","country":"DE","encoding":"utf-8"})");
     auto actual_config = builder.slice();
-    ASSERT_EQ(expected_config.toString(), actual_config.toString());
+    ASSERT_EQ(expected_config->toString(), actual_config.toString());
   }
 
   {
@@ -471,9 +471,9 @@ TEST(icu_locale_utils_test_suite, test_locale_to_vpack) {
     Unicode unicode = Unicode::UTF8;
     ASSERT_TRUE(locale_to_vpack(icu_locale, &builder, &unicode));
 
-    auto expected_config = VPackParser::fromJson(R"({"language":"de","country":"DE","variant":"PHONEBOOK","encoding":"utf-8"})")->slice();
+    auto expected_config = VPackParser::fromJson(R"({"language":"de","country":"DE","variant":"PHONEBOOK","encoding":"utf-8"})");
     auto actual_config = builder.slice();
-    ASSERT_EQ(expected_config.toString(), actual_config.toString());
+    ASSERT_EQ(expected_config->toString(), actual_config.toString());
   }
 
   {
@@ -482,9 +482,9 @@ TEST(icu_locale_utils_test_suite, test_locale_to_vpack) {
     Unicode unicode = Unicode::UTF8;
     ASSERT_TRUE(locale_to_vpack(icu_locale, &builder, &unicode));
 
-    auto expected_config = VPackParser::fromJson(R"({"language":"de","country":"DE","variant":"PHONEBOOK","encoding":"utf-8"})")->slice();
+    auto expected_config = VPackParser::fromJson(R"({"language":"de","country":"DE","variant":"PHONEBOOK","encoding":"utf-8"})");
     auto actual_config = builder.slice();
-    ASSERT_EQ(expected_config.toString(), actual_config.toString());
+    ASSERT_EQ(expected_config->toString(), actual_config.toString());
   }
 
   {
@@ -493,9 +493,9 @@ TEST(icu_locale_utils_test_suite, test_locale_to_vpack) {
     Unicode unicode = Unicode::UTF8;
     ASSERT_TRUE(locale_to_vpack(icu_locale, &builder, &unicode));
 
-    auto expected_config = VPackParser::fromJson(R"({"language":"de","country":"DE","encoding":"utf-8"})")->slice();
+    auto expected_config = VPackParser::fromJson(R"({"language":"de","country":"DE","encoding":"utf-8"})");
     auto actual_config = builder.slice();
-    ASSERT_EQ(expected_config.toString(), actual_config.toString());
+    ASSERT_EQ(expected_config->toString(), actual_config.toString());
   }
 
   {
@@ -504,9 +504,9 @@ TEST(icu_locale_utils_test_suite, test_locale_to_vpack) {
     Unicode unicode = Unicode::UTF8;
     ASSERT_TRUE(locale_to_vpack(icu_locale, &builder, &unicode));
 
-    auto expected_config = VPackParser::fromJson(R"({"language":"de","country":"DE","variant":"PINYAN","encoding":"utf-8"})")->slice();
+    auto expected_config = VPackParser::fromJson(R"({"language":"de","country":"DE","variant":"PINYAN","encoding":"utf-8"})");
     auto actual_config = builder.slice();
-    ASSERT_EQ(expected_config.toString(), actual_config.toString());
+    ASSERT_EQ(expected_config->toString(), actual_config.toString());
   }
 
   {
@@ -515,8 +515,8 @@ TEST(icu_locale_utils_test_suite, test_locale_to_vpack) {
     Unicode unicode = Unicode::UTF8;
     ASSERT_TRUE(locale_to_vpack(icu_locale, &builder, &unicode));
 
-    auto expected_config = VPackParser::fromJson(R"({"language":"de","country":"DE","variant":"PINYAN_PHONEBOOK","encoding":"utf-8"})")->slice();
+    auto expected_config = VPackParser::fromJson(R"({"language":"de","country":"DE","variant":"PINYAN_PHONEBOOK","encoding":"utf-8"})");
     auto actual_config = builder.slice();
-    ASSERT_EQ(expected_config.toString(), actual_config.toString());
+    ASSERT_EQ(expected_config->toString(), actual_config.toString());
   }
 }

--- a/tests/utils/utf8_path_tests.cpp
+++ b/tests/utils/utf8_path_tests.cpp
@@ -40,7 +40,7 @@ class utf8_path_tests: public test_base {
     // Code here will be called immediately after the constructor (right before each test).
 
     test_base::SetUp();
-    cwd_ = irs::utf8_path(true);
+    cwd_ = irs::current_path();
     irs::file_utils::mkdir(test_dir().c_str(), false); // ensure path exists
     irs::file_utils::set_cwd(test_dir().c_str()); // ensure all files/directories created in a valid place
   }
@@ -58,7 +58,7 @@ class utf8_path_tests: public test_base {
 TEST_F(utf8_path_tests, current) {
   // absolute path
   {
-    irs::utf8_path path(true);
+    auto path = irs::current_path();
     std::string directory("deleteme");
     std::string directory2("deleteme2");
     bool tmpBool;
@@ -68,14 +68,14 @@ TEST_F(utf8_path_tests, current) {
     #ifdef _WIN32
       wchar_t buf[_MAX_PATH];
       std::basic_string<wchar_t> current_dir(_wgetcwd(buf, _MAX_PATH));
-      std::basic_string<wchar_t> prefix(L"\\\\?\\"); // prepended by chdir() and returned by win32
+      //std::basic_string<wchar_t> prefix(L"\\\\?\\"); // prepended by chdir() and returned by win32
     #else
       char buf[PATH_MAX];
       std::basic_string<char> current_dir(getcwd(buf, PATH_MAX));
-      std::basic_string<char> prefix;
+      //std::basic_string<char> prefix;
     #endif
 
-    ASSERT_TRUE(current_dir == (prefix + path.native()));
+    ASSERT_TRUE(current_dir == path.native());
     ASSERT_TRUE(irs::file_utils::exists(tmpBool, path.c_str()) && tmpBool);
     ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path.c_str()) && tmpBool);
     ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path.c_str()) && !tmpBool);
@@ -85,7 +85,7 @@ TEST_F(utf8_path_tests, current) {
     path /= directory;
     ASSERT_TRUE(irs::file_utils::mkdir(path.c_str(), true));
     ASSERT_TRUE(irs::file_utils::set_cwd(path.c_str()));
-    ASSERT_TRUE(path.native() == irs::utf8_path(true).native());
+    ASSERT_TRUE(path.native() == irs::current_path().native());
     ASSERT_TRUE(irs::file_utils::exists(tmpBool, path.c_str()) && tmpBool);
     ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path.c_str()) && tmpBool);
     ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path.c_str()) && !tmpBool);
@@ -95,7 +95,7 @@ TEST_F(utf8_path_tests, current) {
     path /= directory2;
     ASSERT_TRUE(irs::file_utils::mkdir(path.c_str(), true));
     ASSERT_TRUE(irs::file_utils::set_cwd(path.c_str()));
-    ASSERT_TRUE(path.native() == irs::utf8_path(true).native());
+    ASSERT_TRUE(path.native() == irs::current_path().native());
     ASSERT_TRUE(irs::file_utils::exists(tmpBool, path.c_str()) && tmpBool);
     ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path.c_str()) && tmpBool);
     ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path.c_str()) && !tmpBool);
@@ -166,32 +166,28 @@ TEST_F(utf8_path_tests, absolute) {
   // empty
   {
     irs::utf8_path path;
-    bool tmpBool;
-    ASSERT_TRUE(path.is_absolute(tmpBool) && !tmpBool);
+    ASSERT_FALSE(path.is_absolute());
   }
 
   // cwd
   {
-    irs::utf8_path path(true);
-    bool tmpBool;
-    ASSERT_TRUE(path.is_absolute(tmpBool) && tmpBool);
+    auto path = irs::current_path();
+    ASSERT_TRUE(path.is_absolute());
   }
 
   // relative
   {
     irs::utf8_path path;
-    bool tmpBool;
     path += "deleteme";
-    ASSERT_TRUE(path.is_absolute(tmpBool) && !tmpBool);
+    ASSERT_FALSE(path.is_absolute());
   }
 
   // absolute
   {
-    irs::utf8_path cwd(true);
+    auto cwd = irs::current_path();
     irs::utf8_path path;
-    bool tmpBool;
     path += cwd.native();
-    ASSERT_TRUE(path.is_absolute(tmpBool) && tmpBool);
+    ASSERT_TRUE(path.is_absolute());
   }
 }
 
@@ -206,18 +202,18 @@ TEST_F(utf8_path_tests, path) {
   std::string file1("deleteme");
   std::string file2(file1 + suffix);
   std::string dir1("deleteme.dir");
-  auto pwd_native = irs::utf8_path(true).native();
-  auto pwd_utf8 = irs::utf8_path(true).u8string();
-  auto file1_abs_native = (irs::utf8_path(true) /= file1).native();
-  auto file1f_abs_native = ((irs::utf8_path(true) += "/") += file1).native(); // abs file1 with forward slash
-  auto file1n_abs_native = ((irs::utf8_path(true) += native_path_sep) += file1).native(); // abs file1 with native slash
-  auto file1_abs_utf8 = (irs::utf8_path(true) /= file1).u8string();
-  auto file1f_abs_utf8 = ((irs::utf8_path(true) += "/") += file1).u8string(); // abs file1 with forward slash
-  auto file1n_abs_utf8 = ((irs::utf8_path(true) += native_path_sep) += file1).u8string(); // abs file1 with native slash
-  auto file2_abs_native = (irs::utf8_path(true) /= file2).native();
-  auto file2_abs_utf8 = (irs::utf8_path(true) /= file2).u8string();
-  auto dir_abs_native = (irs::utf8_path(true) /= dir1).native();
-  auto dir_abs_utf8 = (irs::utf8_path(true) /= dir1).u8string();
+  auto pwd_native = irs::current_path().native();
+  auto pwd_utf8 = irs::current_path().u8string();
+  auto file1_abs_native = (irs::current_path() /= file1).native();
+  auto file1f_abs_native = ((irs::current_path() += "/") += file1).native(); // abs file1 with forward slash
+  auto file1n_abs_native = ((irs::current_path() += native_path_sep) += file1).native(); // abs file1 with native slash
+  auto file1_abs_utf8 = (irs::current_path() /= file1).u8string();
+  auto file1f_abs_utf8 = ((irs::current_path() += "/") += file1).u8string(); // abs file1 with forward slash
+  auto file1n_abs_utf8 = ((irs::current_path() += native_path_sep) += file1).u8string(); // abs file1 with native slash
+  auto file2_abs_native = (irs::current_path() /= file2).native();
+  auto file2_abs_utf8 = (irs::current_path() /= file2).u8string();
+  auto dir_abs_native = (irs::current_path() /= dir1).native();
+  auto dir_abs_utf8 = (irs::current_path() /= dir1).u8string();
 
   // create file
   {
@@ -383,7 +379,7 @@ TEST_F(utf8_path_tests, file) {
   ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, path.c_str()) && tmpUint == data.size() * 2);
 
   // assign test
-  irs::utf8_path other(true);
+  auto other = irs::current_path();
   other.assign(path.c_str());
   ASSERT_EQ(other.u8string(), path.u8string());
 
@@ -396,7 +392,7 @@ TEST_F(utf8_path_tests, directory) {
 
   // absolute path creation
   {
-    irs::utf8_path path(true);
+    auto path = irs::current_path();
     std::string directory("deletemeA");
 
     ASSERT_TRUE(irs::file_utils::exists(tmpBool, path.c_str()) && tmpBool);
@@ -450,8 +446,8 @@ TEST_F(utf8_path_tests, directory) {
   {
     std::string directory1("deleteme1");
     std::string directory2("deleteme2");
-    irs::utf8_path path1(true);
-    irs::utf8_path path2(true);
+    auto path1 = irs::current_path();
+    auto path2 = irs::current_path();
 
     path1 /= directory1;
     path2 /= directory1;
@@ -599,8 +595,8 @@ TEST_F(utf8_path_tests, directory) {
   {
     std::string directory1("deleteme1");
     std::string directory2("deleteme2/deleteme3"); // explicitly use '/' and not native
-    irs::utf8_path path1(true);
-    irs::utf8_path path2(true);
+    auto path1 = irs::current_path();
+    auto path2 = irs::current_path();
 
     path1 /= directory1;
     path2 /= directory1;
@@ -813,8 +809,8 @@ void validate_move(bool src_abs, bool dst_abs) {
     std::string missing("deleteme");
     std::string src("deleteme.src");
     std::string dst("deleteme.dst0");
-    irs::utf8_path src_path(src_abs);
-    irs::utf8_path dst_path(dst_abs);
+    irs::utf8_path src_path = src_abs? irs::current_path() : irs::utf8_path();
+    irs::utf8_path dst_path = dst_abs? irs::current_path() : irs::utf8_path();
 
     src_path/=src;
     dst_path/=dst;
@@ -851,8 +847,8 @@ void validate_move(bool src_abs, bool dst_abs) {
   {
     std::string src("deleteme.src");
     std::string dst("deleteme.dst1");
-    irs::utf8_path src_path(src_abs);
-    irs::utf8_path dst_path(dst_abs);
+    irs::utf8_path src_path = src_abs? irs::current_path() : irs::utf8_path();
+    irs::utf8_path dst_path = dst_abs? irs::current_path() : irs::utf8_path();
 
     src_path/=src;
     dst_path/=dst;
@@ -891,8 +887,8 @@ void validate_move(bool src_abs, bool dst_abs) {
     std::string missing("deleteme");
     std::string src("deleteme.src");
     std::string dst("deleteme.dst2");
-    irs::utf8_path src_path(src_abs);
-    irs::utf8_path dst_path(dst_abs);
+    irs::utf8_path src_path = src_abs? irs::current_path() : irs::utf8_path();
+    irs::utf8_path dst_path = dst_abs? irs::current_path() : irs::utf8_path();
 
     src_path/=src;
     dst_path/=dst;
@@ -931,8 +927,8 @@ void validate_move(bool src_abs, bool dst_abs) {
     std::string file("deleteme.file");
     std::string src("deleteme.src");
     std::string dst("deleteme.dst3");
-    irs::utf8_path src_path(src_abs);
-    irs::utf8_path dst_path(dst_abs);
+    irs::utf8_path src_path = src_abs? irs::current_path() : irs::utf8_path();
+    irs::utf8_path dst_path = dst_abs? irs::current_path() : irs::utf8_path();
 
     src_path/=src;
     dst_path/=dst;
@@ -978,8 +974,8 @@ void validate_move(bool src_abs, bool dst_abs) {
     std::string directory("deleteme");
     std::string src("deleteme.src");
     std::string dst("deleteme.dst4");
-    irs::utf8_path src_path(src_abs);
-    irs::utf8_path dst_path(dst_abs);
+    irs::utf8_path src_path = src_abs? irs::current_path() : irs::utf8_path();
+    irs::utf8_path dst_path = dst_abs? irs::current_path() : irs::utf8_path();
 
     src_path/=src;
     dst_path/=dst;
@@ -1018,8 +1014,8 @@ void validate_move(bool src_abs, bool dst_abs) {
     std::string missing("deleteme");
     std::string src("deleteme.src5");
     std::string dst("deleteme.dst5");
-    irs::utf8_path src_path(src_abs);
-    irs::utf8_path dst_path(dst_abs);
+    irs::utf8_path src_path = src_abs? irs::current_path() : irs::utf8_path();
+    irs::utf8_path dst_path = dst_abs? irs::current_path() : irs::utf8_path();
 
     src_path/=src;
     dst_path/=dst;
@@ -1058,9 +1054,9 @@ void validate_move(bool src_abs, bool dst_abs) {
   {
     std::string src("deleteme.src6");
     std::string dst("deleteme.dst6");
-    irs::utf8_path src_path(src_abs);
-    irs::utf8_path dst_path(dst_abs);
-    irs::utf8_path dst_path_expected(dst_abs);
+    irs::utf8_path src_path = src_abs? irs::current_path() : irs::utf8_path();
+    irs::utf8_path dst_path = dst_abs? irs::current_path() : irs::utf8_path();
+    irs::utf8_path dst_path_expected = dst_abs? irs::current_path() : irs::utf8_path();
 
     src_path/=src;
     dst_path/=dst;
@@ -1108,8 +1104,8 @@ void validate_move(bool src_abs, bool dst_abs) {
     std::string missing("deleteme");
     std::string src("deleteme.src7");
     std::string dst("deleteme.dst7");
-    irs::utf8_path src_path(src_abs);
-    irs::utf8_path dst_path(dst_abs);
+    irs::utf8_path src_path = src_abs? irs::current_path() : irs::utf8_path();
+    irs::utf8_path dst_path = dst_abs? irs::current_path() : irs::utf8_path();
 
     src_path/=src;
     dst_path/=dst;
@@ -1150,8 +1146,8 @@ void validate_move(bool src_abs, bool dst_abs) {
     std::string file("deleteme");
     std::string src("deleteme.src8");
     std::string dst("deleteme.dst8");
-    irs::utf8_path src_path(src_abs);
-    irs::utf8_path dst_path(dst_abs);
+    irs::utf8_path src_path = src_abs? irs::current_path() : irs::utf8_path();
+    irs::utf8_path dst_path = dst_abs? irs::current_path() : irs::utf8_path();
     std::string dst_data("data");
 
     src_path/=src;
@@ -1206,10 +1202,10 @@ void validate_move(bool src_abs, bool dst_abs) {
     std::string dst_dir("deleteme.dst");
     std::string src("deleteme.src9");
     std::string dst("deleteme.dst9");
-    irs::utf8_path src_path(src_abs);
-    irs::utf8_path dst_path(dst_abs);
-    irs::utf8_path src_path_expected(src_abs);
-    irs::utf8_path dst_path_expected(dst_abs);
+    irs::utf8_path src_path = src_abs? irs::current_path() : irs::utf8_path();
+    irs::utf8_path dst_path = dst_abs? irs::current_path() : irs::utf8_path();
+    irs::utf8_path src_path_expected = src_abs? irs::current_path() : irs::utf8_path();
+    irs::utf8_path dst_path_expected = dst_abs? irs::current_path() : irs::utf8_path();
 
     src_path/=src;
     dst_path/=dst;
@@ -1264,8 +1260,8 @@ void validate_move(bool src_abs, bool dst_abs) {
     std::string missing("deleteme");
     std::string src("deleteme.srcA");
     std::string dst("deleteme.dstA");
-    irs::utf8_path src_path(src_abs);
-    irs::utf8_path dst_path(dst_abs);
+    irs::utf8_path src_path = src_abs? irs::current_path() : irs::utf8_path();
+    irs::utf8_path dst_path = dst_abs? irs::current_path() : irs::utf8_path();
 
     src_path/=src;
     dst_path/=dst;
@@ -1310,9 +1306,9 @@ void validate_move(bool src_abs, bool dst_abs) {
     std::string data("ABCdata123");
     std::string src("deleteme.srcB");
     std::string dst("deleteme.dstB");
-    irs::utf8_path src_path(src_abs);
-    irs::utf8_path dst_path(dst_abs);
-    irs::utf8_path dst_path_expected(dst_abs);
+    irs::utf8_path src_path = src_abs? irs::current_path() : irs::utf8_path();
+    irs::utf8_path dst_path = dst_abs? irs::current_path() : irs::utf8_path();
+    irs::utf8_path dst_path_expected = dst_abs? irs::current_path() : irs::utf8_path();
 
     src_path/=src;
     dst_path/=dst;
@@ -1361,8 +1357,8 @@ void validate_move(bool src_abs, bool dst_abs) {
     std::string missing("deleteme");
     std::string src("deleteme.srcC");
     std::string dst("deleteme.dstC");
-    irs::utf8_path src_path(src_abs);
-    irs::utf8_path dst_path(dst_abs);
+    irs::utf8_path src_path = src_abs? irs::current_path() : irs::utf8_path();
+    irs::utf8_path dst_path = dst_abs? irs::current_path() : irs::utf8_path();
 
     src_path/=src;
     dst_path/=dst;
@@ -1410,8 +1406,8 @@ void validate_move(bool src_abs, bool dst_abs) {
     std::string file("deleteme");
     std::string src("deleteme.srcD");
     std::string dst("deleteme.dstD");
-    irs::utf8_path src_path(src_abs);
-    irs::utf8_path dst_path(dst_abs);
+    irs::utf8_path src_path = src_abs? irs::current_path() : irs::utf8_path();
+    irs::utf8_path dst_path = dst_abs? irs::current_path() : irs::utf8_path();
 
     src_path/=src;
     dst_path/=dst;
@@ -1465,8 +1461,8 @@ void validate_move(bool src_abs, bool dst_abs) {
     std::string file("deleteme");
     std::string src("deleteme.srcE");
     std::string dst("deleteme.dstE");
-    irs::utf8_path src_path(src_abs);
-    irs::utf8_path dst_path(dst_abs);
+    irs::utf8_path src_path = src_abs? irs::current_path() : irs::utf8_path();
+    irs::utf8_path dst_path = dst_abs? irs::current_path() : irs::utf8_path();
 
     src_path/=src;
     dst_path/=dst;

--- a/tests/utils/utf8_path_tests.cpp
+++ b/tests/utils/utf8_path_tests.cpp
@@ -1,0 +1,1527 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2017 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Andrey Abramov
+/// @author Vasiliy Nabatchikov
+////////////////////////////////////////////////////////////////////////////////
+
+#include <fstream>
+#include <thread>
+#include <condition_variable>
+
+#include "tests_shared.hpp"
+#include "utils/file_utils.hpp"
+#include "utils/utf8_path.hpp"
+
+using namespace std::chrono_literals;
+
+namespace {
+
+class utf8_path_tests: public test_base {
+  irs::utf8_path cwd_;
+
+  virtual void SetUp() {
+    // Code here will be called immediately after the constructor (right before each test).
+
+    test_base::SetUp();
+    cwd_ = irs::utf8_path(true);
+    irs::file_utils::mkdir(test_dir().c_str(), false); // ensure path exists
+    irs::file_utils::set_cwd(test_dir().c_str()); // ensure all files/directories created in a valid place
+  }
+
+  virtual void TearDown() {
+    // Code here will be called immediately after each test (right before the destructor).
+
+    irs::file_utils::set_cwd(cwd_.c_str());
+    test_base::TearDown();
+  }
+};
+
+}
+
+TEST_F(utf8_path_tests, current) {
+  // absolute path
+  {
+    irs::utf8_path path(true);
+    std::string directory("deleteme");
+    std::string directory2("deleteme2");
+    bool tmpBool;
+    std::time_t tmpTime;
+    uint64_t tmpUint;
+
+    #ifdef _WIN32
+      wchar_t buf[_MAX_PATH];
+      std::basic_string<wchar_t> current_dir(_wgetcwd(buf, _MAX_PATH));
+      std::basic_string<wchar_t> prefix(L"\\\\?\\"); // prepended by chdir() and returned by win32
+    #else
+      char buf[PATH_MAX];
+      std::basic_string<char> current_dir(getcwd(buf, PATH_MAX));
+      std::basic_string<char> prefix;
+    #endif
+
+    ASSERT_TRUE(current_dir == (prefix + path.native()));
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, path.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, path.c_str()));
+
+    path /= directory;
+    ASSERT_TRUE(irs::file_utils::mkdir(path.c_str(), true));
+    ASSERT_TRUE(irs::file_utils::set_cwd(path.c_str()));
+    ASSERT_TRUE(path.native() == irs::utf8_path(true).native());
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, path.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, path.c_str()));
+    
+    path /= directory2;
+    ASSERT_TRUE(irs::file_utils::mkdir(path.c_str(), true));
+    ASSERT_TRUE(irs::file_utils::set_cwd(path.c_str()));
+    ASSERT_TRUE(path.native() == irs::utf8_path(true).native());
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, path.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, path.c_str()));
+  }
+
+  // relative path
+  {
+    irs::utf8_path path;
+    std::string directory("deleteme");
+    std::string directory2("deleteme2");
+    bool tmpBool;
+    std::time_t tmpTime;
+    uint64_t tmpUint;
+
+    #ifdef _WIN32
+      wchar_t buf[_MAX_PATH];
+      std::basic_string<wchar_t> current_dir(_wgetcwd(buf, _MAX_PATH));
+      std::basic_string<wchar_t> prefix(L"\\\\?\\"); // prepended by chdir() and returned by win32
+    #else
+      char buf[PATH_MAX];
+      std::basic_string<char> current_dir(getcwd(buf, PATH_MAX));
+      std::basic_string<char> prefix;
+    #endif
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, path.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, path.c_str()));
+
+    path /= directory;
+    ASSERT_TRUE(irs::file_utils::mkdir(path.c_str(), true));
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, path.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, path.c_str()));
+
+    path /= directory2;
+    ASSERT_TRUE(irs::file_utils::mkdir(path.c_str(), true));
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, path.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, path.c_str()));
+  }
+}
+
+TEST_F(utf8_path_tests, empty) {
+  irs::utf8_path path;
+  std::string empty("");
+  bool tmpBool;
+  std::time_t tmpTime;
+  uint64_t tmpUint;
+
+  ASSERT_TRUE(irs::file_utils::exists(tmpBool, path.c_str()) && !tmpBool);
+  ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path.c_str()) && !tmpBool);
+  ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path.c_str()) && !tmpBool);
+  ASSERT_FALSE(irs::file_utils::mtime(tmpTime, path.c_str()));
+  ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, path.c_str()));
+  path/=empty;
+  ASSERT_FALSE(irs::file_utils::mkdir(path.c_str(), true));
+}
+
+TEST_F(utf8_path_tests, absolute) {
+  // empty
+  {
+    irs::utf8_path path;
+    bool tmpBool;
+    ASSERT_TRUE(path.is_absolute(tmpBool) && !tmpBool);
+  }
+
+  // cwd
+  {
+    irs::utf8_path path(true);
+    bool tmpBool;
+    ASSERT_TRUE(path.is_absolute(tmpBool) && tmpBool);
+  }
+
+  // relative
+  {
+    irs::utf8_path path;
+    bool tmpBool;
+    path += "deleteme";
+    ASSERT_TRUE(path.is_absolute(tmpBool) && !tmpBool);
+  }
+
+  // absolute
+  {
+    irs::utf8_path cwd(true);
+    irs::utf8_path path;
+    bool tmpBool;
+    path += cwd.native();
+    ASSERT_TRUE(path.is_absolute(tmpBool) && tmpBool);
+  }
+}
+
+TEST_F(utf8_path_tests, path) {
+  #if defined(_MSC_VER)
+    const char* native_path_sep("\\");
+  #else
+    const char* native_path_sep("/");
+  #endif
+  std::string data("data");
+  std::string suffix(".other");
+  std::string file1("deleteme");
+  std::string file2(file1 + suffix);
+  std::string dir1("deleteme.dir");
+  auto pwd_native = irs::utf8_path(true).native();
+  auto pwd_utf8 = irs::utf8_path(true).u8string();
+  auto file1_abs_native = (irs::utf8_path(true) /= file1).native();
+  auto file1f_abs_native = ((irs::utf8_path(true) += "/") += file1).native(); // abs file1 with forward slash
+  auto file1n_abs_native = ((irs::utf8_path(true) += native_path_sep) += file1).native(); // abs file1 with native slash
+  auto file1_abs_utf8 = (irs::utf8_path(true) /= file1).u8string();
+  auto file1f_abs_utf8 = ((irs::utf8_path(true) += "/") += file1).u8string(); // abs file1 with forward slash
+  auto file1n_abs_utf8 = ((irs::utf8_path(true) += native_path_sep) += file1).u8string(); // abs file1 with native slash
+  auto file2_abs_native = (irs::utf8_path(true) /= file2).native();
+  auto file2_abs_utf8 = (irs::utf8_path(true) /= file2).u8string();
+  auto dir_abs_native = (irs::utf8_path(true) /= dir1).native();
+  auto dir_abs_utf8 = (irs::utf8_path(true) /= dir1).u8string();
+
+  // create file
+  {
+    std::ofstream out(file1.c_str());
+    out << data;
+    out.close();
+  }
+
+  // from native string_ref
+  {
+    irs::utf8_path path1(file1_abs_native.c_str());
+    irs::utf8_path path1f(file1f_abs_native.c_str());
+    irs::utf8_path path1n(file1n_abs_native.c_str());
+    irs::utf8_path path2(file2_abs_native.c_str());
+    irs::utf8_path dir1(pwd_native.c_str());
+    irs::utf8_path dir2(dir_abs_native.c_str());
+    bool tmpBool;
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path1.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path1.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path1.c_str()) && tmpBool);
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path1f.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path1f.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path1f.c_str()) && tmpBool);
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path1n.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path1n.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path1n.c_str()) && tmpBool);
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path2.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path2.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path2.c_str()) && !tmpBool);
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, dir1.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, dir1.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, dir1.c_str()) && !tmpBool);
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, dir2.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, dir2.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, dir2.c_str()) && !tmpBool);
+  }
+
+  // from utf8 string
+  {
+    irs::utf8_path path1(file1_abs_utf8);
+    irs::utf8_path path1f(file1f_abs_utf8);
+    irs::utf8_path path1n(file1n_abs_utf8);
+    irs::utf8_path path2(file2_abs_utf8);
+    irs::utf8_path dir1(pwd_utf8);
+    irs::utf8_path dir2(dir_abs_utf8);
+    bool tmpBool;
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path1.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path1.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path1.c_str()) && tmpBool);
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path1f.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path1f.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path1f.c_str()) && tmpBool);
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path1n.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path1n.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path1n.c_str()) && tmpBool);
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path2.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path2.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path2.c_str()) && !tmpBool);
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, dir1.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, dir1.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, dir1.c_str()) && !tmpBool);
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, dir2.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, dir2.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, dir2.c_str()) && !tmpBool);
+  }
+
+  // from utf8 string_ref
+  {
+    irs::utf8_path path1(file1_abs_utf8.c_str());
+    irs::utf8_path path1f(file1f_abs_utf8.c_str());
+    irs::utf8_path path1n(file1n_abs_utf8.c_str());
+    irs::utf8_path path2(file2_abs_utf8.c_str());
+    irs::utf8_path dir1(pwd_utf8.c_str());
+    irs::utf8_path dir2(dir_abs_utf8.c_str());
+    bool tmpBool;
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path1.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path1.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path1.c_str()) && tmpBool);
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path1f.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path1f.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path1f.c_str()) && tmpBool);
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path1n.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path1n.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path1n.c_str()) && tmpBool);
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path2.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path2.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path2.c_str()) && !tmpBool);
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, dir1.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, dir1.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, dir1.c_str()) && !tmpBool);
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, dir2.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, dir2.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, dir2.c_str()) && !tmpBool);
+  }
+}
+
+TEST_F(utf8_path_tests, file) {
+  irs::utf8_path path;
+  std::string suffix(".other");
+  std::string file1("deleteme");
+  std::string file2(file1 + suffix);
+  bool tmpBool;
+  std::time_t tmpTime;
+  uint64_t tmpUint;
+
+  ASSERT_TRUE(irs::file_utils::exists(tmpBool, path.c_str()) && !tmpBool);
+  ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path.c_str()) && !tmpBool);
+  ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path.c_str()) && !tmpBool);
+  ASSERT_FALSE(irs::file_utils::mtime(tmpTime, path.c_str()));
+  ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, path.c_str()));
+
+  path/=file1;
+  ASSERT_TRUE(irs::file_utils::exists(tmpBool, path.c_str()) && !tmpBool);
+  ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path.c_str()) && !tmpBool);
+  ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path.c_str()) && !tmpBool);
+  ASSERT_FALSE(irs::file_utils::mtime(tmpTime, path.c_str()));
+  ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, path.c_str()));
+
+  std::string data("data");
+  std::ofstream out1(file1.c_str());
+  out1 << data;
+  out1.close();
+  ASSERT_TRUE(irs::file_utils::exists(tmpBool, path.c_str()) && tmpBool);
+  ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path.c_str()) && !tmpBool);
+  ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path.c_str()) && tmpBool);
+  ASSERT_TRUE(irs::file_utils::mtime(tmpTime, path.c_str()) && tmpTime > 0);
+  ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, path.c_str()) && tmpUint == data.size());
+
+  ASSERT_FALSE(irs::file_utils::mkdir(path.c_str(), true));
+
+  path+=suffix;
+  ASSERT_TRUE(irs::file_utils::exists(tmpBool, path.c_str()) && !tmpBool);
+  ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path.c_str()) && !tmpBool);
+  ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path.c_str()) && !tmpBool);
+  ASSERT_FALSE(irs::file_utils::mtime(tmpTime, path.c_str()));
+  ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, path.c_str()));
+
+  std::ofstream out2(file2.c_str());
+  out2 << data << data;
+  out2.close();
+  ASSERT_TRUE(irs::file_utils::exists(tmpBool, path.c_str()) && tmpBool);
+  ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path.c_str()) && !tmpBool);
+  ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path.c_str()) && tmpBool);
+  ASSERT_TRUE(irs::file_utils::mtime(tmpTime, path.c_str()) && tmpTime > 0);
+  ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, path.c_str()) && tmpUint == data.size() * 2);
+
+  // assign test
+  irs::utf8_path other(true);
+  other.assign(path.c_str());
+  ASSERT_EQ(other.u8string(), path.u8string());
+
+}
+
+TEST_F(utf8_path_tests, directory) {
+  bool tmpBool;
+  std::time_t tmpTime;
+  uint64_t tmpUint;
+
+  // absolute path creation
+  {
+    irs::utf8_path path(true);
+    std::string directory("deletemeA");
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, path.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, path.c_str()));
+
+    path /= directory;
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, path.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, path.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::mkdir(path.c_str(), true));
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, path.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, path.c_str()));
+  }
+
+  // relative path creation
+  {
+    irs::utf8_path path;
+    std::string directory("deletemeR");
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, path.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, path.c_str()));
+
+    path /= directory;
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, path.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, path.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::mkdir(path.c_str(), true));
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, path.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, path.c_str()));
+  }
+
+  // recursive path creation (absolute)
+  {
+    std::string directory1("deleteme1");
+    std::string directory2("deleteme2");
+    irs::utf8_path path1(true);
+    irs::utf8_path path2(true);
+
+    path1 /= directory1;
+    path2 /= directory1;
+    path2 /= directory2;
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path1.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path1.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path1.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, path1.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, path1.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path2.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path2.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path2.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, path2.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, path2.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::mkdir(path2.c_str(), true));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path1.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path1.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path1.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, path1.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, path1.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path2.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path2.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path2.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, path2.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, path2.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::remove(path1.c_str())); // recursive remove successful
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path1.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path1.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path1.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, path1.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, path1.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path2.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path2.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path2.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, path2.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, path2.c_str()));
+
+    ASSERT_FALSE(irs::file_utils::remove(path2.c_str())); // path already removed
+  }
+
+  // recursive path creation (relative)
+  {
+    std::string directory1("deleteme1");
+    std::string directory2("deleteme2");
+    irs::utf8_path path1;
+    irs::utf8_path path2;
+
+    path1 /= directory1;
+    path2 /= directory1;
+    path2 /= directory2;
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path1.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path1.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path1.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, path1.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, path1.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path2.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path2.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path2.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, path2.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, path2.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::mkdir(path2.c_str(), true));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path1.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path1.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path1.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, path1.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, path1.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path2.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path2.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path2.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, path2.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, path2.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::remove(path1.c_str())); // recursive remove successful
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path1.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path1.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path1.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, path1.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, path1.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path2.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path2.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path2.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, path2.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, path2.c_str()));
+
+    ASSERT_FALSE(irs::file_utils::remove(path2.c_str())); // path already removed
+  }
+
+  // recursive path creation failure
+  {
+    std::string data("data");
+    std::string directory("deleteme");
+    std::string file("deleteme.file");
+    irs::utf8_path path1;
+    irs::utf8_path path2;
+
+    path1 /= file;
+    path2 /= file;
+    path2 /= directory;
+
+    // create file
+    {
+      std::ofstream out(file.c_str());
+      out << data;
+      out.close();
+    }
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path1.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path1.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path1.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, path1.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, path1.c_str()) && tmpUint == data.size());
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path2.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path2.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path2.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, path2.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, path2.c_str()));
+
+    ASSERT_FALSE(irs::file_utils::mkdir(path2.c_str(), true));
+
+    ASSERT_TRUE(irs::file_utils::remove(path1.c_str())); // file remove successful
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path1.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path1.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path1.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, path1.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, path1.c_str()));
+  }
+
+  // recursive multi-level path creation (absolute)
+  {
+    std::string directory1("deleteme1");
+    std::string directory2("deleteme2/deleteme3"); // explicitly use '/' and not native
+    irs::utf8_path path1(true);
+    irs::utf8_path path2(true);
+
+    path1 /= directory1;
+    path2 /= directory1;
+    path2 /= directory2;
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path1.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path1.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path1.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, path1.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, path1.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path2.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path2.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path2.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, path2.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, path2.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::mkdir(path2.c_str(), true));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path1.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path1.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path1.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, path1.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, path1.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path2.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path2.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path2.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, path2.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, path2.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::remove(path1.c_str())); // recursive remove successful
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path1.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path1.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path1.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, path1.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, path1.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path2.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path2.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path2.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, path2.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, path2.c_str()));
+
+    ASSERT_FALSE(irs::file_utils::remove(path2.c_str())); // path already removed
+  }
+
+  // recursive multi-level path creation (relative)
+  {
+    std::string directory1("deleteme1");
+    std::string directory2("deleteme2/deleteme3"); // explicitly use '/' and not native
+    irs::utf8_path path1;
+    irs::utf8_path path2;
+
+    path1 /= directory1;
+    path2 /= directory1;
+    path2 /= directory2;
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path1.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path1.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path1.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, path1.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, path1.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path2.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path2.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path2.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, path2.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, path2.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::mkdir(path2.c_str(), true));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path1.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path1.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path1.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, path1.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, path1.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path2.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path2.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path2.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, path2.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, path2.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::remove(path1.c_str())); // recursive remove successful
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path1.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path1.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path1.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, path1.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, path1.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool, path2.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool, path2.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool, path2.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, path2.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, path2.c_str()));
+
+    ASSERT_FALSE(irs::file_utils::remove(path2.c_str())); // path already removed
+  }
+
+  // recursive path creation with concurrency (full path exists)
+  {
+    std::string directory1("deleteme1/deleteme2/deleteme3");
+    irs::utf8_path path1;
+    irs::utf8_path path2;
+
+    path1 /= directory1;
+    path2 /= directory1;
+   
+    EXPECT_TRUE(irs::file_utils::mkdir(path1.c_str(), true));
+    EXPECT_FALSE(irs::file_utils::mkdir(path2.c_str(), true)); // directory already exists 
+    EXPECT_TRUE(irs::file_utils::mkdir(path2.c_str(), false)); // directory exists, but creation is not mandatory
+
+    ASSERT_TRUE(irs::file_utils::remove(path1.c_str()));
+    ASSERT_FALSE(irs::file_utils::remove(path2.c_str())); // path already removed
+  }
+  // recursive path creation with concurrency (only last sement added)
+  {
+    std::string directory1("deleteme1/deleteme2/deleteme3");
+    std::string directory2("deleteme4");
+    irs::utf8_path path1;
+    irs::utf8_path path2;
+
+    path1 /= directory1;
+    path2 /= directory1;
+    path2 /= directory2;
+
+    ASSERT_TRUE(irs::file_utils::mkdir(path1.c_str(), true));
+    ASSERT_TRUE(irs::file_utils::mkdir(path2.c_str(), true)); // last segment created
+
+    ASSERT_TRUE(irs::file_utils::remove(path1.c_str()));
+    ASSERT_FALSE(irs::file_utils::remove(path2.c_str())); // path already removed
+  }
+  // race condition test inside path tree building
+  {
+    std::string directory1("deleteme1");
+    std::string directory2("deleteme2/deleteme3/deleteme_thread");
+    irs::utf8_path pathRoot;
+    pathRoot /= directory1;
+
+    // threads sync for start
+    std::mutex mutex;
+    std::condition_variable ready_cv;
+
+    for (size_t j = 0; j < 3; ++j) {
+      irs::file_utils::remove(pathRoot.c_str()); // make sure full path tree building always needed
+      
+      const auto thread_count = 20;
+      std::vector<int> results(thread_count, false);
+      std::vector<std::thread> pool;
+      // We need all threads to be in same position to maximize test validity (not just ready to run!). 
+      // So we count ready threads
+      size_t readyCount = 0; 
+      bool ready = false;  // flag to indicate all is ready (needed for spurious wakeup check)
+
+      for (size_t i = 0; i < thread_count; ++i) {
+        auto& result = results[i];
+        pool.emplace_back(std::thread([ &result, &directory1, &directory2, i, &mutex, &ready_cv, &readyCount, &ready]() {
+          irs::utf8_path path;
+          path /= directory1;
+          std::ostringstream ss;
+          ss << directory2 << i;
+          path /= ss.str();
+          
+          std::unique_lock<std::mutex> lk(mutex);
+          ++readyCount;
+          while (!ready) {
+            ready_cv.wait(lk);
+          }
+          lk.unlock();
+          result = irs::file_utils::mkdir(path.c_str(), true) ? 1 : 0;
+        }));
+      }
+     
+      while(true) {
+        {
+          std::lock_guard<decltype(mutex)> lock(mutex);
+          if (readyCount >= thread_count) { 
+            // all threads on positions... go, go, go...
+            ready = true;
+            ready_cv.notify_all();
+            break;
+          }
+        }
+        std::this_thread::sleep_for(1000ms);
+      }
+      for (auto& thread : pool) {
+        thread.join();
+      }
+     
+      ASSERT_TRUE(std::all_of(
+        results.begin(), results.end(), [](bool res) { return res != 0; }
+      ));
+      irs::file_utils::remove(pathRoot.c_str()); // cleanup
+    }
+  }
+
+
+}
+
+void validate_move(bool src_abs, bool dst_abs) {
+  bool tmpBool;
+  std::time_t tmpTime;
+  uint64_t tmpUint;
+
+  // non-existent -> non-existent/non-existent
+  {
+    std::string missing("deleteme");
+    std::string src("deleteme.src");
+    std::string dst("deleteme.dst0");
+    irs::utf8_path src_path(src_abs);
+    irs::utf8_path dst_path(dst_abs);
+
+    src_path/=src;
+    dst_path/=dst;
+    dst_path/=missing;
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, src_path.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, src_path.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, dst_path.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, dst_path.c_str()));
+
+    ASSERT_FALSE(irs::file_utils::move(src_path.c_str(), dst_path.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, src_path.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, src_path.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, dst_path.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, dst_path.c_str()));
+  }
+
+  // non-existent -> directory/
+  {
+    std::string src("deleteme.src");
+    std::string dst("deleteme.dst1");
+    irs::utf8_path src_path(src_abs);
+    irs::utf8_path dst_path(dst_abs);
+
+    src_path/=src;
+    dst_path/=dst;
+    ASSERT_TRUE(irs::file_utils::mkdir(dst_path.c_str(), true));
+    dst_path/="";
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, src_path.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, src_path.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  dst_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  dst_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, dst_path.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, dst_path.c_str()));
+
+    ASSERT_FALSE(irs::file_utils::move(src_path.c_str(), dst_path.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, src_path.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, src_path.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  dst_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  dst_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, dst_path.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, dst_path.c_str()));
+  }
+
+  // non-existent -> directory/non-existent
+  {
+    std::string missing("deleteme");
+    std::string src("deleteme.src");
+    std::string dst("deleteme.dst2");
+    irs::utf8_path src_path(src_abs);
+    irs::utf8_path dst_path(dst_abs);
+
+    src_path/=src;
+    dst_path/=dst;
+    ASSERT_TRUE(irs::file_utils::mkdir(dst_path.c_str(), true));
+    dst_path/=missing;
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, src_path.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, src_path.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, dst_path.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, dst_path.c_str()));
+
+    ASSERT_FALSE(irs::file_utils::move(src_path.c_str(), dst_path.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, src_path.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, src_path.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, dst_path.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, dst_path.c_str()));
+  }
+
+  // non-existent -> directory/file
+  {
+    std::string file("deleteme.file");
+    std::string src("deleteme.src");
+    std::string dst("deleteme.dst3");
+    irs::utf8_path src_path(src_abs);
+    irs::utf8_path dst_path(dst_abs);
+
+    src_path/=src;
+    dst_path/=dst;
+    dst_path/=file;
+
+    // create file
+    {
+      std::string data("data");
+      std::ofstream out(dst_path.c_str());
+      out << data;
+      out.close();
+    }
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, src_path.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, src_path.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, dst_path.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, dst_path.c_str()));
+
+    ASSERT_FALSE(irs::file_utils::move(src_path.c_str(), dst_path.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, src_path.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, src_path.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, dst_path.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, dst_path.c_str()));
+  }
+
+  // non-existent -> directory/directory
+  {
+    std::string directory("deleteme");
+    std::string src("deleteme.src");
+    std::string dst("deleteme.dst4");
+    irs::utf8_path src_path(src_abs);
+    irs::utf8_path dst_path(dst_abs);
+
+    src_path/=src;
+    dst_path/=dst;
+    dst_path/=directory;
+    ASSERT_TRUE(irs::file_utils::mkdir(dst_path.c_str(), true));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, src_path.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, src_path.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  dst_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  dst_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, dst_path.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, dst_path.c_str()));
+
+    ASSERT_FALSE(irs::file_utils::move(src_path.c_str(), dst_path.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, src_path.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, src_path.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  dst_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  dst_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, dst_path.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, dst_path.c_str()));
+  }
+
+  // directory -> non-existent/non-existent
+  {
+    std::string missing("deleteme");
+    std::string src("deleteme.src5");
+    std::string dst("deleteme.dst5");
+    irs::utf8_path src_path(src_abs);
+    irs::utf8_path dst_path(dst_abs);
+
+    src_path/=src;
+    dst_path/=dst;
+    dst_path/=missing;
+
+    ASSERT_TRUE(irs::file_utils::mkdir(src_path.c_str(), true));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  src_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  src_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, src_path.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, src_path.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, dst_path.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, dst_path.c_str()));
+
+    ASSERT_FALSE(irs::file_utils::move(src_path.c_str(), dst_path.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  src_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  src_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, src_path.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, src_path.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, dst_path.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, dst_path.c_str()));
+  }
+
+  // directory -> directory/
+  {
+    std::string src("deleteme.src6");
+    std::string dst("deleteme.dst6");
+    irs::utf8_path src_path(src_abs);
+    irs::utf8_path dst_path(dst_abs);
+    irs::utf8_path dst_path_expected(dst_abs);
+
+    src_path/=src;
+    dst_path/=dst;
+    ASSERT_TRUE(irs::file_utils::mkdir(dst_path.c_str(), true));
+    dst_path/="";
+    dst_path_expected/=dst;
+    dst_path_expected/=src;
+
+    ASSERT_TRUE(irs::file_utils::mkdir(src_path.c_str(), true));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  src_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  src_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, src_path.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, src_path.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  dst_path_expected.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  dst_path_expected.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  dst_path_expected.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, dst_path_expected.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, dst_path_expected.c_str()));
+
+#ifdef _WIN32
+    // Boost fails to rename on win32
+    ASSERT_FALSE(irs::file_utils::move(src_path.c_str(), dst_path.c_str()));
+#else
+    ASSERT_TRUE(irs::file_utils::move(src_path.c_str(), dst_path.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, src_path.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, src_path.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  dst_path_expected.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  dst_path_expected.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  dst_path_expected.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, dst_path_expected.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, dst_path_expected.c_str()));
+#endif
+  }
+
+  // directory -> directory/non-existent
+  {
+    std::string missing("deleteme");
+    std::string src("deleteme.src7");
+    std::string dst("deleteme.dst7");
+    irs::utf8_path src_path(src_abs);
+    irs::utf8_path dst_path(dst_abs);
+
+    src_path/=src;
+    dst_path/=dst;
+    ASSERT_TRUE(irs::file_utils::mkdir(dst_path.c_str(), true));
+    dst_path/=missing;
+
+    ASSERT_TRUE(irs::file_utils::mkdir(src_path.c_str(), true));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  src_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  src_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, src_path.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, src_path.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, dst_path.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, dst_path.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::move(src_path.c_str(), dst_path.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, src_path.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, src_path.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  dst_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  dst_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, dst_path.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, dst_path.c_str()));
+  }
+
+  // directory -> directory/file
+  {
+    std::string file("deleteme");
+    std::string src("deleteme.src8");
+    std::string dst("deleteme.dst8");
+    irs::utf8_path src_path(src_abs);
+    irs::utf8_path dst_path(dst_abs);
+    std::string dst_data("data");
+
+    src_path/=src;
+    dst_path/=dst;
+    ASSERT_TRUE(irs::file_utils::mkdir(dst_path.c_str(), true));
+    dst_path/=file;
+
+    ASSERT_TRUE(irs::file_utils::mkdir(src_path.c_str(), true));
+
+    // create file
+    {
+      std::ofstream out(dst_path.c_str());
+      out << dst_data;
+      out.close();
+    }
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  src_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  src_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, src_path.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, src_path.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  dst_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  dst_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, dst_path.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, dst_path.c_str()) && tmpUint == dst_data.size());
+
+#ifdef _WIN32
+    // Boost forces overwrite on win32
+    ASSERT_TRUE(irs::file_utils::move(src_path.c_str(), dst_path.c_str()));
+#else
+    ASSERT_FALSE(irs::file_utils::move(src_path.c_str(), dst_path.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  src_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  src_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, src_path.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, src_path.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  dst_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  dst_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, dst_path.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, dst_path.c_str()) && tmpUint == dst_data.size());
+#endif
+  }
+
+  // directory -> directory/directory
+  {
+    std::string src_dir("deleteme.src");
+    std::string dst_dir("deleteme.dst");
+    std::string src("deleteme.src9");
+    std::string dst("deleteme.dst9");
+    irs::utf8_path src_path(src_abs);
+    irs::utf8_path dst_path(dst_abs);
+    irs::utf8_path src_path_expected(src_abs);
+    irs::utf8_path dst_path_expected(dst_abs);
+
+    src_path/=src;
+    dst_path/=dst;
+    ASSERT_TRUE(irs::file_utils::mkdir(dst_path.c_str(), true));
+    dst_path/=dst_dir;
+    src_path_expected/=src;
+    src_path_expected/=src_dir;
+    src_path_expected/=src_dir; // another nested directory
+    dst_path_expected/=dst;
+    dst_path_expected/=dst_dir;
+    dst_path_expected/=src_dir; // expected another nested directory from src
+
+    ASSERT_TRUE(irs::file_utils::mkdir(src_path.c_str(), true));
+    ASSERT_TRUE(irs::file_utils::mkdir(dst_path.c_str(), true));
+    ASSERT_TRUE(irs::file_utils::mkdir(src_path_expected.c_str(), true));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  src_path_expected.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  src_path_expected.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  src_path_expected.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, src_path_expected.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, src_path_expected.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  dst_path_expected.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  dst_path_expected.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  dst_path_expected.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, dst_path_expected.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, dst_path_expected.c_str()));
+
+#ifdef _WIN32
+    ASSERT_FALSE(irs::file_utils::move(src_path.c_str(), dst_path.c_str()));
+#else
+    // Boost on Posix merges directories
+    ASSERT_TRUE(irs::file_utils::move(src_path.c_str(), dst_path.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  src_path_expected.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  src_path_expected.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  src_path_expected.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, src_path_expected.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, src_path_expected.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  dst_path_expected.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  dst_path_expected.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  dst_path_expected.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, dst_path_expected.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, dst_path_expected.c_str()));
+#endif
+  }
+
+  // file -> non-existent/non-existent
+  {
+    std::string data("ABCdata123");
+    std::string missing("deleteme");
+    std::string src("deleteme.srcA");
+    std::string dst("deleteme.dstA");
+    irs::utf8_path src_path(src_abs);
+    irs::utf8_path dst_path(dst_abs);
+
+    src_path/=src;
+    dst_path/=dst;
+    dst_path/=missing;
+
+    // create file
+    {
+      std::ofstream out(src_path.c_str());
+      out << data;
+      out.close();
+    }
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  src_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  src_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, src_path.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, src_path.c_str()) && tmpUint == data.size());
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, dst_path.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, dst_path.c_str()));
+
+    ASSERT_FALSE(irs::file_utils::move(src_path.c_str(), dst_path.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  src_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  src_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, src_path.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, src_path.c_str()) && tmpUint == data.size());
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, dst_path.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, dst_path.c_str()));
+  }
+
+  // file -> directory/
+  {
+    std::string data("ABCdata123");
+    std::string src("deleteme.srcB");
+    std::string dst("deleteme.dstB");
+    irs::utf8_path src_path(src_abs);
+    irs::utf8_path dst_path(dst_abs);
+    irs::utf8_path dst_path_expected(dst_abs);
+
+    src_path/=src;
+    dst_path/=dst;
+    ASSERT_TRUE(irs::file_utils::mkdir(dst_path.c_str(), true));
+    dst_path/="";
+    dst_path_expected/=dst;
+    dst_path_expected/=src;
+
+    // create file
+    {
+      std::ofstream out(src_path.c_str());
+      out << data;
+      out.close();
+    }
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  src_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  src_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, src_path.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, src_path.c_str()) && tmpUint == data.size());
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  dst_path_expected.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  dst_path_expected.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  dst_path_expected.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, dst_path_expected.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, dst_path_expected.c_str()));
+
+    ASSERT_FALSE(irs::file_utils::move(src_path.c_str(), dst_path.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  src_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  src_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, src_path.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, src_path.c_str()) && tmpUint == data.size());
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  dst_path_expected.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  dst_path_expected.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  dst_path_expected.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, dst_path_expected.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, dst_path_expected.c_str()));
+  }
+
+  // file -> directory/non-existent
+  {
+    std::string data("ABCdata123");
+    std::string missing("deleteme");
+    std::string src("deleteme.srcC");
+    std::string dst("deleteme.dstC");
+    irs::utf8_path src_path(src_abs);
+    irs::utf8_path dst_path(dst_abs);
+
+    src_path/=src;
+    dst_path/=dst;
+    ASSERT_TRUE(irs::file_utils::mkdir(dst_path.c_str(), true));
+    dst_path/=missing;
+
+    // create file
+    {
+      std::ofstream out(src_path.c_str());
+      out << data;
+      out.close();
+    }
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  src_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  src_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, src_path.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, src_path.c_str()) && tmpUint == data.size());
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, dst_path.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, dst_path.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::move(src_path.c_str(), dst_path.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, src_path.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, src_path.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  dst_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  dst_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, dst_path.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, dst_path.c_str()) && tmpUint == data.size());
+  }
+
+  // file -> directory/file
+  {
+    std::string src_data("ABCdata123");
+    std::string dst_data("XyZ");
+    std::string file("deleteme");
+    std::string src("deleteme.srcD");
+    std::string dst("deleteme.dstD");
+    irs::utf8_path src_path(src_abs);
+    irs::utf8_path dst_path(dst_abs);
+
+    src_path/=src;
+    dst_path/=dst;
+    ASSERT_TRUE(irs::file_utils::mkdir(dst_path.c_str(), true));
+    dst_path/=file;
+
+    // create file
+    {
+      std::ofstream out(src_path.c_str());
+      out << src_data;
+      out.close();
+    }
+
+    // create file
+    {
+      std::ofstream out(dst_path.c_str());
+      out << dst_data;
+      out.close();
+    }
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  src_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  src_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, src_path.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, src_path.c_str()) && tmpUint == src_data.size());
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  dst_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  dst_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, dst_path.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, dst_path.c_str()) && tmpUint == dst_data.size());
+
+    ASSERT_TRUE(irs::file_utils::move(src_path.c_str(), dst_path.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_FALSE(irs::file_utils::mtime(tmpTime, src_path.c_str()));
+    ASSERT_FALSE(irs::file_utils::byte_size(tmpUint, src_path.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  dst_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  dst_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, dst_path.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, dst_path.c_str()) && tmpUint == src_data.size());
+  }
+
+  // file -> directory/directory
+  {
+    std::string data("ABCdata123");
+    std::string file("deleteme");
+    std::string src("deleteme.srcE");
+    std::string dst("deleteme.dstE");
+    irs::utf8_path src_path(src_abs);
+    irs::utf8_path dst_path(dst_abs);
+
+    src_path/=src;
+    dst_path/=dst;
+    ASSERT_TRUE(irs::file_utils::mkdir(dst_path.c_str(), true));
+    dst_path/=file;
+
+    // create file
+    {
+      std::ofstream out(src_path.c_str());
+      out << data;
+      out.close();
+    }
+
+    ASSERT_TRUE(irs::file_utils::mkdir(dst_path.c_str(), true));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  src_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  src_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, src_path.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, src_path.c_str()) && tmpUint == data.size());
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  dst_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  dst_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, dst_path.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, dst_path.c_str()));
+
+    ASSERT_FALSE(irs::file_utils::move(src_path.c_str(), dst_path.c_str()));
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  src_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  src_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  src_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, src_path.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, src_path.c_str()) && tmpUint == data.size());
+
+    ASSERT_TRUE(irs::file_utils::exists(tmpBool,  dst_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_directory(tmpBool,  dst_path.c_str()) && tmpBool);
+    ASSERT_TRUE(irs::file_utils::exists_file(tmpBool,  dst_path.c_str()) && !tmpBool);
+    ASSERT_TRUE(irs::file_utils::mtime(tmpTime, dst_path.c_str()) && tmpTime > 0);
+    ASSERT_TRUE(irs::file_utils::byte_size(tmpUint, dst_path.c_str()));
+  }
+}
+
+TEST_F(utf8_path_tests, move_absolute_absolute) {
+  validate_move(true, true);
+}
+
+TEST_F(utf8_path_tests, move_absolute_relative) {
+  validate_move(true, false);
+}
+
+TEST_F(utf8_path_tests, move_relative_absolute) {
+  validate_move(false, true);
+}
+
+TEST_F(utf8_path_tests, move_relative_relative) {
+  validate_move(false, false);
+}


### PR DESCRIPTION
Temporary resurrect utf8_path class and use it instead of std::filesystem::path to support MacOS 10.14 where std::filesystem is not implemented.
Class interface was modified to match std::filesystem::path for simpler switch back once MacOs 10.14  support is dropped.