### PR TITLE
allow using CMPXCHG16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,8 +93,8 @@ option(SUPPRESS_EXTERNAL_WARNINGS "Suppress warnings originating in 3rd party co
 add_option_gprof(FALSE)
 
 # test for ARM
-if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64.*|AARCH64.*|arm64.*|ARM64.*)")
-  set(IS_ARM 1)
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64.*|AARCH64.*|arm64.*|ARM64.*|armv8.*|ARMV8.*)")
+  set(IS_ARM ON)
 endif()
 
 if (USE_VALGRIND)
@@ -123,7 +123,7 @@ if (MSVC)
     set(CMAKE_C_FLAGS "/MP ${CMAKE_C_FLAGS}")
     set(CMAKE_CXX_FLAGS "/MP ${CMAKE_CXX_FLAGS}")
   endif()
-elseif(NOT IS_ARM)
+elseif (NOT IS_ARM)
   # allow 16 byte compare-exchange
   add_compile_options(-mcx16)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,11 @@ option(SUPPRESS_EXTERNAL_WARNINGS "Suppress warnings originating in 3rd party co
 
 add_option_gprof(FALSE)
 
+# test for ARM
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64.*|AARCH64.*|arm64.*|ARM64.*)")
+  set(IS_ARM 1)
+endif()
+
 if (USE_VALGRIND)
   add_definitions(-DIRESEARCH_VALGRIND)
 endif()
@@ -114,11 +119,11 @@ if (MSVC)
   if (MSVC_BUILD_THREADS)
     set(CMAKE_C_FLAGS "/MP${MSVC_BUILD_THREADS} ${CMAKE_C_FLAGS}")
     set(CMAKE_CXX_FLAGS "/MP${MSVC_BUILD_THREADS} ${CMAKE_CXX_FLAGS}")
-  else ()
+  else()
     set(CMAKE_C_FLAGS "/MP ${CMAKE_C_FLAGS}")
     set(CMAKE_CXX_FLAGS "/MP ${CMAKE_CXX_FLAGS}")
   endif()
-else()
+elseif(NOT IS_ARM)
   # allow 16 byte compare-exchange
   add_compile_options(-mcx16)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,9 @@ if (MSVC)
     set(CMAKE_C_FLAGS "/MP ${CMAKE_C_FLAGS}")
     set(CMAKE_CXX_FLAGS "/MP ${CMAKE_CXX_FLAGS}")
   endif()
+else()
+  # allow 16 byte compare-exchange
+  add_compile_options(-mcx16)
 endif()
 
 ################################################################################

--- a/core/utils/object_pool.hpp
+++ b/core/utils/object_pool.hpp
@@ -139,10 +139,6 @@ class concurrent_stack : private util::noncopyable {
   }
 
   std::atomic<concurrent_node> head_;
-
-#ifndef _MSC_VER
-  static_assert(decltype(head_)::is_always_lock_free);
-#endif
 }; // concurrent_stack
 
 //////////////////////////////////////////////////////////////////////////////

--- a/core/utils/object_pool.hpp
+++ b/core/utils/object_pool.hpp
@@ -139,6 +139,10 @@ class concurrent_stack : private util::noncopyable {
   }
 
   std::atomic<concurrent_node> head_;
+
+#ifndef _MSC_VER
+  static_assert(decltype(head_)::is_always_lock_free);
+#endif
 }; // concurrent_stack
 
 //////////////////////////////////////////////////////////////////////////////

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -21,7 +21,7 @@ add_subdirectory(highway)
 
 add_library(sse2neon INTERFACE)
 
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "(aarch64.*|AARCH64.*|arm64.*|ARM64.*)")
+if (IS_ARM)
   set(SSE2NEON_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/sse2neon)
 
   target_include_directories(

--- a/external/simdcomp/CMakeLists.txt
+++ b/external/simdcomp/CMakeLists.txt
@@ -24,7 +24,7 @@ else()
 endif()
 
 # test for arm
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64.*|AARCH64.*|arm64.*|aarch64.*)")
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64.*|AARCH64.*|arm64.*|ARM64.*)")
    set(BASE_FLAGS
      ${BASE_FLAGS}
      "-D__ARM_NEON__"

--- a/external/simdcomp/CMakeLists.txt
+++ b/external/simdcomp/CMakeLists.txt
@@ -24,7 +24,7 @@ else()
 endif()
 
 # test for arm
-if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64.*|AARCH64.*|arm64.*|ARM64.*)")
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64.*|AARCH64.*|arm64.*|ARM64.*|armv8.*|ARMV8.*)")
    set(BASE_FLAGS
      ${BASE_FLAGS}
      "-D__ARM_NEON__"


### PR DESCRIPTION
Adjust compiler definitions to allow using  `CMPXCHG16` instruction