### PR TITLE
Fix build for MSVC 2022

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,12 @@ if (MSVC)
     set(CMAKE_C_FLAGS "/MP ${CMAKE_C_FLAGS}")
     set(CMAKE_CXX_FLAGS "/MP ${CMAKE_CXX_FLAGS}")
   endif()
+  
+  if (${MSVC_VERSION} STRGREATER_EQUAL 1930)
+    # see https://docs.microsoft.com/en-us/cpp/overview/cpp-conformance-improvements?view=msvc-170#error-on-a-non-dependent-static_assert
+    set(CMAKE_C_FLAGS "/Zc:static_assert- ${CMAKE_C_FLAGS}")
+    set(CMAKE_CXX_FLAGS "/Zc:static_assert- ${CMAKE_CXX_FLAGS}")
+  endif()
 elseif (NOT IS_ARM)
   # allow 16 byte compare-exchange
   add_compile_options(-mcx16)

--- a/core/shared.hpp
+++ b/core/shared.hpp
@@ -221,7 +221,7 @@
 
 // define function name used for pretty printing
 // NOTE: the alias points to a compile time finction not a preprocessor macro
-#if defined(__FUNCSIG__)
+#if defined(__FUNCSIG__) || _MSC_FULL_VER >= 193000000
   #define IRESEARCH_CURRENT_FUNCTION __FUNCSIG__
 #elif defined(__PRETTY_FUNCTION__) || defined(__GNUC__) || defined(__clang__)
   #define IRESEARCH_CURRENT_FUNCTION __PRETTY_FUNCTION__


### PR DESCRIPTION
__FUNCSIG__ is not detected by "ifdef" but still works.
/Zc:static_assert- flag added to disable  breaking change ins static assert evaluation  see  https://docs.microsoft.com/en-us/cpp/overview/cpp-conformance-improvements?view=msvc-170#error-on-a-non-dependent-static_assert