### PR TITLE
Hackup simdcomp build

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -21,7 +21,7 @@ add_subdirectory(highway)
 
 add_library(sse2neon INTERFACE)
 
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "(aarch64.*|AARCH64.*)")
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "(aarch64.*|AARCH64.*|arm64.*|ARM64.*)")
   set(SSE2NEON_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/sse2neon)
 
   target_include_directories(

--- a/external/simdcomp/CMakeLists.txt
+++ b/external/simdcomp/CMakeLists.txt
@@ -24,7 +24,7 @@ else()
 endif()
 
 # test for arm
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64.*|AARCH64.*)")
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64.*|AARCH64.*|arm64.*|aarch64.*)")
    set(BASE_FLAGS
      ${BASE_FLAGS}
      "-D__ARM_NEON__"


### PR DESCRIPTION
This fixes building (for me) on Apple M1. 

I am really quite dubious that this is the correct fix for the problem: `simdcomp` seems to be a library for `x86_64` and it is unclear to me why it is built when on ARM.