### PR TITLE
fix buffer overflow for larger numbers

### DIFF
--- a/utils/index-put.cpp
+++ b/utils/index-put.cpp
@@ -283,7 +283,7 @@ struct WikiDoc : Doc {
 
     // id: uint64_t to string, base 36
     uint64_t id = next_id++;  // atomic fetch and get
-    char str[10];
+    char str[21];
     itoa(id, str, 36);
     char str2[10];
     snprintf(str2, sizeof(str2), "%6s", str);


### PR DESCRIPTION
fixes compile warnings
```
In member function ‘itoa’,
    inlined from ‘itoa’ at /home/jan/Downloads/iresearch/utils/index-put.cpp:116:9,
    inlined from ‘fill’ at /home/jan/Downloads/iresearch/utils/index-put.cpp:287:9:
/home/jan/Downloads/iresearch/utils/index-put.cpp:140:15: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
  140 |       *ptr1++ = tmp_char;
      |               ^
/home/jan/Downloads/iresearch/utils/index-put.cpp:140:15: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
/home/jan/Downloads/iresearch/utils/index-put.cpp:140:15: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
/home/jan/Downloads/iresearch/utils/index-put.cpp:140:15: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
/home/jan/Downloads/iresearch/utils/index-put.cpp:140:15: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
In member function ‘itoa’,
    inlined from ‘itoa’ at /home/jan/Downloads/iresearch/utils/index-put.cpp:116:9,
    inlined from ‘fill’ at /home/jan/Downloads/iresearch/utils/index-put.cpp:287:9,
    inlined from ‘operator()’ at /home/jan/Downloads/iresearch/utils/index-put.cpp:552:19:
/home/jan/Downloads/iresearch/utils/index-put.cpp:140:15: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
  140 |       *ptr1++ = tmp_char;
      |               ^
/home/jan/Downloads/iresearch/utils/index-put.cpp:140:15: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
/home/jan/Downloads/iresearch/utils/index-put.cpp:140:15: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
/home/jan/Downloads/iresearch/utils/index-put.cpp:140:15: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
/home/jan/Downloads/iresearch/utils/index-put.cpp:140:15: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
```