### PR TITLE
Fix leftover documents tracking

### DIFF
--- a/core/formats/skip_list.hpp
+++ b/core/formats/skip_list.hpp
@@ -147,11 +147,17 @@ class SkipReaderBase : util::noncopyable {
     Level(Level&&) = default;
     Level& operator=(Level&&) = delete;
 
-    index_input::ptr stream; // level data stream
-    uint64_t begin; // where level starts
-    uint64_t child{}; // pointer to child level
-    ptrdiff_t left; // number of documents left at a level
-    const doc_id_t step; // how many docs we jump over with a single skip
+    // Level data stream.
+    index_input::ptr stream;
+    // Where level starts.
+    uint64_t begin;
+    // Pointer to child level.
+    uint64_t child{};
+    // Number of documents left at a level.
+    // ptrdiff_t to be able to go below 0.
+    ptrdiff_t left;
+    // How many docs we jump over with a single skip
+    const doc_id_t step;
   };
 
   static_assert(std::is_nothrow_move_constructible_v<Level>);

--- a/core/formats/skip_list.hpp
+++ b/core/formats/skip_list.hpp
@@ -229,6 +229,9 @@ doc_id_t SkipReader<Read>::Seek(doc_id_t target) {
     }
   }
 
+  auto& level_0 = levels_.back();
+  const doc_id_t step_0{level_0.step};
+
   if (id != size) {
     --size;
     for (uint64_t child_ptr{0}; id != size; ++id) {
@@ -249,19 +252,15 @@ doc_id_t SkipReader<Read>::Seek(doc_id_t target) {
       reader_.MoveDown(next_id);
     }
 
-    auto& level = levels_.back();
-    assert(&level == &levels_[id]);
-    const doc_id_t step{level.step};
-    auto& stream{*level.stream};
+    assert(&level_0 == &levels_[id]);
+    auto& stream{*level_0.stream};
 
     do {
-      reader_.Read(id, level.left -= step, stream);
+      reader_.Read(id, level_0.left -= step_0, stream);
     } while (reader_.IsLess(id, target));
-
-    return level.left + step;
   }
 
-  return 0;
+  return level_0.left + step_0;
 }
 
 } // iresearch

--- a/tests/formats/formats_10_tests.cpp
+++ b/tests/formats/formats_10_tests.cpp
@@ -201,6 +201,14 @@ class format_10_test_case : public tests::format_test_case {
           }
         };
 
+        {
+          auto it = reader->iterator(field.index_features, irs::IndexFeatures::NONE, read_meta);
+          ASSERT_FALSE(irs::doc_limits::valid(it->value()));
+          ASSERT_TRUE(it->next());
+          ASSERT_EQ(docs.front().first, it->value());
+          ASSERT_TRUE(irs::doc_limits::eof(it->seek(docs.back().first + 42)));
+        }
+
         // seek to every document 127th document in a block
         assert_docs(kVersion10PostingsWriterBlockSize-1, kVersion10PostingsWriterBlockSize);
 

--- a/tests/formats/formats_10_tests.cpp
+++ b/tests/formats/formats_10_tests.cpp
@@ -201,6 +201,7 @@ class format_10_test_case : public tests::format_test_case {
           }
         };
 
+        // next + seek to eof
         {
           auto it = reader->iterator(field.index_features, irs::IndexFeatures::NONE, read_meta);
           ASSERT_FALSE(irs::doc_limits::valid(it->value()));

--- a/tests/formats/formats_15_tests.cpp
+++ b/tests/formats/formats_15_tests.cpp
@@ -341,6 +341,15 @@ void Format15TestCase::PostingsWandSeek(
         }
       };
 
+      // next + seek to eof
+      {
+        auto it = reader->wanderator(field.index_features, irs::IndexFeatures::NONE, read_meta);
+        ASSERT_FALSE(irs::doc_limits::valid(it->value()));
+        ASSERT_TRUE(it->next());
+        ASSERT_EQ(docs.front().first, it->value());
+        ASSERT_TRUE(irs::doc_limits::eof(it->seek(docs.back().first + 42)));
+      }
+
       assert_docs_seq();
 
       // seek for every document 127th document in a block

--- a/tests/formats/skip_list_test.cpp
+++ b/tests/formats/skip_list_test.cpp
@@ -201,13 +201,13 @@ TEST_F(SkipWriterTest, Reset) {
     out.write_vlong(cur_doc);
   };
 
-  //.Prepare writer
+  // Prepare writer
   irs::SkipWriter writer(skip, skip);
   ASSERT_EQ(0, writer.MaxLevels());
   writer.Prepare(max_levels, count);
   ASSERT_NE(max_levels, writer.MaxLevels());
 
-  //.Prepare directory
+  // Prepare directory
   irs::memory_directory dir;
 
   // write initial data
@@ -388,7 +388,7 @@ TEST_F(SkipReaderTest,Prepare) {
     {
       auto in = dir.open("docs", irs::IOAdvice::NORMAL);
       ASSERT_FALSE(!in);
-      reader.Prepare(std::move(in));
+      reader.Prepare(std::move(in), count);
     }
     ASSERT_EQ(0, reader.NumLevels());
     ASSERT_EQ(skip, reader.Skip0());
@@ -431,7 +431,7 @@ TEST_F(SkipReaderTest,Prepare) {
     ASSERT_EQ(0, reader.NumLevels());
     auto in = dir.open("docs", irs::IOAdvice::NORMAL);
     ASSERT_FALSE(!in);
-    reader.Prepare(std::move(in));
+    reader.Prepare(std::move(in), count);
     ASSERT_EQ(writer.MaxLevels(), reader.NumLevels());
     ASSERT_EQ(skip, reader.Skip0());
     ASSERT_EQ(skip, reader.SkipN());
@@ -562,7 +562,7 @@ TEST_F(SkipReaderTest, Seek) {
       ASSERT_EQ(0, reader.NumLevels());
       auto in = dir.open(kFile, irs::IOAdvice::NORMAL);
       ASSERT_FALSE(!in);
-      reader.Prepare(std::move(in));
+      reader.Prepare(std::move(in), kCount);
       ASSERT_EQ(3, reader.NumLevels());
       ASSERT_EQ(kSkip0, reader.Skip0());
       ASSERT_EQ(kSkipN, reader.SkipN());
@@ -829,7 +829,7 @@ TEST_F(SkipReaderTest, Seek) {
       ASSERT_EQ(0, reader.NumLevels());
       auto in = dir.open(kFile, irs::IOAdvice::RANDOM);
       ASSERT_FALSE(!in);
-      reader.Prepare(std::move(in));
+      reader.Prepare(std::move(in), kCount);
       ASSERT_EQ(writer.MaxLevels(), reader.NumLevels());
       ASSERT_EQ(kSkip0, reader.Skip0());
       ASSERT_EQ(kSkipN, reader.SkipN());
@@ -990,7 +990,7 @@ TEST_F(SkipReaderTest, Seek) {
       ASSERT_EQ(0, reader.NumLevels());
       auto in = dir.open(kFile, irs::IOAdvice::RANDOM);
       ASSERT_FALSE(!in);
-      reader.Prepare(std::move(in));
+      reader.Prepare(std::move(in), kCount);
       ASSERT_EQ(writer.MaxLevels(), reader.NumLevels());
       ASSERT_EQ(kSkip0, reader.Skip0());
       ASSERT_EQ(kSkipN, reader.SkipN());
@@ -1125,7 +1125,7 @@ TEST_F(SkipReaderTest, Seek) {
       ASSERT_EQ(0, reader.NumLevels());
       auto in = dir.open(kFile, irs::IOAdvice::NORMAL);
       ASSERT_FALSE(!in);
-      reader.Prepare(std::move(in));
+      reader.Prepare(std::move(in), kCount);
 
       // seek forward
       {


### PR DESCRIPTION
Invalid tracking of leftover documents may cause underflow of `doc_iterator_base<...>::left_`.