### PR TITLE
Fix compilation with clang-cl

### DIFF
--- a/core/search/bm25.cpp
+++ b/core/search/bm25.cpp
@@ -422,7 +422,7 @@ struct MakeScoreFunctionImpl<BM15Context> {
 
           const float_t c1 = state.norm_const;
 
-          sort::score_cast<score_t>(state.score_buf) = c0 - c0 / (1.f + tf / c1);
+          irs::sort::score_cast<score_t>(state.score_buf) = c0 - c0 / (1.f + tf / c1);
 
           return state.score_buf;
         }
@@ -456,7 +456,7 @@ struct MakeScoreFunctionImpl<BM25Context<Norm>> {
             c0 = state.num;
           }
 
-          auto& buf = sort::score_cast<score_t>(state.score_buf);
+          auto& buf = irs::sort::score_cast<score_t>(state.score_buf);
 
           if constexpr (NormType::kNorm2Tiny == Norm::kType) {
             static_assert(std::is_same_v<uint32_t, decltype(state.norm())>);


### PR DESCRIPTION
Make MSVC's clang-cl happy, it otherwise complains with
```
iresearch/core/search/bm25.cpp(459,29): error: no member named 'score_cast' in 'iresearch::bm25::sort'
          auto& buf = sort::score_cast<score_t>(state.score_buf);
                      ~~~~~~^
...
iresearch/core/search/bm25.cpp(459,40): error: unexpected type name 'score_t': expected expression
          auto& buf = sort::score_cast<score_t>(state.score_buf);
                                       ^
...
iresearch/core/search/bm25.cpp(425,17): error: no member named 'score_cast' in 'iresearch::bm25::sort'
          sort::score_cast<score_t>(state.score_buf) = c0 - c0 / (1.f + tf / c1);
          ~~~~~~^
...
iresearch/core/search/bm25.cpp(425,28): error: unexpected type name 'score_t': expected expression
          sort::score_cast<score_t>(state.score_buf) = c0 - c0 / (1.f + tf / c1);
                           ^
```