### PR TITLE
Bug fix/fix cleanup race

### DIFF
--- a/core/utils/directory_utils.cpp
+++ b/core/utils/directory_utils.cpp
@@ -334,6 +334,9 @@ index_output::ptr ref_tracking_directory::create(
     const std::string& name) noexcept {
   try {
 
+    // Do not change the order of calls!
+    // The cleaner should "see" the file in directory
+    // ONLY if there is a tracking reference present!
     auto ref = attribute_.add(name);
     auto result = impl_.create(name);
 

--- a/core/utils/directory_utils.cpp
+++ b/core/utils/directory_utils.cpp
@@ -333,14 +333,16 @@ void ref_tracking_directory::clear_refs() const noexcept {
 index_output::ptr ref_tracking_directory::create(
     const std::string& name) noexcept {
   try {
+
+    auto ref = attribute_.add(name);
     auto result = impl_.create(name);
 
     // only track ref on successful call to impl_
     if (result) {
-      auto ref = attribute_.add(name);
-
       auto lock = make_lock_guard(mutex_);
-      refs_.emplace(ref);
+      refs_.insert(std::move(ref));
+    } else {
+      attribute_.remove(name);
     }
 
     return result;

--- a/tests/index/index_tests.cpp
+++ b/tests/index/index_tests.cpp
@@ -2460,43 +2460,26 @@ TEST_P(index_test_case, writer_commit_cleanup_interleaved) {
     &tests::generic_json_field_factory
   );
 
-  auto writer = irs::index_writer::make(dir(), codec(), irs::OM_CREATE);
-  std::atomic<bool> finish{false};
-  auto cleaner = std::thread([this, &finish](void) {
-    while (!finish) {
-      irs::directory_utils::remove_all_unreferenced(dir());
-      std::this_thread::yield();
-    }
-    });
+  auto clean = [this]() {
+    irs::directory_utils::remove_all_unreferenced(dir());
+  };
+  tests::callback_directory synced_dir(dir(), std::move(clean));
+  auto writer = irs::index_writer::make(synced_dir, codec(), irs::OM_CREATE);
   {
-    size_t current = 0;
-    tests::document const* doc1{nullptr};
-    while(current < 100) {
-      doc1 = gen.next();
-      if (!doc1) {
-        gen.reset();
-        doc1 = gen.next();
-      }
-      ASSERT_TRUE(
-        insert(*writer,
-          doc1->indexed.begin(), doc1->indexed.end(),
-          doc1->stored.begin(), doc1->stored.end()
-        )
-      );
-      ++current;
-      writer->commit();
-      // check index, it should contain expected number of docs
-      if (current)
-      {
-        auto reader = irs::directory_reader::open(dir(), codec());
-        ASSERT_EQ(current, reader.live_docs_count());
-        ASSERT_EQ(current, reader.docs_count());
-        ASSERT_NE(reader.begin(), reader.end());
-      }
-    }
+    auto const*doc1 = gen.next();
+    ASSERT_TRUE(
+      insert(*writer,
+        doc1->indexed.begin(), doc1->indexed.end(),
+        doc1->stored.begin(), doc1->stored.end()
+      )
+    );
+    writer->commit();
+    // check index, it should contain expected number of docs
+    auto reader = irs::directory_reader::open(dir(), codec());
+    ASSERT_EQ(1, reader.live_docs_count());
+    ASSERT_EQ(1, reader.docs_count());
+    ASSERT_NE(reader.begin(), reader.end());
   }
-  finish = true;
-  cleaner.join();
 }
 
 TEST_P(index_test_case, writer_commit_clear) {

--- a/tests/index/index_tests.hpp
+++ b/tests/index/index_tests.hpp
@@ -146,6 +146,23 @@ struct blocking_directory : directory_mock {
   std::mutex intermediate_commits_lock;
 }; // blocking_directory
 
+struct callback_directory : directory_mock {
+
+  typedef std::function<void()> AfterCallback;
+
+  explicit callback_directory(irs::directory& impl, AfterCallback&& p)
+    : tests::directory_mock(impl), after(p) {
+  }
+
+  irs::index_output::ptr create(const std::string& name) noexcept {
+    auto stream = tests::directory_mock::create(name);
+    after();
+    return stream;
+  }
+
+  AfterCallback after;
+}; // callback_directory
+
 struct format_info {
   constexpr format_info(
       const char* codec = nullptr,

--- a/tests/index/index_tests.hpp
+++ b/tests/index/index_tests.hpp
@@ -147,7 +147,6 @@ struct blocking_directory : directory_mock {
 }; // blocking_directory
 
 struct callback_directory : directory_mock {
-
   typedef std::function<void()> AfterCallback;
 
   explicit callback_directory(irs::directory& impl, AfterCallback&& p)


### PR DESCRIPTION
Fix for possible race during file creation.
There was a possibility for cleaner to see file as "untracked" right after actual file creation but before "reference" is created in the tracking directory.

https://jenkins.arangodb.biz:3456/view/PR/job/iresearch_s-pr/380/