### PR TITLE
Feature/splitted commit

### DIFF
--- a/core/index/index_writer.cpp
+++ b/core/index/index_writer.cpp
@@ -2439,12 +2439,10 @@ IndexWriter::PendingContext IndexWriter::FlushAll(
         continue;  // skip empty segments
       }
 
-      const auto doc_id_begin = segment->uncomitted_doc_id_begin_;
       size_t flushed_docs_count = 0;
 
       // was updated after flush
-      auto flushed_doc_id_end = doc_id_begin;
-      IRS_ASSERT(doc_id_begin <= flushed_doc_id_end);
+      auto flushed_doc_id_end = segment->uncomitted_doc_id_begin_;
       IRS_ASSERT(flushed_doc_id_end - doc_limits::min() <=
                  segment->flushed_update_contexts_.size());
 
@@ -2463,15 +2461,12 @@ IndexWriter::PendingContext IndexWriter::FlushAll(
 
         if (!flushed.meta.live_docs_count /* empty SegmentMeta */
             // SegmentMeta fully before the start of this flush_context
-            || flushed_doc_id_end - doc_limits::min() <= flushed_docs_start
-            // SegmentMeta fully after the start of this flush_context
-            || doc_id_begin - doc_limits::min() >= flushed_docs_count) {
+            || flushed_doc_id_end - doc_limits::min() <= flushed_docs_start) {
           continue;
         }
 
         // 0-based
-        auto update_contexts_begin =
-          std::max(doc_id_begin - doc_limits::min(), flushed_docs_start);
+        auto update_contexts_begin = flushed_docs_start;
         // 0-based
         auto update_contexts_end =
           std::min(flushed_doc_id_end - doc_limits::min(), flushed_docs_count);

--- a/core/index/index_writer.cpp
+++ b/core/index/index_writer.cpp
@@ -792,13 +792,13 @@ void IndexWriter::Transaction::Reset() noexcept {
     return ctx->uncommitted_docs_ < flushed.GetDocsEnd();
   });
   if (it != end) {
-    const auto docs_begin = it->GetDocsBegin();
-    const auto docs_end = it->GetDocsEnd();
-    if (it->SetValidEnd(ctx->uncommitted_docs_)) {
+    if (it->SetCommitted(ctx->uncommitted_docs_)) {
+      const auto docs_end = it->GetDocsEnd();
       ctx->flushed_.erase(it + 1, end);
       ctx->flushed_update_contexts_.resize(docs_end);
       ctx->uncommitted_docs_ = docs_end;
     } else {
+      const auto docs_begin = it->GetDocsBegin();
       ctx->flushed_.erase(it, end);
       ctx->flushed_update_contexts_.resize(docs_begin);
       ctx->uncommitted_docs_ = docs_begin;

--- a/core/index/index_writer.cpp
+++ b/core/index/index_writer.cpp
@@ -143,7 +143,7 @@ void RemoveFromExistingSegment(
 bool RemoveFromImportedSegment(
   std::span<IndexWriter::ModificationContext> modifications,
   const SubReader& reader, document_mask& docs_mask,
-  size_t min_modification_generation) {
+  uint64_t min_modification_generation) {
   IRS_ASSERT(!modifications.empty());
   bool modified = false;
 
@@ -1064,7 +1064,7 @@ IndexWriter::SegmentContext::SegmentContext(
 
 void IndexWriter::SegmentContext::UpdateGeneration(uint64_t base) noexcept {
   IRS_ASSERT(writer_);
-  IRS_ASSERT(writer_->docs_cached() <= doc_limits::eof());
+  IRS_ASSERT(writer_->docs_cached() < doc_limits::eof());
 
   // Update generations of modification queries
   std::for_each(
@@ -1073,9 +1073,8 @@ void IndexWriter::SegmentContext::UpdateGeneration(uint64_t base) noexcept {
       // Must be < than 'count' since inserts come after modification
       IRS_ASSERT(v.generation < modification_queries_.size() -
                                   uncommitted_modification_queries_);
-
       // Update to flush_context generation
-      const_cast<size_t&>(v.generation) += base;
+      v.generation += base;
     });
 
   // Update generations for insertions

--- a/core/index/index_writer.cpp
+++ b/core/index/index_writer.cpp
@@ -1230,18 +1230,12 @@ uint64_t IndexWriter::SegmentContext::Flush() {
 
   IRS_ASSERT(writer_->docs_cached() <= doc_limits::eof());
 
-  const std::span ctxs{writer_->docs_context()};
-  // 1-based
-  const auto docs_begin =
-    static_cast<doc_id_t>(flushed_update_contexts_.size()) + 1;
-
-  auto& segment =
-    flushed_.emplace_back(std::move(writer_meta_), docs_begin,
-                          docs_begin + static_cast<doc_id_t>(ctxs.size()));
+  auto& segment = flushed_.emplace_back(std::move(writer_meta_));
 
   try {
     writer_->flush(segment, segment.docs_mask);
 
+    const std::span ctxs{writer_->docs_context()};
     flushed_update_contexts_.insert(flushed_update_contexts_.end(),
                                     ctxs.begin(), ctxs.end());
   } catch (...) {
@@ -2435,7 +2429,6 @@ IndexWriter::PendingContext IndexWriter::FlushAll(
     }
 
     std::vector<FlushSegmentContext> segment_ctxs;
-    segment_ctxs.reserve(total_pending_segment_context_segments);
     size_t current_pending_segment_context_segments = 0;
 
     // proces all segments that have been seen by the current flush_context
@@ -2465,15 +2458,28 @@ IndexWriter::PendingContext IndexWriter::FlushAll(
 
         // sum of all previous SegmentMeta::docs_count including this meta
         flushed_docs_count += flushed.meta.docs_count;
-        const auto docs_begin = flushed.docs_begin;
-        const auto docs_end = flushed.docs_end;
-        IRS_ASSERT((docs_end - docs_begin) == flushed.meta.docs_count);
 
         if (!flushed.meta.live_docs_count /* empty SegmentMeta */
             // SegmentMeta fully before the start of this flush_context
-            || flushed_doc_id_end - doc_limits::min() <= flushed_docs_start ||
-            docs_begin == docs_end) {
+            || flushed_doc_id_end - doc_limits::min() <= flushed_docs_start) {
           continue;
+        }
+
+        auto update_contexts_begin = flushed_docs_start;
+        // 0-based
+        auto update_contexts_end =
+          std::min(flushed_doc_id_end - doc_limits::min(), flushed_docs_count);
+        IRS_ASSERT(update_contexts_begin <= update_contexts_end);
+        // beginning doc_id in this SegmentMeta
+        const auto valid_doc_id_begin =
+          update_contexts_begin - flushed_docs_start + doc_limits::min();
+        const auto valid_doc_id_end =
+          std::min(update_contexts_end - flushed_docs_start + doc_limits::min(),
+                   static_cast<size_t>(flushed.docs_mask_tail_doc_id));
+        IRS_ASSERT(valid_doc_id_begin <= valid_doc_id_end);
+
+        if (valid_doc_id_begin == valid_doc_id_end) {
+          continue;  // empty segment since head+tail == 'docs_count'
         }
 
         auto reader =
@@ -2488,12 +2494,12 @@ IndexWriter::PendingContext IndexWriter::FlushAll(
         }
 
         const std::span flush_update_contexts{
-          segment->flushed_update_contexts_.begin() + docs_begin,
+          segment->flushed_update_contexts_.data() + flushed_docs_start,
           flushed.meta.docs_count};
 
         auto& flush_segment_ctx = segment_ctxs.emplace_back(
           std::move(reader), std::move(flushed), std::move(flushed.docs_mask),
-          flushed.docs_begin, flushed.docs_end, flush_update_contexts,
+          valid_doc_id_begin, valid_doc_id_end, flush_update_contexts,
           segment->modification_queries_);
 
         // read document_mask as was originally flushed
@@ -2501,14 +2507,15 @@ IndexWriter::PendingContext IndexWriter::FlushAll(
         auto& docs_mask = flush_segment_ctx.docs_mask_;
 
         // add doc_ids before start of this flush_context to document_mask
-        for (size_t doc_id = doc_limits::min(); doc_id < docs_begin; ++doc_id) {
+        for (size_t doc_id = doc_limits::min(); doc_id < valid_doc_id_begin;
+             ++doc_id) {
           IRS_ASSERT(std::numeric_limits<doc_id_t>::max() >= doc_id);
           docs_mask.emplace(static_cast<doc_id_t>(doc_id));
         }
 
         // add tail doc_ids not part of this flush_context to documents_mask
         // (including truncated)
-        for (size_t doc_id = docs_end,
+        for (size_t doc_id = valid_doc_id_end,
                     doc_id_end = flushed.meta.docs_count + doc_limits::min();
              doc_id < doc_id_end; ++doc_id) {
           IRS_ASSERT(std::numeric_limits<doc_id_t>::max() >= doc_id);

--- a/core/index/index_writer.hpp
+++ b/core/index/index_writer.hpp
@@ -640,10 +640,11 @@ class IndexWriter : private util::noncopyable {
     size_t GetDocsBegin() const noexcept { return docs_begin; }
     size_t GetDocsEnd() const noexcept { return docs_begin + meta.docs_count; }
 
-    bool SetValidEnd(size_t valid_docs_end) noexcept {
+    bool SetCommitted(size_t committed) noexcept {
+      IRS_ASSERT(committed < GetDocsEnd());
       docs_mask_valid_end =
-        static_cast<doc_id_t>(valid_docs_end - docs_begin + doc_limits::min());
-      return docs_begin != valid_docs_end;
+        static_cast<doc_id_t>(committed - docs_begin + doc_limits::min());
+      return docs_begin != committed;
     }
     doc_id_t GetValidEnd() const noexcept {
       return std::min(
@@ -658,6 +659,8 @@ class IndexWriter : private util::noncopyable {
 
     // Flushed segment removals
     document_mask docs_mask;
+
+   private:
     // starting doc_id that should be added to docs_mask
     doc_id_t docs_mask_valid_end{doc_limits::eof()};
     size_t docs_begin;

--- a/core/index/index_writer.hpp
+++ b/core/index/index_writer.hpp
@@ -630,15 +630,9 @@ class IndexWriter : private util::noncopyable {
 
   struct FlushedSegment : public IndexSegment {
     FlushedSegment() = default;
-    explicit FlushedSegment(SegmentMeta&& meta, doc_id_t docs_begin,
-                            doc_id_t docs_end) noexcept
-      : IndexSegment{.meta = std::move(meta)},
-        docs_begin{docs_begin},
-        docs_end{docs_end} {}
+    explicit FlushedSegment(SegmentMeta&& meta) noexcept
+      : IndexSegment{.meta = std::move(meta)} {}
 
-    // Range of the flushed docs in SegmentContext::flushed_update_contexts_
-    doc_id_t docs_begin{};
-    doc_id_t docs_end{};
     // Flushed segment removals
     document_mask docs_mask;
     // starting doc_id that should be added to docs_mask

--- a/core/index/index_writer.hpp
+++ b/core/index/index_writer.hpp
@@ -244,7 +244,7 @@ class IndexWriter : private util::noncopyable {
    public:
     Document(FlushContext& ctx, std::shared_ptr<SegmentContext> segment,
              const segment_writer::update_context& update);
-    Document(Document&&) noexcept = default;
+    Document(Document&&) = default;
     ~Document() noexcept;
 
     Document& operator=(Document&&) = delete;
@@ -700,6 +700,14 @@ class IndexWriter : private util::noncopyable {
     segment_meta_generator_t meta_generator_;
     // sequential list of pending modification
     std::vector<ModificationContext> modification_queries_;
+
+    // '|...Fxx|....F....|F.....|F'
+    // F -- SegmentContext::Flush()
+    // | -- Transaction::Commit()
+    // xx -- docs remain cached on Transaction::Commit
+    // Part of uncommitted_docs_ which we need to remove from it,
+    // if new segment is empty
+    size_t last_trx_buffered_docs_{0};
 
     // Transaction::Commit was not called for these:
     size_t uncommitted_docs_;

--- a/core/index/index_writer.hpp
+++ b/core/index/index_writer.hpp
@@ -706,6 +706,8 @@ class IndexWriter : private util::noncopyable {
                    const FeatureInfoProvider& feature_info,
                    const Comparer* comparator);
 
+    void UpdateGeneration(uint64_t base) noexcept;
+
     // Flush current writer state into a materialized segment.
     // Return tick of last committed transaction.
     uint64_t Flush();

--- a/core/index/index_writer.hpp
+++ b/core/index/index_writer.hpp
@@ -346,7 +346,7 @@ class IndexWriter : private util::noncopyable {
       auto ctx = UpdateSegment(false);  // updates 'segment_' and 'ctx_'
       IRS_ASSERT(segment_.ctx());
 
-      // guarded by flush_context::flush_mutex_
+      // guarded by FlushContext::context_mutex_
       segment_.ctx()->Remove(std::forward<Filter>(filter));
     }
 
@@ -385,7 +385,7 @@ class IndexWriter : private util::noncopyable {
     void ForceFlush();
 
    private:
-    // refresh segment if required (guarded by flush_context::flush_mutex_)
+    // refresh segment if required (guarded by FlushContext::context_mutex_)
     // is is thread-safe to use ctx_/segment_ while holding 'flush_context_ptr'
     // since active 'flush_context' will not change and hence no reload required
     FlushContextPtr UpdateSegment(bool disable_flush);
@@ -659,7 +659,7 @@ class IndexWriter : private util::noncopyable {
     format::ptr codec_;
     // true if flush_all() started processing this segment (this
     // segment should not be used for any new operations), guarded by
-    // the flush_context::flush_mutex_
+    // the FlushContext::context_mutex_
     std::atomic_bool dirty_;
     // ref tracking for segment_writer to allow for easy ref removal on
     // segment_writer reset
@@ -667,7 +667,7 @@ class IndexWriter : private util::noncopyable {
     // guard 'flushed_', 'uncomitted_*' and 'writer_' from concurrent flush
     std::mutex flush_mutex_;
     // all of the previously flushed versions of this segment, guarded by the
-    // flush_context::flush_mutex_
+    // SegmentContext::flush_mutex_
     std::vector<FlushedSegment> flushed_;
     // update_contexts to use with 'flushed_'
     // sequentially increasing through all offsets
@@ -788,7 +788,7 @@ class IndexWriter : private util::noncopyable {
     RefTrackingDirectory::ptr dir_;
     // guard for the current context during flush (write)
     // operations vs update (read)
-    std::shared_mutex flush_mutex_;
+    std::shared_mutex context_mutex_;
     // guard for the current context during struct update operations,
     // e.g. pending_segments_, pending_segment_contexts_
     std::mutex mutex_;

--- a/core/index/index_writer.hpp
+++ b/core/index/index_writer.hpp
@@ -630,9 +630,15 @@ class IndexWriter : private util::noncopyable {
 
   struct FlushedSegment : public IndexSegment {
     FlushedSegment() = default;
-    explicit FlushedSegment(SegmentMeta&& meta) noexcept
-      : IndexSegment{.meta = std::move(meta)} {}
+    explicit FlushedSegment(SegmentMeta&& meta, doc_id_t docs_begin,
+                            doc_id_t docs_end) noexcept
+      : IndexSegment{.meta = std::move(meta)},
+        docs_begin{docs_begin},
+        docs_end{docs_end} {}
 
+    // Range of the flushed docs in SegmentContext::flushed_update_contexts_
+    doc_id_t docs_begin{};
+    doc_id_t docs_end{};
     // Flushed segment removals
     document_mask docs_mask;
     // starting doc_id that should be added to docs_mask

--- a/core/index/index_writer.hpp
+++ b/core/index/index_writer.hpp
@@ -421,7 +421,7 @@ class IndexWriter : private util::noncopyable {
 
     // keep a handle to the filter for the case when this object has ownership
     std::shared_ptr<const irs::filter> filter;
-    size_t generation;
+    uint64_t generation;
     // this is an update modification (as opposed to remove)
     bool update;
     bool seen{false};
@@ -566,7 +566,7 @@ class IndexWriter : private util::noncopyable {
 
   struct ImportContext {
     ImportContext(
-      IndexSegment&& segment, size_t generation, FileRefs&& refs,
+      IndexSegment&& segment, uint64_t generation, FileRefs&& refs,
       Consolidation&& consolidation_candidates,
       std::shared_ptr<const SegmentReaderImpl>&& reader,
       std::shared_ptr<const DirectoryReaderImpl>&& consolidation_reader,
@@ -580,7 +580,7 @@ class IndexWriter : private util::noncopyable {
           .candidates = std::move(consolidation_candidates),
           .merger = std::move(merger)} {}
 
-    ImportContext(IndexSegment&& segment, size_t generation, FileRefs&& refs,
+    ImportContext(IndexSegment&& segment, uint64_t generation, FileRefs&& refs,
                   Consolidation&& consolidation_candidates,
                   std::shared_ptr<const SegmentReaderImpl>&& reader,
                   std::shared_ptr<const DirectoryReaderImpl>&&
@@ -593,7 +593,7 @@ class IndexWriter : private util::noncopyable {
           .consolidation_reader = std::move(consolidation_reader),
           .candidates = std::move(consolidation_candidates)} {}
 
-    ImportContext(IndexSegment&& segment, size_t generation, FileRefs&& refs,
+    ImportContext(IndexSegment&& segment, uint64_t generation, FileRefs&& refs,
                   Consolidation&& consolidation_candidates,
                   std::shared_ptr<const SegmentReaderImpl>&& reader) noexcept
       : generation{generation},
@@ -602,14 +602,14 @@ class IndexWriter : private util::noncopyable {
         reader{std::move(reader)},
         consolidation_ctx{.candidates = std::move(consolidation_candidates)} {}
 
-    ImportContext(IndexSegment&& segment, size_t generation, FileRefs&& refs,
+    ImportContext(IndexSegment&& segment, uint64_t generation, FileRefs&& refs,
                   std::shared_ptr<const SegmentReaderImpl>&& reader) noexcept
       : generation{generation},
         segment{std::move(segment)},
         refs{std::move(refs)},
         reader{std::move(reader)} {}
 
-    ImportContext(IndexSegment&& segment, size_t generation,
+    ImportContext(IndexSegment&& segment, uint64_t generation,
                   std::shared_ptr<const SegmentReaderImpl>&& reader) noexcept
       : generation{generation},
         segment{std::move(segment)},
@@ -620,7 +620,7 @@ class IndexWriter : private util::noncopyable {
     ImportContext& operator=(const ImportContext&) = delete;
     ImportContext& operator=(ImportContext&&) = delete;
 
-    const size_t generation;
+    const uint64_t generation;
     IndexSegment segment;
     FileRefs refs;
     std::shared_ptr<const SegmentReaderImpl> reader;
@@ -703,7 +703,7 @@ class IndexWriter : private util::noncopyable {
 
     // Transaction::Commit was not called for these:
     size_t uncommitted_docs_;
-    size_t uncommitted_generation_;
+    uint64_t uncommitted_generation_;
     size_t uncommitted_modification_queries_;
 
     std::unique_ptr<segment_writer> writer_;
@@ -796,7 +796,7 @@ class IndexWriter : private util::noncopyable {
     using SegmentMask = absl::flat_hash_set<const SubReader*>;
 
     // current modification/update generation
-    std::atomic_size_t generation_{0};
+    std::atomic_uint64_t generation_{0};
     // ref tracking directory used by this context (tracks all/only
     // refs for this context)
     RefTrackingDirectory::ptr dir_;

--- a/core/index/segment_writer.cpp
+++ b/core/index/segment_writer.cpp
@@ -269,7 +269,8 @@ document_mask segment_writer::get_doc_mask(const doc_map& docmap) {
   return docs_mask;
 }
 
-void segment_writer::flush(IndexSegment& segment, document_mask& docs_mask) {
+std::span<segment_writer::update_context> segment_writer::flush(
+  IndexSegment& segment, document_mask& docs_mask) {
   REGISTER_TIMER_DETAILED();
   IRS_ASSERT(docs_mask.empty());
 
@@ -326,6 +327,8 @@ void segment_writer::flush(IndexSegment& segment, document_mask& docs_mask) {
   // We intentionally don't write document mask here as it might
   // be changed by removals accumulated in IndexWriter.
   index_utils::FlushIndexSegment(dir_, segment);
+
+  return docs_context_;
 }
 
 void segment_writer::reset() noexcept {

--- a/core/index/segment_writer.cpp
+++ b/core/index/segment_writer.cpp
@@ -183,8 +183,7 @@ segment_writer::segment_writer(ConstructToken, directory& dir,
   : sort_(column_info, {}),
     fields_(feature_info, cached_columns_, comparator),
     column_info_(&column_info),
-    dir_(dir),
-    initialized_(false) {}
+    dir_(dir) {}
 
 bool segment_writer::index(const hashed_string_view& name, const doc_id_t doc,
                            IndexFeatures index_features,

--- a/core/index/segment_writer.hpp
+++ b/core/index/segment_writer.hpp
@@ -83,8 +83,6 @@ class segment_writer : util::noncopyable {
   // Return doc_id_t as per doc_limits
   doc_id_t begin(const update_context& ctx, size_t reserve_rollback_extra = 0);
 
-  std::span<update_context> docs_context() noexcept { return docs_context_; }
-
   template<Action action, typename Field>
   bool insert(Field&& field) {
     if (IRS_LIKELY(valid_)) {
@@ -146,7 +144,10 @@ class segment_writer : util::noncopyable {
     valid_ = false;
   }
 
-  void flush(IndexSegment& segment, document_mask& docs_mask);
+  std::span<update_context> docs_context() noexcept { return docs_context_; }
+
+  std::span<update_context> flush(IndexSegment& segment,
+                                  document_mask& docs_mask);
 
   const std::string& name() const noexcept { return seg_name_; }
   size_t docs_cached() const noexcept { return docs_context_.size(); }

--- a/core/index/segment_writer.hpp
+++ b/core/index/segment_writer.hpp
@@ -71,7 +71,7 @@ class segment_writer : util::noncopyable {
 
  public:
   struct update_context {
-    size_t generation;
+    uint64_t generation;
     size_t update_id;
   };
 

--- a/core/index/segment_writer.hpp
+++ b/core/index/segment_writer.hpp
@@ -380,7 +380,7 @@ class segment_writer : util::noncopyable {
   columnstore_writer::ptr col_writer_;
   TrackingDirectory dir_;
   uint64_t tick_{0};
-  bool initialized_;
+  bool initialized_{false};
   bool valid_{true};  // current state
 };
 

--- a/core/utils/wildcard_utils.cpp
+++ b/core/utils/wildcard_utils.cpp
@@ -57,7 +57,7 @@ WildcardType wildcard_type(bytes_view expr) noexcept {
   const auto* char_begin = expr.data();
   const auto* end = expr.data() + expr.size();
 
-  for (size_t i = 0; char_begin < end; ++i) {
+  while (char_begin < end) {
     const size_t char_length = utf8_utils::cp_length_msb(*char_begin);
     const auto char_end = char_begin + char_length;
 

--- a/tests/index/index_profile_tests.cpp
+++ b/tests/index/index_profile_tests.cpp
@@ -373,10 +373,9 @@ class index_profile_test_case : public tests::index_test_base {
     std::cout << "Path to timing log: " << path.string() << std::endl;
 
     auto reader = irs::DirectoryReader(dir(), codec());
-    ASSERT_EQ(
-      true,
-      1 <= reader.size());  // not all commits might produce a new segment,
-                            // some might merge with concurrent commits
+    // not all commits might produce a new segment,
+    ASSERT_LE(1, reader.size());
+    // some might merge with concurrent commits
     ASSERT_TRUE(writer_commit_count * thread_count + writer_import_count >=
                 reader.size());  // worst case each thread is concurrently
                                  // populating its own segment for every commit

--- a/tests/index/segment_writer_tests.cpp
+++ b/tests/index/segment_writer_tests.cpp
@@ -599,9 +599,8 @@ TEST_F(segment_writer_tests, reorder) {
     irs::IndexSegment index_segment;
     irs::document_mask docs_mask;
     index_segment.meta.codec = default_codec();
-    writer->flush(index_segment, docs_mask);
+    auto docs_context = writer->flush(index_segment, docs_mask);
     ASSERT_TRUE(docs_mask.empty());
-    auto docs_context = writer->docs_context();
     ASSERT_EQ(docs_context.size(), kLen);
     for (size_t i = 0; i < kLen; ++i) {
       EXPECT_EQ(expected[i], docs_context[i].generation);

--- a/tests/tests_param.hpp
+++ b/tests/tests_param.hpp
@@ -146,10 +146,14 @@ enum Types : uint64_t {
   kTypesRot13_7 = 1 << 3,
 };
 
+// #define IRESEARCH_ONLY_MEMORY
+
 template<uint64_t Type>
 constexpr auto getDirectories() {
   constexpr auto kCount = std::popcount(Type);
-#ifdef IRESEARCH_URING
+#ifdef IRESEARCH_ONLY_MEMORY
+  std::array<dir_param_f, kCount * 1> data;
+#elif defined(IRESEARCH_URING)
   std::array<dir_param_f, kCount * 4> data;
 #else
   std::array<dir_param_f, kCount * 3> data;
@@ -157,27 +161,33 @@ constexpr auto getDirectories() {
   auto* p = data.data();
   if constexpr (Type & kTypesDefault) {
     *p++ = &tests::directory<&tests::memory_directory>;
+#ifndef IRESEARCH_ONLY_MEMORY
 #ifdef IRESEARCH_URING
     *p++ = &tests::directory<&tests::async_directory>;
 #endif
     *p++ = &tests::directory<&tests::mmap_directory>;
     *p++ = &tests::directory<&tests::fs_directory>;
+#endif
   }
   if constexpr (Type & kTypesRot13_16) {
     *p++ = &tests::rot13_directory<&tests::memory_directory, 16>;
+#ifndef IRESEARCH_ONLY_MEMORY
 #ifdef IRESEARCH_URING
     *p++ = &tests::rot13_directory<&tests::async_directory, 16>;
 #endif
     *p++ = &tests::rot13_directory<&tests::mmap_directory, 16>;
     *p++ = &tests::rot13_directory<&tests::fs_directory, 16>;
+#endif
   }
   if constexpr (Type & kTypesRot13_7) {
     *p++ = &tests::rot13_directory<&tests::memory_directory, 7>;
+#ifndef IRESEARCH_ONLY_MEMORY
 #ifdef IRESEARCH_URING
     *p++ = &tests::rot13_directory<&tests::async_directory, 7>;
 #endif
     *p++ = &tests::rot13_directory<&tests::mmap_directory, 7>;
     *p++ = &tests::rot13_directory<&tests::fs_directory, 7>;
+#endif
   }
   return data;
 }

--- a/tests/tests_param.hpp
+++ b/tests/tests_param.hpp
@@ -146,7 +146,7 @@ enum Types : uint64_t {
   kTypesRot13_7 = 1 << 3,
 };
 
-// #define IRESEARCH_ONLY_MEMORY
+#define IRESEARCH_ONLY_MEMORY
 
 template<uint64_t Type>
 constexpr auto getDirectories() {

--- a/tests/tests_param.hpp
+++ b/tests/tests_param.hpp
@@ -146,7 +146,7 @@ enum Types : uint64_t {
   kTypesRot13_7 = 1 << 3,
 };
 
-#define IRESEARCH_ONLY_MEMORY
+// #define IRESEARCH_ONLY_MEMORY
 
 template<uint64_t Type>
 constexpr auto getDirectories() {


### PR DESCRIPTION
Try to make commit more understandable.
Also 
1. Fix generation (see UpdateGeneration), needs backport to 3.10
2. Early discard empty segment produced by Flush()
3. Improve Emplace logic
4. Remove unnecessary lock in dtor
