### PR TITLE
prepare iresearch code for a future velocypack upgrade

### DIFF
--- a/core/analysis/token_stopwords_stream.cpp
+++ b/core/analysis/token_stopwords_stream.cpp
@@ -101,7 +101,8 @@ irs::analysis::analyzer::ptr construct(const VPackArrayIterator& mask,
   size_t offset = 0;
   irs::analysis::token_stopwords_stream::stopwords_set tokens;
 
-  for (auto itr = mask.begin(), end = mask.end(); itr != end; ++itr, ++offset) {
+  auto end = mask.end();
+  for (auto itr = mask.begin(); itr != end; ++itr, ++offset) {
     if (!(*itr).isString()) {
       IR_FRMT_WARN(
         "Non-string value in 'mask' at offset '" IR_SIZE_T_SPECIFIER


### PR DESCRIPTION
after the velocypack upgrade, the types of VPackXXXIterator::begin() and VPackXXXIterator::end() may differ. as end() may use `std::default_sentinel_t`.
The change in this PR should be compatible with the "old" and new versions of velocypack.

Commit that made the change in velocypack:
https://github.com/arangodb/velocypack/pull/141/files#diff-c1541b17db38faa9c3d35b5518644ce5f3ccdeeffc0a2de7ba65deb33e99bab6R90

