### PR TITLE
Update abseil and use absl::crc32c

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/arangodb/velocypack.git
 [submodule "external/abseil-cpp"]
 	path = external/abseil-cpp
-	url = https://github.com/abseil/abseil-cpp.git
+	url = https://github.com/arangodb/abseil-cpp.git

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -59,8 +59,8 @@ if (MSVC)
 else ()
   add_definitions(-Wall)
 
-  if (NOT APPLE)
-    set(CMAKE_CXX_FLAGS_RELEASE "-s ${CMAKE_CXX_FLAGS_RELEASE}")
+  if (NOT APPLE AND NOT (CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo" OR CMAKE_BUILD_TYPE STREQUAL "Debug"))
+    add_link_options(-s)
   endif ()
 
   # set OS specific headers
@@ -420,6 +420,7 @@ target_link_libraries(iresearch-static
   ${URING_LIBRARIES}
   PUBLIC absl::flat_hash_map
   PUBLIC absl::flat_hash_set
+  absl::crc32c
   ${GCOV_LIBRARY}
   ${BFD_STATIC_LIBS}
   ${Lz4_STATIC_LIB}

--- a/core/formats/formats_burst_trie.cpp
+++ b/core/formats/formats_burst_trie.cpp
@@ -63,8 +63,6 @@
 // NOOP
 #endif
 
-#include "boost/crc.hpp"
-
 #if defined(_MSC_VER)
 #pragma warning(default : 4244)
 #pragma warning(default : 4245)

--- a/core/utils/crc.hpp
+++ b/core/utils/crc.hpp
@@ -20,90 +20,38 @@
 /// @author Andrey Abramov
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef IRESEARCH_CRC_H
-#define IRESEARCH_CRC_H
+#pragma once
+
+#include <absl/crc/crc32c.h>
 
 #include <shared.hpp>
-
-#ifdef IRESEARCH_SSE4_2
-
-#include <nmmintrin.h>
 
 namespace iresearch {
 
 class crc32c {
+  // TODO(MBkkt) kCrc32Xor == 0 is incorrect, we ignore all first zero bytes,
+  //  We can fix it with new directory format and kCrc32Xor = 0xffffffff
+  static constexpr uint32_t kCrc32Xor = 0;
+
  public:
-  explicit crc32c(uint32_t seed = 0) noexcept : value_(seed) {}
+  explicit crc32c(uint32_t seed = 0) noexcept
+    : value_{absl::ToCrc32c(seed ^ kCrc32Xor)} {}
 
-  FORCE_INLINE void process_bytes(const void* buffer, size_t size) noexcept {
-    const auto* begin = reinterpret_cast<const uint8_t*>(buffer);
-    process_block(begin, begin + size);
+  FORCE_INLINE void process_bytes(const void* data, size_t size) noexcept {
+    value_ = absl::ExtendCrc32c(
+      value_, std::string_view{static_cast<const char*>(data), size}, 0);
   }
 
-  FORCE_INLINE void process_block(const void* buffer_begin,
-                                  const void* buffer_end) noexcept {
-    const auto* begin = process_block_32(buffer_begin, buffer_end);
-    const auto* end = reinterpret_cast<const uint8_t*>(buffer_end);
-
-    for (; begin < end; ++begin) {
-      value_ = _mm_crc32_u8(value_, *begin);
-    }
+  FORCE_INLINE void process_block(const void* begin, const void* end) noexcept {
+    process_bytes(begin, std::distance(static_cast<const char*>(begin),
+                                       static_cast<const char*>(end)));
   }
 
-  FORCE_INLINE void process_byte(unsigned char b) {
-    process_bytes(&b, sizeof(b));
+  FORCE_INLINE uint32_t checksum() const noexcept {
+    return static_cast<uint32_t>(value_) ^ kCrc32Xor;
   }
 
-  FORCE_INLINE uint32_t checksum() const noexcept { return value_; }
-
- private:
-  FORCE_INLINE const uint8_t* process_block_32(
-    const void* buffer_begin, const void* buffer_end) noexcept {
-    constexpr size_t BS = 8 * sizeof(uint32_t);
-
-    const auto k = std::distance(reinterpret_cast<const uint8_t*>(buffer_begin),
-                                 reinterpret_cast<const uint8_t*>(buffer_end)) /
-                   BS;
-
-    const auto* begin = reinterpret_cast<const uint32_t*>(buffer_begin);
-    const auto* end = reinterpret_cast<const uint32_t*>(
-      reinterpret_cast<const uint8_t*>(buffer_begin) + k * BS);
-
-    for (; begin < end; ++begin) {
-      value_ = _mm_crc32_u32(value_, *begin);
-    }
-
-    return reinterpret_cast<const uint8_t*>(begin);
-  }
-
-  uint32_t value_;
-};  // crc32c
+  absl::crc32c_t value_;
+};
 
 }  // namespace iresearch
-
-#else
-
-#if defined(_MSC_VER)
-#pragma warning(disable : 4244)
-#pragma warning(disable : 4245)
-#elif defined(__GNUC__)
-// NOOP
-#endif
-
-#include <boost/crc.hpp>
-
-#if defined(_MSC_VER)
-#pragma warning(default : 4244)
-#pragma warning(default : 4245)
-#elif defined(__GNUC__)
-// NOOP
-#endif
-
-namespace iresearch {
-
-typedef boost::crc_optimal<32, 0x1EDC6F41, 0, 0, true, true> crc32c;
-
-}
-
-#endif  // IRESEARCH_SSE
-#endif  // IRESEARCH_CRC_H

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -173,7 +173,6 @@ if (NOT TARGET absl::base)
   if ("${ABSL_ROOT}" STREQUAL "")
     message(FATAL_ERROR "ABSL_ROOT not set")
   else ()
-    set(CMAKE_CXX_STANDARD 17)
     set(CMAKE_CXX_STANDARD_REQUIRED ON CACHE BOOL "" FORCE)
     set(ABSL_BUILD_TESTING OFF CACHE BOOL "" FORCE)
     set(ABSL_PROPAGATE_CXX_STD ON CACHE BOOL "" FORCE)
@@ -182,7 +181,6 @@ if (NOT TARGET absl::base)
     add_subdirectory(${ABSL_ROOT_EXP}
       ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/iresearch-abseil-cpp.dir
       EXCLUDE_FROM_ALL)
-    set(CMAKE_CXX_STANDARD 20)
   endif ()
 endif ()
 

--- a/microbench/CMakeLists.txt
+++ b/microbench/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(iresearch-microbench
   ./segmentation_stream_benchmark.cpp
   ./simd_utils_benchmark.cpp
   ./lower_bound_benchmark.cpp
+  ./crc_benchmark.cpp
   ./microbench_main.cpp
   )
 
@@ -48,6 +49,7 @@ target_link_libraries(iresearch-microbench
   iresearch-static
   ${PTHREAD_LIBRARY}
   benchmark::benchmark
+  absl::crc32c
   )
 
 include_directories(iresearch-microbench

--- a/microbench/crc_benchmark.cpp
+++ b/microbench/crc_benchmark.cpp
@@ -1,0 +1,71 @@
+#include <absl/crc/crc32c.h>
+#include <benchmark/benchmark.h>
+
+#include <string>
+
+#include "utils/crc.hpp"
+
+namespace {
+
+std::string TestString(size_t len) {
+  std::string result;
+  result.reserve(len);
+  for (size_t i = 0; i < len; ++i) {
+    result.push_back(static_cast<char>(i % 256));
+  }
+  return result;
+}
+
+void BM_Calculate(benchmark::State& state) {
+  int len = state.range(0);
+  std::string data = TestString(len);
+  for (auto s : state) {
+    benchmark::DoNotOptimize(data);
+    absl::crc32c_t crc = absl::ComputeCrc32c(data);
+    benchmark::DoNotOptimize(crc);
+  }
+}
+
+BENCHMARK(BM_Calculate)->Arg(0)->Arg(1)->Arg(100)->Arg(10000)->Arg(500000);
+
+void BM_Calculate2(benchmark::State& state) {
+  int len = state.range(0);
+  std::string data = TestString(len);
+  for (auto s : state) {
+    benchmark::DoNotOptimize(data);
+    iresearch::crc32c crc;
+    crc.process_bytes(data.data(), data.size());
+    benchmark::DoNotOptimize(crc.checksum());
+  }
+}
+
+BENCHMARK(BM_Calculate2)->Arg(0)->Arg(1)->Arg(100)->Arg(10000)->Arg(500000);
+
+void BM_Extend(benchmark::State& state) {
+  int len = state.range(0);
+  std::string extension = TestString(len);
+  absl::crc32c_t base = absl::ToCrc32c(0xC99465AA);  // CRC32C of "Hello World"
+  for (auto s : state) {
+    benchmark::DoNotOptimize(base);
+    benchmark::DoNotOptimize(extension);
+    absl::crc32c_t crc = absl::ExtendCrc32c(base, extension);
+    benchmark::DoNotOptimize(crc);
+  }
+}
+
+void BM_Extend2(benchmark::State& state) {
+  int len = state.range(0);
+  std::string extension = TestString(len);
+  iresearch::crc32c base{0xC99465AA};  // CRC32C of "Hello World"
+  for (auto s : state) {
+    benchmark::DoNotOptimize(base);
+    benchmark::DoNotOptimize(extension);
+    base.process_bytes(extension.data(), extension.size());
+    benchmark::DoNotOptimize(base.checksum());
+  }
+}
+
+BENCHMARK(BM_Extend)->Arg(0)->Arg(1)->Arg(100)->Arg(10000)->Arg(500000);
+BENCHMARK(BM_Extend2)->Arg(0)->Arg(1)->Arg(100)->Arg(10000)->Arg(500000);
+
+}  // namespace

--- a/microbench/segmentation_stream_benchmark.cpp
+++ b/microbench/segmentation_stream_benchmark.cpp
@@ -36,7 +36,7 @@ void BM_segmentation_analyzer(benchmark::State& state) {
 
   segmentation_token_stream stream(std::move(opts));
 
-  const irs::string_ref str = "QUICK BROWN FOX JUMPS OVER THE LAZY DOG";
+  const std::string_view str = "QUICK BROWN FOX JUMPS OVER THE LAZY DOG";
   for (auto _ : state) {
     stream.reset(str);
     while (const bool has_next = stream.next()) {

--- a/tests/store/directory_test_case.cpp
+++ b/tests/store/directory_test_case.cpp
@@ -4064,7 +4064,7 @@ TEST_P(directory_test_case, smoke_store) {
     EXPECT_EQ(it->size() + sizeof buf, file->file_pointer());
     crc.process_bytes(buf, sizeof buf);
     file->write_byte(++b);
-    crc.process_byte(b);
+    crc.process_bytes(&b, sizeof b);
     EXPECT_EQ(it->size() + sizeof buf + 1, file->file_pointer());
 
     EXPECT_EQ(crc.checksum(), file->checksum());
@@ -4286,7 +4286,8 @@ TEST_P(directory_test_case, smoke_store) {
 
       crc.process_bytes(buf.c_str(), buf.size());
       crc.process_bytes(readbuf, sizeof readbuf);
-      crc.process_byte(b + 1);
+      const irs::byte_type t = b + 1;
+      crc.process_bytes(&t, sizeof t);
       ++b;
 
       EXPECT_TRUE(file->eof());

--- a/tests/utils/crc_test.cpp
+++ b/tests/utils/crc_test.cpp
@@ -21,13 +21,11 @@
 /// @author Vasiliy Nabatchikov
 ////////////////////////////////////////////////////////////////////////////////
 
-#include "tests_shared.hpp"
-
-#ifdef IRESEARCH_SSE4_2
-
 #include "utils/crc.hpp"
 
 #include <fstream>
+
+#include "tests_shared.hpp"
 
 #if defined(_MSC_VER)
 #pragma warning(disable : 4244)
@@ -44,14 +42,6 @@
 #elif defined(__GNUC__)
 // NOOP
 #endif
-
-TEST(crc_test, check_invalid_range) {
-  irs::crc32c crc;
-
-  char buf[1257]{1, 2, 3};
-  crc.process_block(std::end(buf), std::begin(buf));
-  ASSERT_EQ(0, crc.checksum());
-}
 
 TEST(crc_test, check) {
   typedef boost::crc_optimal<32, 0x1EDC6F41, 0, 0, true, true> crc32c_expected;
@@ -74,5 +64,3 @@ TEST(crc_test, check) {
 
   ASSERT_EQ(crc.checksum(), crc_expected.checksum());
 }
-
-#endif


### PR DESCRIPTION
Also fix benchmark compilation and test target

For old implementation crc32c implementation

```
➜  ~ ./projects/iresearch/build_release/bin/iresearch-microbench
2022-11-25T23:25:46+01:00
Running ./projects/iresearch/build_release/bin/iresearch-microbench
Run on (16 X 2400 MHz CPU s)
CPU Caches:
  L1 Data 48 KiB (x8)
  L1 Instruction 32 KiB (x8)
  L2 Unified 1280 KiB (x8)
  L3 Unified 24576 KiB (x1)
Load Average: 1.10, 0.57, 0.23
---------------------------------------------------------------
Benchmark                     Time             CPU   Iterations
---------------------------------------------------------------
BM_Calculate/0             3.36 ns         3.36 ns    211546396
BM_Calculate/1             3.40 ns         3.40 ns    203854215
BM_Calculate/100           12.8 ns         12.8 ns     55323370
BM_Calculate/10000          518 ns          518 ns      1351530
BM_Calculate/500000       25107 ns        25095 ns        27894
BM_Calculate2/0           0.660 ns        0.660 ns   1000000000
BM_Calculate2/1            1.60 ns         1.60 ns    436403596
BM_Calculate2/100          14.2 ns         14.2 ns     46299797
BM_Calculate2/10000        2945 ns         2944 ns       237900
BM_Calculate2/500000     150382 ns       150318 ns         4657
BM_Extend/0                1.60 ns         1.60 ns    436410749
BM_Extend/1                1.60 ns         1.60 ns    436396822
BM_Extend/100              12.5 ns         12.5 ns     56166584
BM_Extend/10000             525 ns          525 ns      1334047
BM_Extend/500000          25103 ns        25095 ns        27893
BM_Extend2/0              0.691 ns        0.691 ns   1000000000
BM_Extend2/1               1.91 ns         1.91 ns    384488894
BM_Extend2/100             33.7 ns         33.7 ns     20758010
BM_Extend2/10000           3025 ns         3024 ns       231491
BM_Extend2/500000        150430 ns       150379 ns         4655
```