### PR TITLE
Feature/refactor object pool

### DIFF
--- a/core/index/directory_reader.cpp
+++ b/core/index/directory_reader.cpp
@@ -205,16 +205,16 @@ directory_reader& directory_reader::operator=(
     const directory_reader& other) noexcept {
   if (this != &other) {
     // make a copy
-    impl_ptr impl = atomic_utils::atomic_load(&other.impl_);
+    impl_ptr impl = std::atomic_load(&other.impl_);
 
-    atomic_utils::atomic_store(&impl_, impl);
+    std::atomic_store(&impl_, impl);
   }
 
   return *this;
 }
 
 const directory_meta& directory_reader::meta() const {
-  auto impl = atomic_utils::atomic_load(&impl_);  // make a copy
+  auto impl = std::atomic_load(&impl_);  // make a copy
 
   return down_cast<directory_reader_impl>(*impl).meta();
 }
@@ -227,7 +227,7 @@ const directory_meta& directory_reader::meta() const {
 directory_reader directory_reader::reopen(
     format::ptr codec /*= nullptr*/) const {
   // make a copy
-  impl_ptr impl = atomic_utils::atomic_load(&impl_);
+  impl_ptr impl = std::atomic_load(&impl_);
 
   return directory_reader_impl::open(
       down_cast<directory_reader_impl>(*impl).dir(), codec.get(), impl);

--- a/core/index/directory_reader.hpp
+++ b/core/index/directory_reader.hpp
@@ -24,8 +24,8 @@
 #ifndef IRESEARCH_DIRECTORY_READER_H
 #define IRESEARCH_DIRECTORY_READER_H
 
-#include "shared.hpp"
 #include "index_reader.hpp"
+#include "shared.hpp"
 #include "utils/object_pool.hpp"
 
 namespace iresearch {
@@ -44,23 +44,18 @@ struct directory_meta {
 ////////////////////////////////////////////////////////////////////////////////
 class directory_reader final : public index_reader {
  public:
-  typedef atomic_shared_ptr_helper<const index_reader> atomic_utils;
-  typedef directory_reader element_type; // type same as self
-  typedef directory_reader ptr; // pointer to self
+  typedef directory_reader element_type;  // type same as self
+  typedef directory_reader ptr;           // pointer to self
 
-  directory_reader() = default; // allow creation of an uninitialized ptr
+  directory_reader() = default;  // allow creation of an uninitialized ptr
   directory_reader(const directory_reader& other) noexcept;
   directory_reader& operator=(const directory_reader& other) noexcept;
 
   explicit operator bool() const noexcept { return bool(impl_); }
 
-  bool operator==(std::nullptr_t) const noexcept {
-    return !impl_;
-  }
+  bool operator==(std::nullptr_t) const noexcept { return !impl_; }
 
-  bool operator!=(std::nullptr_t) const noexcept {
-    return !(*this == nullptr);
-  }
+  bool operator!=(std::nullptr_t) const noexcept { return !(*this == nullptr); }
 
   bool operator==(const directory_reader& rhs) const noexcept {
     return impl_ == rhs.impl_;
@@ -79,9 +74,7 @@ class directory_reader final : public index_reader {
     return (*impl_)[i];
   }
 
-  virtual uint64_t docs_count() const override {
-    return impl_->docs_count();
-  }
+  virtual uint64_t docs_count() const override { return impl_->docs_count(); }
 
   virtual uint64_t live_docs_count() const override {
     return impl_->live_docs_count();
@@ -93,38 +86,29 @@ class directory_reader final : public index_reader {
   //////////////////////////////////////////////////////////////////////////////
   const directory_meta& meta() const;
 
-  virtual size_t size() const override {
-    return impl_->size();
-  }
+  virtual size_t size() const override { return impl_->size(); }
 
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief create an index reader over the specified directory
   ///        if codec == nullptr then use the latest file for all known codecs
   ////////////////////////////////////////////////////////////////////////////////
-  static directory_reader open(
-    const directory& dir,
-    format::ptr codec = nullptr
-  );
+  static directory_reader open(const directory& dir,
+                               format::ptr codec = nullptr);
 
   ////////////////////////////////////////////////////////////////////////////////
-  /// @brief open a new instance based on the latest file for the specified codec
+  /// @brief open a new instance based on the latest file for the specified
+  /// codec
   ///        this call will atempt to reuse segments from the existing reader
   ///        if codec == nullptr then use the latest file for all known codecs
   ////////////////////////////////////////////////////////////////////////////////
-  virtual directory_reader reopen(
-    format::ptr codec = nullptr
-  ) const;
+  virtual directory_reader reopen(format::ptr codec = nullptr) const;
 
-  void reset() noexcept {
-    impl_.reset();
-  }
+  void reset() noexcept { impl_.reset(); }
 
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief converts current directory_reader to 'index_reader::ptr'
   ////////////////////////////////////////////////////////////////////////////////
-  explicit operator index_reader::ptr() const noexcept {
-    return impl_;
-  }
+  explicit operator index_reader::ptr() const noexcept { return impl_; }
 
  private:
   typedef std::shared_ptr<const index_reader> impl_ptr;
@@ -132,7 +116,7 @@ class directory_reader final : public index_reader {
   impl_ptr impl_;
 
   directory_reader(impl_ptr&& impl) noexcept;
-}; // directory_reader
+};  // directory_reader
 
 inline bool operator==(std::nullptr_t, const directory_reader& rhs) noexcept {
   return rhs == nullptr;
@@ -142,6 +126,6 @@ inline bool operator!=(std::nullptr_t, const directory_reader& rhs) noexcept {
   return rhs != nullptr;
 }
 
-}
+}  // namespace iresearch
 
 #endif

--- a/core/index/index_writer.cpp
+++ b/core/index/index_writer.cpp
@@ -1428,7 +1428,7 @@ index_writer::consolidation_result index_writer::consolidate(
   // hold a reference to the last committed state to prevent files from being
   // deleted by a cleaner during the upcoming consolidation
   // use atomic_load(...) since finish() may modify the pointer
-  auto committed_state = committed_state_helper::atomic_load(&committed_state_);
+  auto committed_state = std::atomic_load(&committed_state_);
   assert(committed_state);
   if (IRS_UNLIKELY(!committed_state)) {
     return { 0, ConsolidationError::FAIL };
@@ -2519,11 +2519,10 @@ void index_writer::finish() {
 #ifndef __APPLE__
     // atomic_store may throw
     static_assert(!noexcept
-      (committed_state_helper::atomic_store(&committed_state_,
+      (std::atomic_store(&committed_state_,
         std::move(pending_state_.commit))));
 #endif
-    committed_state_helper::atomic_store(&committed_state_,
-      std::move(pending_state_.commit));
+    std::atomic_store(&committed_state_, std::move(pending_state_.commit));
   } catch (...) {
     abort(); // rollback transaction
 

--- a/core/index/index_writer.cpp
+++ b/core/index/index_writer.cpp
@@ -1917,8 +1917,7 @@ index_writer::active_segment_context index_writer::get_segment_context(
     return segment_meta(file_name(meta_.increment()), codec_);
   };
 
-  // FIXME(gnusi): why shared_ptr?
-  std::shared_ptr segment_ctx{segment_writer_pool_.emplace(
+  segment_context_ptr segment_ctx{segment_writer_pool_.emplace(
     dir_, std::move(meta_generator),
     column_info_, feature_info_,
     comparator_)};

--- a/core/index/index_writer.cpp
+++ b/core/index/index_writer.cpp
@@ -1916,10 +1916,12 @@ index_writer::active_segment_context index_writer::get_segment_context(
   auto meta_generator = [this]()->segment_meta {
     return segment_meta(file_name(meta_.increment()), codec_);
   };
-  auto segment_ctx = segment_writer_pool_.emplace(
+
+  // FIXME(gnusi): why shared_ptr?
+  std::shared_ptr segment_ctx{segment_writer_pool_.emplace(
     dir_, std::move(meta_generator),
     column_info_, feature_info_,
-    comparator_).release();
+    comparator_)};
   auto segment_memory_max = segment_limits_.segment_memory_max.load();
 
   // recreate writer if it reserved more memory than allowed by current limits

--- a/core/index/index_writer.hpp
+++ b/core/index/index_writer.hpp
@@ -936,9 +936,6 @@ class index_writer : private util::noncopyable {
     std::pair<std::shared_ptr<index_meta>,
     file_refs_t
   >> committed_state_t;
-  typedef atomic_shared_ptr_helper<
-    committed_state_t::element_type
-  > committed_state_helper;
 
   typedef unbounded_object_pool<segment_context> segment_pool_t;
 

--- a/core/index/segment_reader.cpp
+++ b/core/index/segment_reader.cpp
@@ -276,9 +276,9 @@ segment_reader& segment_reader::operator=(
     const segment_reader& other) noexcept {
   if (this != &other) {
     // make a copy
-    impl_ptr impl = atomic_utils::atomic_load(&other.impl_);
+    impl_ptr impl = std::atomic_load(&other.impl_);
 
-    atomic_utils::atomic_store(&impl_, impl);
+    std::atomic_store(&impl_, impl);
   }
 
   return *this;
@@ -292,7 +292,7 @@ segment_reader& segment_reader::operator=(
 
 segment_reader segment_reader::reopen(const segment_meta& meta) const {
   // make a copy
-  impl_ptr impl = atomic_utils::atomic_load(&impl_);
+  impl_ptr impl = std::atomic_load(&impl_);
 
   auto& reader_impl = down_cast<segment_reader_impl>(*impl);
 
@@ -301,10 +301,6 @@ segment_reader segment_reader::reopen(const segment_meta& meta) const {
     ? *this
     : segment_reader_impl::open(reader_impl.dir(), meta);
 }
-
-// -------------------------------------------------------------------
-// segment_reader_impl
-// -------------------------------------------------------------------
 
 segment_reader_impl::segment_reader_impl(
     const directory& dir,

--- a/core/index/segment_reader.hpp
+++ b/core/index/segment_reader.hpp
@@ -34,7 +34,6 @@ namespace iresearch {
 ////////////////////////////////////////////////////////////////////////////////
 class segment_reader final : public sub_reader {
  public:
-  typedef atomic_shared_ptr_helper<const sub_reader> atomic_utils;
   typedef segment_reader element_type; // type same as self
   typedef segment_reader ptr; // pointer to self
 

--- a/core/store/fs_directory.cpp
+++ b/core/store/fs_directory.cpp
@@ -441,7 +441,8 @@ index_input::ptr pooled_fs_index_input::reopen() const {
 
 fs_index_input::file_handle::ptr pooled_fs_index_input::reopen(const file_handle& src) const {
   // reserve a new handle from the pool
-  std::shared_ptr handle{const_cast<pooled_fs_index_input*>(this)->fd_pool_->emplace()};
+  std::shared_ptr<fs_index_input::file_handle> handle{
+    const_cast<pooled_fs_index_input*>(this)->fd_pool_->emplace()};
 
   if (!handle->handle) {
     handle->handle = irs::file_utils::open(src, irs::file_utils::OpenMode::Read, src.posix_open_advice); // same permission as in fs_index_input::open(...)

--- a/core/store/fs_directory.cpp
+++ b/core/store/fs_directory.cpp
@@ -441,7 +441,7 @@ index_input::ptr pooled_fs_index_input::reopen() const {
 
 fs_index_input::file_handle::ptr pooled_fs_index_input::reopen(const file_handle& src) const {
   // reserve a new handle from the pool
-  auto handle = const_cast<pooled_fs_index_input*>(this)->fd_pool_->emplace().release();
+  std::shared_ptr handle{const_cast<pooled_fs_index_input*>(this)->fd_pool_->emplace()};
 
   if (!handle->handle) {
     handle->handle = irs::file_utils::open(src, irs::file_utils::OpenMode::Read, src.posix_open_advice); // same permission as in fs_index_input::open(...)

--- a/core/utils/object_pool.hpp
+++ b/core/utils/object_pool.hpp
@@ -134,9 +134,9 @@ class async_value {
 
   value_type& value() noexcept { return value_; }
 
-  auto lock_read() { return make_shared_lock(lock_); }
+  auto lock_read() { return std::shared_lock{lock_}; }
 
-  auto lock_write() { return make_unique_lock(lock_); }
+  auto lock_write() { return std::unique_lock{lock_}; }
 
  protected:
   value_type value_;
@@ -209,7 +209,7 @@ class bounded_object_pool {
           ptr, [slot](element_type*) mutable noexcept { reset_impl(slot); });
     }
 
-    operator bool() const noexcept { return nullptr != slot_; }
+    explicit operator bool() const noexcept { return nullptr != slot_; }
     element_type& operator*() const noexcept { return *slot_->value.ptr; }
     element_type* operator->() const noexcept { return get(); }
     element_type* get() const noexcept { return ptr_; }
@@ -600,7 +600,7 @@ class unbounded_object_pool_volatile : public unbounded_object_pool_base<T> {
     element_type& operator*() const noexcept { return *value_; }
     pointer operator->() const noexcept { return get(); }
     pointer get() const noexcept { return value_; }
-    operator bool() const noexcept { return static_cast<bool>(gen_); }
+    explicit operator bool() const noexcept { return static_cast<bool>(gen_); }
 
     friend bool operator==(const ptr& lhs, std::nullptr_t) noexcept {
       return !static_cast<bool>(lhs);

--- a/core/utils/object_pool.hpp
+++ b/core/utils/object_pool.hpp
@@ -210,7 +210,7 @@ class bounded_object_pool {
     }
 
     explicit operator bool() const noexcept { return nullptr != slot_; }
-    element_type& operator*() const noexcept { return *slot_->value.ptr; }
+    element_type& operator*() const noexcept { return *get(); }
     element_type* operator->() const noexcept { return get(); }
     element_type* get() const noexcept { return ptr_; }
 

--- a/core/utils/object_pool.hpp
+++ b/core/utils/object_pool.hpp
@@ -47,9 +47,9 @@ class concurrent_stack : private util::noncopyable {
 
   struct node_type {
     element_type value{};
-    std::atomic<node_type*>
-        next{};  // next needs to be atomic because
-                 // nodes are kept in a free-list and reused!
+    // next needs to be atomic because
+    // nodes are kept in a free-list and reused!
+    std::atomic<node_type*> next{};
   };
 
   explicit concurrent_stack(node_type* head = nullptr) noexcept
@@ -160,7 +160,7 @@ class bounded_object_pool {
     bounded_object_pool* owner;
     typename T::ptr ptr;
     std::atomic<element_type*> value{};
-  };  // slot
+  };
 
   using stack = concurrent_stack<slot>;
   using node_type = typename stack::node_type;

--- a/core/utils/object_pool.hpp
+++ b/core/utils/object_pool.hpp
@@ -26,22 +26,23 @@
 #include <algorithm>
 #include <atomic>
 #include <functional>
-#include <vector>
 #include <utility>
+#include <vector>
 
-#include "memory.hpp"
-#include "shared.hpp"
-#include "thread_utils.hpp"
 #include "async_utils.hpp"
+#include "memory.hpp"
 #include "misc.hpp"
 #include "noncopyable.hpp"
+#include "shared.hpp"
+#include "thread_utils.hpp"
 
 namespace iresearch {
 
 template<typename T>
 class atomic_shared_ptr_helper {
  public:
-  static std::shared_ptr<T> atomic_exchange(std::shared_ptr<T>* p, std::shared_ptr<T> r) {
+  static std::shared_ptr<T> atomic_exchange(std::shared_ptr<T>* p,
+                                            std::shared_ptr<T> r) {
     return std::atomic_exchange(p, r);
   }
 
@@ -52,13 +53,10 @@ class atomic_shared_ptr_helper {
   static std::shared_ptr<T> atomic_load(const std::shared_ptr<T>* p) {
     return std::atomic_load(p);
   }
-}; // atomic_shared_ptr_helper
+};
 
-//////////////////////////////////////////////////////////////////////////////
-/// @class concurrent_stack
-/// @brief lock-free stack
-/// @note move construction/assignment is not thread-safe
-//////////////////////////////////////////////////////////////////////////////
+// Lock-free stack.
+// Move construction/assignment is not thread-safe.
 template<typename T>
 class concurrent_stack : private util::noncopyable {
  public:
@@ -66,13 +64,13 @@ class concurrent_stack : private util::noncopyable {
 
   struct node_type {
     element_type value{};
-    std::atomic<node_type*> next{}; // next needs to be atomic because
-                                    // nodes are kept in a free-list and reused!
+    std::atomic<node_type*>
+        next{};  // next needs to be atomic because
+                 // nodes are kept in a free-list and reused!
   };
 
   explicit concurrent_stack(node_type* head = nullptr) noexcept
-    : head_{concurrent_node{head}} {
-  }
+      : head_{concurrent_node{head}} {}
 
   concurrent_stack(concurrent_stack&& rhs) noexcept {
     move_unsynchronized(std::move(rhs));
@@ -100,9 +98,8 @@ class concurrent_stack : private util::noncopyable {
 
       new_head.node = head.node->next.load(std::memory_order_relaxed);
       new_head.version = head.version + 1;
-    } while (!head_.compare_exchange_weak(head, new_head,
-                                          std::memory_order_acquire,
-                                          std::memory_order_relaxed));
+    } while (!head_.compare_exchange_weak(
+        head, new_head, std::memory_order_acquire, std::memory_order_relaxed));
 
     return head.node;
   }
@@ -115,9 +112,8 @@ class concurrent_stack : private util::noncopyable {
       new_node.next.store(head.node, std::memory_order_relaxed);
 
       new_head.version = head.version + 1;
-    } while (!head_.compare_exchange_weak(head, new_head,
-                                          std::memory_order_release,
-                                          std::memory_order_relaxed));
+    } while (!head_.compare_exchange_weak(
+        head, new_head, std::memory_order_release, std::memory_order_relaxed));
   }
 
  private:
@@ -125,16 +121,14 @@ class concurrent_stack : private util::noncopyable {
   // (memory) operand be 16-byte aligned
   struct alignas(IRESEARCH_CMPXCHG16B_ALIGNMENT) concurrent_node {
     explicit concurrent_node(node_type* node = nullptr) noexcept
-      : version{0}, node{node} {
-    }
+        : version{0}, node{node} {}
 
-    uintptr_t version; // avoid aba problem
+    uintptr_t version;  // avoid aba problem
     node_type* node;
-  }; // concurrent_node
+  };  // concurrent_node
 
-  static_assert(
-    IRESEARCH_CMPXCHG16B_ALIGNMENT == alignof(concurrent_node),
-    "invalid alignment");
+  static_assert(IRESEARCH_CMPXCHG16B_ALIGNMENT == alignof(concurrent_node),
+                "invalid alignment");
 
   void move_unsynchronized(concurrent_stack&& rhs) noexcept {
     head_ = rhs.head_.load(std::memory_order_relaxed);
@@ -142,52 +136,37 @@ class concurrent_stack : private util::noncopyable {
   }
 
   std::atomic<concurrent_node> head_;
-}; // concurrent_stack
+};
 
-//////////////////////////////////////////////////////////////////////////////
-/// @class async_value
-/// @brief convenient class storing value and associated read-write lock
-//////////////////////////////////////////////////////////////////////////////
+// Convenient class storing value and associated read-write lock
 template<typename T>
 class async_value {
  public:
   using value_type = T;
 
   template<typename... Args>
-  explicit async_value(Args&&... args)
-    : value_{std::forward<Args>(args)...} {
-  }
+  explicit async_value(Args&&... args) : value_{std::forward<Args>(args)...} {}
 
-  const value_type& value() const noexcept {
-    return value_;
-  }
+  const value_type& value() const noexcept { return value_; }
 
-  value_type& value() noexcept {
-    return value_;
-  }
+  value_type& value() noexcept { return value_; }
 
-  auto lock_read() {
-    return make_shared_lock(lock_);
-  }
+  auto lock_read() { return make_shared_lock(lock_); }
 
-  auto lock_write() {
-    return make_unique_lock(lock_);
-  }
+  auto lock_write() { return make_unique_lock(lock_); }
 
  protected:
   value_type value_;
   std::shared_mutex lock_;
-}; // async_value
+};
 
-//////////////////////////////////////////////////////////////////////////////
-/// @brief a fixed size pool of objects
-///        if the pool is empty then a new object is created via make(...)
-///        if an object is available in a pool then in is returned but tracked
-///        by the pool
-///        when the object is released it is placed back into the pool
-/// @note object 'ptr' that evaluate to false after make(...) are not considered
-///       part of the pool
-//////////////////////////////////////////////////////////////////////////////
+// A fixed size pool of objects
+// if the pool is empty then a new object is created via make(...)
+// if an object is available in a pool then in is returned but tracked
+// by the pool.
+// when the object is released it is placed back into the pool
+// Object 'ptr' that evaluate to false after make(...) are not considered
+// part of the pool.
 template<typename T>
 class bounded_object_pool {
  public:
@@ -198,36 +177,26 @@ class bounded_object_pool {
     bounded_object_pool* owner;
     typename T::ptr ptr;
     std::atomic<element_type*> value{};
-  }; // slot
+  };  // slot
 
-  using stack = concurrent_stack<slot> ;
+  using stack = concurrent_stack<slot>;
   using node_type = typename stack::node_type;
 
  public:
-  /////////////////////////////////////////////////////////////////////////////
-  /// @class ptr
-  /// @brief represents a control object of bounded_object_pool with
-  ///        semantic similar to smart pointers
-  /////////////////////////////////////////////////////////////////////////////
+  // Represents a control object of bounded_object_pool with
+  // semantic similar to smart pointers
   class ptr : util::noncopyable {
    private:
     static node_type EMPTY_SLOT;
 
    public:
-    ptr() noexcept
-      : slot_{&EMPTY_SLOT},
-        ptr_{nullptr} {
-    }
+    ptr() noexcept : slot_{&EMPTY_SLOT}, ptr_{nullptr} {}
 
     explicit ptr(node_type& slot, element_type& ptr) noexcept
-      : slot_{&slot},
-        ptr_{&ptr}  {
-    }
+        : slot_{&slot}, ptr_{&ptr} {}
 
-    ptr(ptr&& rhs) noexcept
-      : slot_{rhs.slot_},
-        ptr_{rhs.ptr_} {
-      rhs.slot_ = &EMPTY_SLOT; // take ownership
+    ptr(ptr&& rhs) noexcept : slot_{rhs.slot_}, ptr_{rhs.ptr_} {
+      rhs.slot_ = &EMPTY_SLOT;  // take ownership
       rhs.ptr_ = nullptr;
     }
 
@@ -235,15 +204,13 @@ class bounded_object_pool {
       if (this != &rhs) {
         slot_ = rhs.slot_;
         ptr_ = rhs.ptr_;
-        rhs.slot_ = &EMPTY_SLOT; // take ownership
+        rhs.slot_ = &EMPTY_SLOT;  // take ownership
         rhs.ptr_ = nullptr;
       }
       return *this;
     }
 
-    ~ptr() noexcept {
-      reset();
-    }
+    ~ptr() noexcept { reset(); }
 
     FORCE_INLINE void reset() noexcept {
       reset_impl(slot_);
@@ -253,16 +220,13 @@ class bounded_object_pool {
     std::shared_ptr<element_type> release() {
       auto* slot = slot_;
       auto* ptr = ptr_;
-      slot_ = &EMPTY_SLOT; // moved
+      slot_ = &EMPTY_SLOT;  // moved
       ptr_ = nullptr;
 
       // in case if exception occurs
       // destructor will be called
       return std::shared_ptr<element_type>(
-        ptr,
-        [slot] (element_type*) mutable noexcept {
-          reset_impl(slot);
-      });
+          ptr, [slot](element_type*) mutable noexcept { reset_impl(slot); });
     }
 
     operator bool() const noexcept { return &EMPTY_SLOT != slot_; }
@@ -292,15 +256,14 @@ class bounded_object_pool {
 
       assert(slot->value.owner);
       slot->value.owner->unlock(*slot);
-      slot = &EMPTY_SLOT; // release ownership
+      slot = &EMPTY_SLOT;  // release ownership
     }
 
     node_type* slot_;
     element_type* ptr_;
-  }; // ptr
+  };  // ptr
 
-  explicit bounded_object_pool(size_t size)
-    : pool_(std::max(size_t(1), size)) {
+  explicit bounded_object_pool(size_t size) : pool_(std::max(size_t(1), size)) {
     // initialize pool
     for (auto& node : pool_) {
       auto& slot = node.value;
@@ -340,7 +303,7 @@ class bounded_object_pool {
         return ptr(*head, *p);
       }
 
-      free_list_.push(*head); // put empty slot back into the free list
+      free_list_.push(*head);  // put empty slot back into the free list
       cond_.notify_all();
 
       return ptr();
@@ -360,7 +323,7 @@ class bounded_object_pool {
   bool visit(const Visitor& visitor) const {
     stack list;
 
-    auto release_all = make_finally([this, &list]()noexcept{
+    auto release_all = make_finally([this, &list]() noexcept {
       while (auto* head = list.pop()) {
         free_list_.push(*head);
       }
@@ -409,20 +372,17 @@ class bounded_object_pool {
   mutable std::mutex mutex_;
   mutable std::vector<node_type> pool_;
   mutable stack free_list_;
-}; // bounded_object_pool
+};
 
 template<typename T>
-typename bounded_object_pool<T>::node_type bounded_object_pool<T>::ptr::EMPTY_SLOT;
+typename bounded_object_pool<T>::node_type
+    bounded_object_pool<T>::ptr::EMPTY_SLOT;
 
-//////////////////////////////////////////////////////////////////////////////
-/// @class unbounded_object_pool_base
-/// @brief base class for all unbounded object pool implementations
-//////////////////////////////////////////////////////////////////////////////
-template<
-  typename T,
-  typename = std::enable_if_t<
-    is_unique_ptr_v<typename T::ptr> &&
-    std::is_empty_v<typename T::ptr::deleter_type>>>
+// Base class for all unbounded object pool implementations
+template<typename T,
+         typename =
+             std::enable_if_t<is_unique_ptr_v<typename T::ptr> &&
+                              std::is_empty_v<typename T::ptr::deleter_type>>>
 class unbounded_object_pool_base : private util::noncopyable {
  public:
   using deleter_type = typename T::ptr::deleter_type;
@@ -432,7 +392,7 @@ class unbounded_object_pool_base : private util::noncopyable {
  private:
   struct slot : util::noncopyable {
     pointer value{};
-  }; // slot
+  };  // slot
 
  public:
   size_t size() const noexcept { return pool_.size(); }
@@ -442,12 +402,11 @@ class unbounded_object_pool_base : private util::noncopyable {
   using node = typename stack::node_type;
 
   explicit unbounded_object_pool_base(size_t size)
-    : pool_(size),
-      free_slots_{pool_.data()} {
+      : pool_(size), free_slots_{pool_.data()} {
     // build up linked list
-    for (auto begin = pool_.begin(), end = pool_.end(), next = begin < end ? (begin + 1) : end;
-         next < end;
-         begin = next, ++next) {
+    for (auto begin = pool_.begin(), end = pool_.end(),
+              next = begin < end ? (begin + 1) : end;
+         next < end; begin = next, ++next) {
       begin->next = &*next;
     }
   }
@@ -483,35 +442,33 @@ class unbounded_object_pool_base : private util::noncopyable {
       return;
     }
 
-    [[maybe_unused]] const auto old_value = std::exchange(slot->value.value, value);
+    [[maybe_unused]] const auto old_value =
+        std::exchange(slot->value.value, value);
     assert(!old_value);
     free_objects_.push(*slot);
   }
 
   unbounded_object_pool_base(unbounded_object_pool_base&& rhs) noexcept
-    : pool_{std::move(rhs.pool_)} {
+      : pool_{std::move(rhs.pool_)} {
     // need for volatile pool only
   }
   unbounded_object_pool_base& operator=(unbounded_object_pool_base&&) = delete;
 
   std::vector<node> pool_;
-  stack free_objects_; // list of created objects that are ready to be reused
-  stack free_slots_; // list of free slots to be reused
-}; // unbounded_object_pool_base
+  stack free_objects_;  // list of created objects that are ready to be reused
+  stack free_slots_;    // list of free slots to be reused
+};
 
-//////////////////////////////////////////////////////////////////////////////
-/// @class unbounded_object_pool
-/// @brief a fixed size pool of objects
-///        if the pool is empty then a new object is created via make(...)
-///        if an object is available in a pool then in is returned and no
-///        longer tracked by the pool
-///        when the object is released it is placed back into the pool if
-///        space in the pool is available
-///        pool owns produced object so it's not allowed to destroy before
-///        all acquired objects will be destroyed
-/// @note object 'ptr' that evaluate to false when returnd back into the pool
-///       will be discarded instead
-//////////////////////////////////////////////////////////////////////////////
+// A fixed size pool of objects
+// if the pool is empty then a new object is created via make(...)
+// if an object is available in a pool then in is returned and no
+// longer tracked by the pool
+// when the object is released it is placed back into the pool if
+// space in the pool is available
+// pool owns produced object so it's not allowed to destroy before
+// all acquired objects will be destroyed.
+// Object 'ptr' that evaluate to false when returned back into the pool
+// will be discarded instead.
 template<typename T>
 class unbounded_object_pool : public unbounded_object_pool_base<T> {
  private:
@@ -522,88 +479,23 @@ class unbounded_object_pool : public unbounded_object_pool_base<T> {
   using element_type = typename base_t::element_type;
   using pointer = typename base_t::pointer;
 
-  /////////////////////////////////////////////////////////////////////////////
-  /// @class ptr
-  /// @brief represents a control object of unbounded_object_pool with
-  ///        semantic similar to smart pointers
-  /////////////////////////////////////////////////////////////////////////////
-  class ptr : util::noncopyable {
+  class releaser final {
    public:
-    ptr() noexcept : value_{nullptr} {}
-    ptr(pointer value,
-        unbounded_object_pool& owner)
-      : value_{value},
-        owner_{&owner} {
-    }
+    explicit releaser(unbounded_object_pool& owner) noexcept : owner_{&owner} {}
 
-    ptr(ptr&& rhs) noexcept
-      : value_{rhs.value_},
-        owner_{rhs.owner_} {
-      rhs.value_ = nullptr;
-    }
-
-    ptr& operator=(ptr&& rhs) noexcept {
-      if (this != &rhs) {
-        reset();
-        value_ = rhs.value_;
-        rhs.value_ = nullptr;
-        owner_ = rhs.owner_;
+    void operator()(pointer p) const noexcept {
+      if (p) {
+        owner_->release(p);
       }
-      return *this;
-    }
-   
-    ~ptr() noexcept {
-      reset();
-    }
-
-    FORCE_INLINE void reset() noexcept {
-      if (value_) {
-        owner_->release(value_);
-        value_ = nullptr;
-      }
-    }
-
-    std::shared_ptr<element_type> release() {
-      auto* raw = value_;
-      value_ = nullptr; // moved
-
-      // in case if exception occurs
-      // destructor will be called
-      return std::shared_ptr<element_type>(
-        raw,
-        [owner = owner_] (pointer p) mutable noexcept {
-          owner->release(p);
-      });
-    }
-
-    element_type& operator*() const noexcept { return *value_; }
-    pointer operator->() const noexcept { return get(); }
-    pointer get() const noexcept { return value_; }
-    operator bool() const noexcept {
-      return static_cast<bool>(value_);
-    }
-
-    friend bool operator==(const ptr& lhs, std::nullptr_t) noexcept {
-      return !static_cast<bool>(lhs);
-    }
-    friend bool operator!=(const ptr& lhs, std::nullptr_t rhs) noexcept {
-      return !(lhs == rhs);
-    }
-    friend bool operator==(std::nullptr_t lhs, const ptr& rhs) noexcept {
-      return (rhs == lhs);
-    }
-    friend bool operator!=(std::nullptr_t lhs, const ptr& rhs) noexcept {
-      return !(rhs == lhs);
     }
 
    private:
-    pointer value_;
     unbounded_object_pool* owner_;
   };
 
-  explicit unbounded_object_pool(size_t size = 0)
-    : base_t{size} {
-  }
+  using ptr = std::unique_ptr<element_type, releaser>;
+
+  explicit unbounded_object_pool(size_t size = 0) : base_t{size} {}
 
   ~unbounded_object_pool() {
     for (auto& slot : this->pool_) {
@@ -614,15 +506,13 @@ class unbounded_object_pool : public unbounded_object_pool_base<T> {
   }
 
 #if defined(_MSC_VER)
-  #pragma warning( disable : 4706 )
-#elif defined (__GNUC__)
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wparentheses"
+#pragma warning(disable : 4706)
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wparentheses"
 #endif
 
-  /////////////////////////////////////////////////////////////////////////////
-  /// @brief clears all cached objects
-  /////////////////////////////////////////////////////////////////////////////
+  // Clears all cached objects
   void clear() {
     node* head = nullptr;
 
@@ -636,45 +526,42 @@ class unbounded_object_pool : public unbounded_object_pool_base<T> {
   }
 
 #if defined(_MSC_VER)
-  #pragma warning( default : 4706 )
-#elif defined (__GNUC__)
-  #pragma GCC diagnostic pop
+#pragma warning(default : 4706)
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
 #endif
 
   template<typename... Args>
   ptr emplace(Args&&... args) {
-    return ptr(this->acquire(std::forward<Args>(args)...), *this);
+    return {this->acquire(std::forward<Args>(args)...), releaser{*this}};
   }
 
  private:
   // disallow move
   unbounded_object_pool(unbounded_object_pool&&) = delete;
   unbounded_object_pool& operator=(unbounded_object_pool&&) = delete;
-}; // unbounded_object_pool
+};
 
-//////////////////////////////////////////////////////////////////////////////
-/// @class unbounded_object_pool_volatile
-/// @brief a fixed size pool of objects
-///        if the pool is empty then a new object is created via make(...)
-///        if an object is available in a pool then in is returned and no
-///        longer tracked by the pool
-///        when the object is released it is placed back into the pool if
-///        space in the pool is available
-///        pool may be safely destroyed even there are some produced objects
-///        alive
-/// @note object 'ptr' that evaluate to false when returnd back into the pool
-///       will be discarded instead
-//////////////////////////////////////////////////////////////////////////////
+// A fixed size pool of objects.
+// if the pool is empty then a new object is created via make(...)
+// if an object is available in a pool then in is returned and no
+// longer tracked by the pool
+// when the object is released it is placed back into the pool if
+// space in the pool is available
+// pool may be safely destroyed even there are some produced objects
+// alive.
+// Object 'ptr' that evaluate to false when returnd back into the pool
+// will be discarded instead.
 template<typename T>
 class unbounded_object_pool_volatile : public unbounded_object_pool_base<T> {
  private:
   struct generation {
-    explicit generation(unbounded_object_pool_volatile * owner) noexcept
-      : owner{owner} {
-    }
+    explicit generation(unbounded_object_pool_volatile* owner) noexcept
+        : owner{owner} {}
 
-    unbounded_object_pool_volatile* owner; // current owner (null == stale generation)
-  }; // generation
+    // current owner (null == stale generation)
+    unbounded_object_pool_volatile* owner;
+  };
 
   using base_t = unbounded_object_pool_base<T>;
   using generation_t = async_value<generation>;
@@ -686,22 +573,14 @@ class unbounded_object_pool_volatile : public unbounded_object_pool_base<T> {
   using element_type = typename base_t::element_type;
   using pointer = typename base_t::pointer;
 
-  /////////////////////////////////////////////////////////////////////////////
-  /// @class ptr
-  /// @brief represents a control object of unbounded_object_pool with
-  ///        semantic similar to smart pointers
-  /////////////////////////////////////////////////////////////////////////////
+  // Represents a control object of unbounded_object_pool with
+  // semantic similar to smart pointers.
   class ptr : private util::noncopyable {
    public:
-    ptr(pointer value,
-        generation_ptr_t gen) noexcept
-      : value_{value},
-        gen_{std::move(gen)} {
-    }
+    ptr(pointer value, generation_ptr_t gen) noexcept
+        : value_{value}, gen_{std::move(gen)} {}
 
-    ptr(ptr&& rhs) noexcept
-      : value_{rhs.value_},
-        gen_{std::move(rhs.gen_)} {
+    ptr(ptr&& rhs) noexcept : value_{rhs.value_}, gen_{std::move(rhs.gen_)} {
       rhs.value_ = nullptr;
     }
     ptr& operator=(ptr&& rhs) noexcept {
@@ -715,9 +594,7 @@ class unbounded_object_pool_volatile : public unbounded_object_pool_base<T> {
       return *this;
     }
 
-    ~ptr() noexcept {
-      reset();
-    }
+    ~ptr() noexcept { reset(); }
 
     void reset() noexcept {
       if (!gen_) {
@@ -727,31 +604,28 @@ class unbounded_object_pool_volatile : public unbounded_object_pool_base<T> {
 
       reset_impl(value_, *gen_);
       value_ = nullptr;
-      gen_ = nullptr; // mark as destroyed
+      gen_ = nullptr;  // mark as destroyed
     }
 
     std::shared_ptr<element_type> release() {
       auto raw = value_;
       auto moved_gen = make_move_on_copy(std::move(gen_));
-      assert(!gen_); // moved
+      assert(!gen_);  // moved
 
       // in case if exception occurs
       // destructor will be called
       return std::shared_ptr<element_type>(
-        raw,
-        [moved_gen] (pointer p) noexcept {
-          if (p) {
-            reset_impl(p, *moved_gen.value());
-          }
-      });
+          raw, [moved_gen](pointer p) noexcept {
+            if (p) {
+              reset_impl(p, *moved_gen.value());
+            }
+          });
     }
 
     element_type& operator*() const noexcept { return *value_; }
     pointer operator->() const noexcept { return get(); }
     pointer get() const noexcept { return value_; }
-    operator bool() const noexcept {
-      return static_cast<bool>(gen_);
-    }
+    operator bool() const noexcept { return static_cast<bool>(gen_); }
 
     friend bool operator==(const ptr& lhs, std::nullptr_t) noexcept {
       return !static_cast<bool>(lhs);
@@ -788,12 +662,10 @@ class unbounded_object_pool_volatile : public unbounded_object_pool_base<T> {
 
     pointer value_;
     generation_ptr_t gen_;
-  }; // ptr
+  };  // ptr
 
   explicit unbounded_object_pool_volatile(size_t size = 0)
-    : base_t{size},
-      gen_{memory::make_shared<generation_t>(this)} {
-  }
+      : base_t{size}, gen_{memory::make_shared<generation_t>(this)} {}
 
   // FIXME check what if
   //
@@ -801,11 +673,11 @@ class unbounded_object_pool_volatile : public unbounded_object_pool_base<T> {
   // thread0: p0.clear();
   // thread1: unbounded_object_pool_volatile p1(std::move(p0));
   unbounded_object_pool_volatile(unbounded_object_pool_volatile&& rhs) noexcept
-    : base_t{std::move(rhs)} {
+      : base_t{std::move(rhs)} {
     gen_ = atomic_utils::atomic_load(&rhs.gen_);
 
     auto lock = gen_->lock_write();
-    gen_->value().owner = this; // change owner
+    gen_->value().owner = this;  // change owner
 
     this->free_slots_ = std::move(rhs.free_slots_);
     this->free_objects_ = std::move(rhs.free_objects_);
@@ -828,12 +700,10 @@ class unbounded_object_pool_volatile : public unbounded_object_pool_base<T> {
     clear(false);
   }
 
-  /////////////////////////////////////////////////////////////////////////////
-  /// @brief clears all cached objects and optionally prevents already created
-  ///        objects from returning into the pool
-  /// @param new_generation if true, prevents already created objects from
-  ///        returning into the pool, otherwise just clears all cached objects
-  /////////////////////////////////////////////////////////////////////////////
+  // Clears all cached objects and optionally prevents already created
+  // objects from returning into the pool.
+  // `new_generation` if true, prevents already created objects from
+  // returning into the pool, otherwise just clears all cached objects.
   void clear(bool new_generation = false) {
     // prevent existing elements from returning into the pool
     if (new_generation) {
@@ -844,7 +714,8 @@ class unbounded_object_pool_volatile : public unbounded_object_pool_base<T> {
       }
 
       // mark new generation
-      atomic_utils::atomic_store(&gen_, memory::make_shared<generation_t>(this));
+      atomic_utils::atomic_store(&gen_,
+                                 memory::make_shared<generation_t>(this));
     }
 
     typename base_t::node* head = nullptr;
@@ -860,27 +731,27 @@ class unbounded_object_pool_volatile : public unbounded_object_pool_base<T> {
 
   template<typename... Args>
   ptr emplace(Args&&... args) {
-    const auto gen = atomic_utils::atomic_load(&gen_); // retrieve before seek/instantiate
+    const auto gen =
+        atomic_utils::atomic_load(&gen_);  // retrieve before seek/instantiate
     auto value = this->acquire(std::forward<Args>(args)...);
 
-    return value
-      ? ptr{value, gen}
-      : ptr{nullptr, generation_ptr_t{}};
+    return value ? ptr{value, gen} : ptr{nullptr, generation_ptr_t{}};
   }
 
   size_t generation_size() const noexcept {
     const auto use_count = atomic_utils::atomic_load(&gen_).use_count();
     assert(use_count >= 2);
-    return use_count - 2; // -1 for temporary object, -1 for this->_gen
+    return use_count - 2;  // -1 for temporary object, -1 for this->_gen
   }
 
  private:
   // disallow move assignment
-  unbounded_object_pool_volatile& operator=(unbounded_object_pool_volatile&&) = delete;
+  unbounded_object_pool_volatile& operator=(unbounded_object_pool_volatile&&) =
+      delete;
 
-  generation_ptr_t gen_; // current generation
-}; // unbounded_object_pool_volatile
+  generation_ptr_t gen_;  // current generation
+};
 
-}
+}  // namespace iresearch
 
 #endif

--- a/tests/utils/object_pool_tests.cpp
+++ b/tests/utils/object_pool_tests.cpp
@@ -449,7 +449,7 @@ TEST(unbounded_object_pool_tests, test_uobject_pool_1) {
     std::condition_variable cond;
     std::mutex mutex;
     irs::unbounded_object_pool<test_uobject> pool(1);
-    std::shared_ptr obj = pool.emplace(1);
+    std::shared_ptr<test_uobject> obj = pool.emplace(1);
 
     {
       auto lock = irs::make_unique_lock(mutex);
@@ -490,7 +490,7 @@ TEST(unbounded_object_pool_tests, test_uobject_pool_1) {
     ASSERT_FALSE(obj);
     ASSERT_EQ(1, test_uobject_nullptr::MAKE_COUNT);
     obj.reset();
-    std::shared_ptr obj_shared = pool.emplace();
+    std::shared_ptr<test_uobject_nullptr> obj_shared = pool.emplace();
     ASSERT_FALSE(obj);
     ASSERT_EQ(2, test_uobject_nullptr::MAKE_COUNT);
     obj.reset();
@@ -507,7 +507,7 @@ TEST(unbounded_object_pool_tests, test_uobject_pool_1) {
     obj.reset();
     ASSERT_FALSE(obj);
     ASSERT_EQ(nullptr, obj.get());
-    std::shared_ptr obj_shared{pool.emplace(2)};
+    std::shared_ptr<test_uobject> obj_shared{pool.emplace(2)};
     ASSERT_TRUE(bool(obj_shared));
     ASSERT_EQ(1, obj_shared->id);
     ASSERT_EQ(obj_ptr, obj_shared.get());
@@ -518,7 +518,7 @@ TEST(unbounded_object_pool_tests, test_uobject_pool_1) {
     irs::unbounded_object_pool<test_uobject> pool(1);
     auto obj0 = pool.emplace(1);
     ASSERT_TRUE(obj0);
-    std::shared_ptr obj1{pool.emplace(2)};
+    std::shared_ptr<test_uobject> obj1{pool.emplace(2)};
     ASSERT_TRUE(bool(obj1));
     auto* obj0_ptr = obj0.get();
 
@@ -532,7 +532,7 @@ TEST(unbounded_object_pool_tests, test_uobject_pool_1) {
     ASSERT_FALSE(obj1);
     ASSERT_EQ(nullptr, obj1.get());
 
-    std::shared_ptr obj2{pool.emplace(3)};
+    std::shared_ptr<test_uobject> obj2{pool.emplace(3)};
     ASSERT_TRUE(bool(obj2));
     auto obj3 = pool.emplace(4);
     ASSERT_TRUE(obj3);
@@ -585,7 +585,7 @@ TEST(unbounded_object_pool_tests, test_uobject_pool_2) {
     std::condition_variable cond;
     std::mutex mutex;
     irs::unbounded_object_pool<test_uobject> pool(1);
-    std::shared_ptr obj = pool.emplace(1);
+    std::shared_ptr<test_uobject> obj = pool.emplace(1);
 
     {
       auto lock = irs::make_unique_lock(mutex);
@@ -610,7 +610,7 @@ TEST(unbounded_object_pool_tests, test_uobject_pool_2) {
     ASSERT_FALSE(obj);
     ASSERT_EQ(1, test_uobject_nullptr::MAKE_COUNT);
     obj.reset();
-    std::shared_ptr obj_shared = pool.emplace();
+    std::shared_ptr<test_uobject_nullptr> obj_shared = pool.emplace();
     ASSERT_FALSE(obj);
     ASSERT_EQ(2, test_uobject_nullptr::MAKE_COUNT);
     obj.reset();
@@ -627,7 +627,7 @@ TEST(unbounded_object_pool_tests, test_uobject_pool_2) {
     obj.reset();
     ASSERT_FALSE(obj);
     ASSERT_EQ(nullptr, obj.get());
-    std::shared_ptr obj_shared{pool.emplace(2)};
+    std::shared_ptr<test_uobject> obj_shared{pool.emplace(2)};
     ASSERT_TRUE(bool(obj_shared));
     ASSERT_EQ(1, obj_shared->id);
     ASSERT_EQ(obj_ptr, obj_shared.get());
@@ -638,7 +638,7 @@ TEST(unbounded_object_pool_tests, test_uobject_pool_2) {
     irs::unbounded_object_pool<test_uobject> pool(1);
     auto obj0 = pool.emplace(1);
     ASSERT_TRUE(obj0);
-    std::shared_ptr obj1{pool.emplace(2)};
+    std::shared_ptr<test_uobject> obj1{pool.emplace(2)};
     ASSERT_TRUE(bool(obj1));
     auto* obj0_ptr = obj0.get();
 
@@ -652,7 +652,7 @@ TEST(unbounded_object_pool_tests, test_uobject_pool_2) {
     ASSERT_FALSE(obj1);
     ASSERT_EQ(nullptr, obj1.get());
 
-    std::shared_ptr obj2{pool.emplace(3)};
+    std::shared_ptr<test_uobject> obj2{pool.emplace(3)};
     ASSERT_TRUE(bool(obj2));
     auto obj3 = pool.emplace(4);
     ASSERT_TRUE(obj3);
@@ -866,7 +866,7 @@ TEST(unbounded_object_pool_volatile_tests, test_uobject_pool_1) {
     std::mutex mutex;
     irs::unbounded_object_pool_volatile<test_uobject> pool(1);
     ASSERT_EQ(0, pool.generation_size());
-    std::shared_ptr obj = pool.emplace(1);
+    std::shared_ptr<test_uobject> obj = pool.emplace(1);
     ASSERT_EQ(1, pool.generation_size());
 
     {
@@ -909,7 +909,7 @@ TEST(unbounded_object_pool_volatile_tests, test_uobject_pool_1) {
     ASSERT_FALSE(obj);
     ASSERT_EQ(1, test_uobject_nullptr::MAKE_COUNT);
     obj.reset();
-    std::shared_ptr obj_shared = pool.emplace();
+    std::shared_ptr<test_uobject_nullptr> obj_shared = pool.emplace();
     ASSERT_FALSE(obj);
     ASSERT_EQ(2, test_uobject_nullptr::MAKE_COUNT);
     obj.reset();
@@ -928,7 +928,7 @@ TEST(unbounded_object_pool_volatile_tests, test_uobject_pool_1) {
     ASSERT_FALSE(obj);
     ASSERT_EQ(nullptr, obj.get());
     ASSERT_EQ(0, pool.generation_size());
-    std::shared_ptr obj_shared{pool.emplace(2)};
+    std::shared_ptr<test_uobject> obj_shared{pool.emplace(2)};
     ASSERT_EQ(1, pool.generation_size());
     ASSERT_EQ(1, obj_shared->id);
     ASSERT_EQ(obj_ptr, obj_shared.get());
@@ -941,7 +941,7 @@ TEST(unbounded_object_pool_volatile_tests, test_uobject_pool_1) {
     auto obj0 = pool.emplace(1);
     ASSERT_EQ(1, pool.generation_size());
     ASSERT_TRUE(obj0);
-    std::shared_ptr obj1 = pool.emplace(2);
+    std::shared_ptr<test_uobject> obj1 = pool.emplace(2);
     ASSERT_EQ(2, pool.generation_size());
     ASSERT_TRUE(bool(obj1));
     auto* obj0_ptr = obj0.get();
@@ -958,7 +958,7 @@ TEST(unbounded_object_pool_volatile_tests, test_uobject_pool_1) {
     ASSERT_FALSE(obj1);
     ASSERT_EQ(nullptr, obj1.get());
 
-    std::shared_ptr obj2 = pool.emplace(3);
+    std::shared_ptr<test_uobject> obj2 = pool.emplace(3);
     ASSERT_EQ(1, pool.generation_size());
     ASSERT_TRUE(bool(obj2));
     auto obj3 = pool.emplace(4);
@@ -1041,7 +1041,7 @@ TEST(unbounded_object_pool_volatile_tests, return_object_after_pool_destroyed) {
   ASSERT_EQ(1, pool->generation_size());
   ASSERT_TRUE(obj);
   ASSERT_EQ(42, obj->id);
-  std::shared_ptr objShared = pool->emplace(442);
+  std::shared_ptr<test_uobject> objShared = pool->emplace(442);
   ASSERT_EQ(2, pool->generation_size());
   ASSERT_NE(nullptr, objShared);
   ASSERT_EQ(442, objShared->id);
@@ -1085,7 +1085,7 @@ TEST(unbounded_object_pool_volatile_tests, test_uobject_pool_2) {
     ASSERT_FALSE(obj);
     ASSERT_EQ(1, test_uobject_nullptr::MAKE_COUNT);
     obj.reset();
-    std::shared_ptr obj_shared = pool.emplace();
+    std::shared_ptr<test_uobject_nullptr> obj_shared = pool.emplace();
     ASSERT_FALSE(obj);
     ASSERT_EQ(2, test_uobject_nullptr::MAKE_COUNT);
     obj.reset();

--- a/tests/utils/object_pool_tests.cpp
+++ b/tests/utils/object_pool_tests.cpp
@@ -499,7 +499,7 @@ TEST(unbounded_object_pool_tests, test_uobject_pool_1) {
     obj.reset();
     ASSERT_FALSE(obj);
     ASSERT_EQ(nullptr, obj.get());
-    auto obj_shared = pool.emplace(2).release();
+    std::shared_ptr obj_shared{pool.emplace(2)};
     ASSERT_TRUE(bool(obj_shared));
     ASSERT_EQ(1, obj_shared->id);
     ASSERT_EQ(obj_ptr, obj_shared.get());
@@ -510,7 +510,7 @@ TEST(unbounded_object_pool_tests, test_uobject_pool_1) {
     irs::unbounded_object_pool<test_uobject> pool(1);
     auto obj0 = pool.emplace(1);
     ASSERT_TRUE(obj0);
-    auto obj1 = pool.emplace(2).release();
+    std::shared_ptr obj1{pool.emplace(2)};
     ASSERT_TRUE(bool(obj1));
     auto* obj0_ptr = obj0.get();
 
@@ -524,7 +524,7 @@ TEST(unbounded_object_pool_tests, test_uobject_pool_1) {
     ASSERT_FALSE(obj1);
     ASSERT_EQ(nullptr, obj1.get());
 
-    auto obj2 = pool.emplace(3).release();
+    std::shared_ptr obj2{pool.emplace(3)};
     ASSERT_TRUE(bool(obj2));
     auto obj3 = pool.emplace(4);
     ASSERT_TRUE(obj3);
@@ -616,7 +616,7 @@ TEST(unbounded_object_pool_tests, test_uobject_pool_2) {
     obj.reset();
     ASSERT_FALSE(obj);
     ASSERT_EQ(nullptr, obj.get());
-    auto obj_shared = pool.emplace(2).release();
+    std::shared_ptr obj_shared{pool.emplace(2)};
     ASSERT_TRUE(bool(obj_shared));
     ASSERT_EQ(1, obj_shared->id);
     ASSERT_EQ(obj_ptr, obj_shared.get());
@@ -627,7 +627,7 @@ TEST(unbounded_object_pool_tests, test_uobject_pool_2) {
     irs::unbounded_object_pool<test_uobject> pool(1);
     auto obj0 = pool.emplace(1);
     ASSERT_TRUE(obj0);
-    auto obj1 = pool.emplace(2).release();
+    std::shared_ptr obj1{pool.emplace(2)};
     ASSERT_TRUE(bool(obj1));
     auto* obj0_ptr = obj0.get();
 
@@ -641,7 +641,7 @@ TEST(unbounded_object_pool_tests, test_uobject_pool_2) {
     ASSERT_FALSE(obj1);
     ASSERT_EQ(nullptr, obj1.get());
 
-    auto obj2 = pool.emplace(3).release();
+    std::shared_ptr obj2{pool.emplace(3)};
     ASSERT_TRUE(bool(obj2));
     auto obj3 = pool.emplace(4);
     ASSERT_TRUE(obj3);

--- a/tests/utils/object_pool_tests.cpp
+++ b/tests/utils/object_pool_tests.cpp
@@ -117,7 +117,7 @@ TEST(bounded_object_pool_tests, check_total_number_of_instances) {
       }
     }
 
-    pool.emplace(id++).release();
+    pool.emplace(id++);
   };
 
   const size_t THREADS_COUNT = 32;
@@ -148,7 +148,7 @@ TEST(bounded_object_pool_tests, test_sobject_pool) {
     std::condition_variable cond;
     std::mutex mutex;
     irs::bounded_object_pool<test_sobject> pool(1);
-    auto obj = pool.emplace(1).release();
+    auto obj = pool.emplace(1);
 
     {
       auto lock = irs::make_unique_lock(mutex);
@@ -182,7 +182,7 @@ TEST(bounded_object_pool_tests, test_sobject_pool) {
     std::mutex mutex;
     irs::bounded_object_pool<test_sobject_nullptr> pool(2);
     test_sobject_nullptr::MAKE_COUNT = 0;
-    auto obj = pool.emplace().release();
+    auto obj = pool.emplace();
     ASSERT_FALSE(obj);
     ASSERT_EQ(1, test_sobject_nullptr::MAKE_COUNT);
 
@@ -216,7 +216,7 @@ TEST(bounded_object_pool_tests, test_sobject_pool) {
     ASSERT_EQ(1, obj->id);
     obj.reset();
     ASSERT_FALSE(obj);
-    auto obj_shared = pool.emplace(2).release();
+    auto obj_shared = pool.emplace(2);
     ASSERT_EQ(1, obj_shared->id);
     ASSERT_EQ(obj_ptr, obj_shared.get());
   }
@@ -301,7 +301,7 @@ TEST(bounded_object_pool_tests, test_uobject_pool) {
     std::mutex mutex;
     irs::bounded_object_pool<test_uobject_nullptr> pool(2);
     test_uobject_nullptr::MAKE_COUNT = 0;
-    auto obj = pool.emplace().release();
+    auto obj = pool.emplace();
     ASSERT_FALSE(obj);
     ASSERT_EQ(1, test_uobject_nullptr::MAKE_COUNT);
 
@@ -416,7 +416,7 @@ TEST(unbounded_object_pool_tests, check_total_number_of_cached_instances) {
     }
 
     for (size_t i = 0; i < 100000; ++i) {
-      auto p = pool.emplace(id++).release();
+      auto p = pool.emplace(id++);
       ASSERT_TRUE(p->id >= 0);
     }
   };
@@ -477,7 +477,7 @@ TEST(unbounded_object_pool_tests, test_uobject_pool_1) {
     obj.reset();
     ASSERT_FALSE(obj);
     ASSERT_EQ(nullptr, obj.get());
-    auto obj_shared = pool.emplace(2).release();
+    auto obj_shared = pool.emplace(2);
     ASSERT_TRUE(bool(obj_shared));
     ASSERT_EQ(2, obj_shared->id);
   }
@@ -866,7 +866,7 @@ TEST(unbounded_object_pool_volatile_tests, test_uobject_pool_1) {
     std::mutex mutex;
     irs::unbounded_object_pool_volatile<test_uobject> pool(1);
     ASSERT_EQ(0, pool.generation_size());
-    std::shared_ptr obj = pool.emplace(1).release();
+    std::shared_ptr obj = pool.emplace(1);
     ASSERT_EQ(1, pool.generation_size());
 
     {
@@ -876,9 +876,8 @@ TEST(unbounded_object_pool_volatile_tests, test_uobject_pool_1) {
         auto lock = irs::make_unique_lock(mutex);
         cond.notify_all();
       });
-      ASSERT_EQ(
-          std::cv_status::no_timeout,
-          cond.wait_for(lock, 1000ms));  // assume threads start within 1000msec
+      // assume threads start within 1000msec
+      ASSERT_EQ(std::cv_status::no_timeout, cond.wait_for(lock, 1000ms));
       lock.unlock();
       thread.join();
     }
@@ -897,7 +896,7 @@ TEST(unbounded_object_pool_volatile_tests, test_uobject_pool_1) {
     obj.reset();
     ASSERT_FALSE(obj);
     ASSERT_EQ(nullptr, obj.get());
-    auto obj_shared = pool.emplace(2).release();
+    auto obj_shared = pool.emplace(2);
     ASSERT_TRUE(bool(obj_shared));
     ASSERT_EQ(2, obj_shared->id);
   }
@@ -910,7 +909,7 @@ TEST(unbounded_object_pool_volatile_tests, test_uobject_pool_1) {
     ASSERT_FALSE(obj);
     ASSERT_EQ(1, test_uobject_nullptr::MAKE_COUNT);
     obj.reset();
-    std::shared_ptr obj_shared = pool.emplace().release();
+    std::shared_ptr obj_shared = pool.emplace();
     ASSERT_FALSE(obj);
     ASSERT_EQ(2, test_uobject_nullptr::MAKE_COUNT);
     obj.reset();
@@ -929,7 +928,7 @@ TEST(unbounded_object_pool_volatile_tests, test_uobject_pool_1) {
     ASSERT_FALSE(obj);
     ASSERT_EQ(nullptr, obj.get());
     ASSERT_EQ(0, pool.generation_size());
-    std::shared_ptr obj_shared{pool.emplace(2).release()};
+    std::shared_ptr obj_shared{pool.emplace(2)};
     ASSERT_EQ(1, pool.generation_size());
     ASSERT_EQ(1, obj_shared->id);
     ASSERT_EQ(obj_ptr, obj_shared.get());
@@ -942,7 +941,7 @@ TEST(unbounded_object_pool_volatile_tests, test_uobject_pool_1) {
     auto obj0 = pool.emplace(1);
     ASSERT_EQ(1, pool.generation_size());
     ASSERT_TRUE(obj0);
-    std::shared_ptr obj1 = pool.emplace(2).release();
+    std::shared_ptr obj1 = pool.emplace(2);
     ASSERT_EQ(2, pool.generation_size());
     ASSERT_TRUE(bool(obj1));
     auto* obj0_ptr = obj0.get();
@@ -959,7 +958,7 @@ TEST(unbounded_object_pool_volatile_tests, test_uobject_pool_1) {
     ASSERT_FALSE(obj1);
     ASSERT_EQ(nullptr, obj1.get());
 
-    std::shared_ptr obj2 = pool.emplace(3).release();
+    std::shared_ptr obj2 = pool.emplace(3);
     ASSERT_EQ(1, pool.generation_size());
     ASSERT_TRUE(bool(obj2));
     auto obj3 = pool.emplace(4);
@@ -1042,7 +1041,7 @@ TEST(unbounded_object_pool_volatile_tests, return_object_after_pool_destroyed) {
   ASSERT_EQ(1, pool->generation_size());
   ASSERT_TRUE(obj);
   ASSERT_EQ(42, obj->id);
-  auto objShared = pool->emplace(442).release();
+  std::shared_ptr objShared = pool->emplace(442);
   ASSERT_EQ(2, pool->generation_size());
   ASSERT_NE(nullptr, objShared);
   ASSERT_EQ(442, objShared->id);
@@ -1071,9 +1070,8 @@ TEST(unbounded_object_pool_volatile_tests, test_uobject_pool_2) {
         auto lock = irs::make_unique_lock(mutex);
         cond.notify_all();
       });
-      ASSERT_EQ(
-          std::cv_status::no_timeout,
-          cond.wait_for(lock, 1000ms));  // assume threads start within 1000msec
+      // assume threads start within 1000msec
+      ASSERT_EQ(std::cv_status::no_timeout, cond.wait_for(lock, 1000ms));
       lock.unlock();
       thread.join();
     }
@@ -1087,7 +1085,7 @@ TEST(unbounded_object_pool_volatile_tests, test_uobject_pool_2) {
     ASSERT_FALSE(obj);
     ASSERT_EQ(1, test_uobject_nullptr::MAKE_COUNT);
     obj.reset();
-    std::shared_ptr obj_shared = pool.emplace().release();
+    std::shared_ptr obj_shared = pool.emplace();
     ASSERT_FALSE(obj);
     ASSERT_EQ(2, test_uobject_nullptr::MAKE_COUNT);
     obj.reset();
@@ -1234,7 +1232,7 @@ TEST(unbounded_object_pool_volatile_tests,
     }
 
     for (size_t i = 0; i < 100000; ++i) {
-      auto p = pool.emplace(id++).release();
+      auto p = pool.emplace(id++);
       ASSERT_TRUE(p->id >= 0);
     }
   };

--- a/tests/utils/object_pool_tests.cpp
+++ b/tests/utils/object_pool_tests.cpp
@@ -866,7 +866,7 @@ TEST(unbounded_object_pool_volatile_tests, test_uobject_pool_1) {
     std::mutex mutex;
     irs::unbounded_object_pool_volatile<test_uobject> pool(1);
     ASSERT_EQ(0, pool.generation_size());
-    std::shared_ptr obj = pool.emplace(1);
+    std::shared_ptr obj = pool.emplace(1).release();
     ASSERT_EQ(1, pool.generation_size());
 
     {
@@ -910,7 +910,7 @@ TEST(unbounded_object_pool_volatile_tests, test_uobject_pool_1) {
     ASSERT_FALSE(obj);
     ASSERT_EQ(1, test_uobject_nullptr::MAKE_COUNT);
     obj.reset();
-    std::shared_ptr obj_shared = pool.emplace();
+    std::shared_ptr obj_shared = pool.emplace().release();
     ASSERT_FALSE(obj);
     ASSERT_EQ(2, test_uobject_nullptr::MAKE_COUNT);
     obj.reset();
@@ -929,7 +929,7 @@ TEST(unbounded_object_pool_volatile_tests, test_uobject_pool_1) {
     ASSERT_FALSE(obj);
     ASSERT_EQ(nullptr, obj.get());
     ASSERT_EQ(0, pool.generation_size());
-    std::shared_ptr obj_shared{pool.emplace(2)};
+    std::shared_ptr obj_shared{pool.emplace(2).release()};
     ASSERT_EQ(1, pool.generation_size());
     ASSERT_EQ(1, obj_shared->id);
     ASSERT_EQ(obj_ptr, obj_shared.get());
@@ -942,7 +942,7 @@ TEST(unbounded_object_pool_volatile_tests, test_uobject_pool_1) {
     auto obj0 = pool.emplace(1);
     ASSERT_EQ(1, pool.generation_size());
     ASSERT_TRUE(obj0);
-    std::shared_ptr obj1 = pool.emplace(2);
+    std::shared_ptr obj1 = pool.emplace(2).release();
     ASSERT_EQ(2, pool.generation_size());
     ASSERT_TRUE(bool(obj1));
     auto* obj0_ptr = obj0.get();
@@ -959,7 +959,7 @@ TEST(unbounded_object_pool_volatile_tests, test_uobject_pool_1) {
     ASSERT_FALSE(obj1);
     ASSERT_EQ(nullptr, obj1.get());
 
-    std::shared_ptr obj2 = pool.emplace(3);
+    std::shared_ptr obj2 = pool.emplace(3).release();
     ASSERT_EQ(1, pool.generation_size());
     ASSERT_TRUE(bool(obj2));
     auto obj3 = pool.emplace(4);
@@ -1087,7 +1087,7 @@ TEST(unbounded_object_pool_volatile_tests, test_uobject_pool_2) {
     ASSERT_FALSE(obj);
     ASSERT_EQ(1, test_uobject_nullptr::MAKE_COUNT);
     obj.reset();
-    std::shared_ptr obj_shared = pool.emplace();
+    std::shared_ptr obj_shared = pool.emplace().release();
     ASSERT_FALSE(obj);
     ASSERT_EQ(2, test_uobject_nullptr::MAKE_COUNT);
     obj.reset();


### PR DESCRIPTION
Remove custom `std::unique_ptr`-like smart pointers in object pools.