### PR TITLE
Fix primary sort generations for Flush which separated by Commit/Rollback

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -149,3 +149,4 @@ StatementMacros:
   - QT_REQUIRE_VERSION
 TabWidth: 8
 UseTab: Never
+QualifierAlignment: Left

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -20,4 +20,4 @@ jobs:
           mkdir -p build 
           git diff --diff-filter=ACMRT --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} -- core/ tests/ > build/DIFF
       - name: clang-format
-        uses: iresearch-toolkit/clang-format-action@1.0.4
+        uses: iresearch-toolkit/clang-format-action@1.0.5

--- a/core/formats/formats.hpp
+++ b/core/formats/formats.hpp
@@ -442,11 +442,11 @@ class format {
 };
 
 struct flush_state {
-  directory* dir{};
+  directory* const dir{};
   const doc_map* docmap{};
-  const std::set<type_info::type_id>* features{};  // segment features
-  std::string_view name;                           // segment name
-  size_t doc_count;
+  const std::set<type_info::type_id>* features{};     // segment features
+  const std::string_view name;                        // segment name
+  const size_t doc_count;
   IndexFeatures index_features{IndexFeatures::NONE};  // segment index features
 };
 

--- a/core/formats/formats.hpp
+++ b/core/formats/formats.hpp
@@ -444,8 +444,8 @@ class format {
 struct flush_state {
   directory* const dir{};
   const doc_map* docmap{};
-  const std::set<type_info::type_id>* features{};     // segment features
-  const std::string_view name;                        // segment name
+  const std::set<type_info::type_id>* features{};  // segment features
+  const std::string_view name;                     // segment name
   const size_t doc_count;
   IndexFeatures index_features{IndexFeatures::NONE};  // segment index features
 };

--- a/core/index/index_writer.cpp
+++ b/core/index/index_writer.cpp
@@ -1049,7 +1049,7 @@ bool IndexWriter::FlushContext::AddToPending(ActiveSegmentContext& segment) {
     return false;
   }
   std::lock_guard lock{mutex_};
-  auto const size_before = pending_segment_contexts_.size();
+  const auto size_before = pending_segment_contexts_.size();
   pending_segment_contexts_.emplace_back(segment.ctx_, size_before);
   segment.flush_ctx_ = this;
   segment.pending_segment_context_offset_ = size_before;
@@ -2047,10 +2047,10 @@ IndexWriter::FlushPending(FlushContext& ctx,
 }
 
 IndexWriter::PendingContext IndexWriter::FlushAll(
-  uint64_t tick, ProgressReportCallback const& progress_callback) {
+  uint64_t tick, const ProgressReportCallback& progress_callback) {
   REGISTER_TIMER_DETAILED();
 
-  auto const& progress =
+  const auto& progress =
     (progress_callback != nullptr ? progress_callback : kNoProgress);
 
   IndexMeta pending_meta;
@@ -2530,7 +2530,7 @@ void IndexWriter::StartImpl(FlushContextPtr&& ctx, DirectoryMeta&& to_commit,
   IRS_ASSERT(pending_state_.Valid());
 }
 
-bool IndexWriter::Start(uint64_t tick, ProgressReportCallback const& progress) {
+bool IndexWriter::Start(uint64_t tick, const ProgressReportCallback& progress) {
   IRS_ASSERT(!commit_lock_.try_lock());  // already locked
 
   REGISTER_TIMER_DETAILED();

--- a/core/index/index_writer.cpp
+++ b/core/index/index_writer.cpp
@@ -66,13 +66,15 @@ const FeatureInfoProvider kDefaultFeatureInfo = [](irs::type_info::type_id) {
 
 struct FlushSegmentContext {
   // starting doc_id to consider in 'segment.meta' (inclusive)
-  const size_t doc_id_begin_;
+  const doc_id_t doc_id_begin_;
   // ending doc_id to consider in 'segment.meta' (exclusive)
-  const size_t doc_id_end_;
+  const doc_id_t doc_id_end_;
   // copy so that it can be moved into 'index_writer::pending_state_'
   IndexSegment segment_;
   // doc_ids masked in SegmentMeta
   document_mask docs_mask_;
+  doc_map old2new_;
+  doc_map new2old_;
   // modification contexts referenced by 'update_contexts_'
   std::span<const IndexWriter::ModificationContext> modification_contexts_;
   // update contexts for documents in SegmentMeta
@@ -81,19 +83,47 @@ struct FlushSegmentContext {
 
   FlushSegmentContext(
     std::shared_ptr<const SegmentReaderImpl>&& reader, IndexSegment&& segment,
-    document_mask&& docs_mask, size_t doc_id_begin, size_t doc_id_end,
+    document_mask&& docs_mask, doc_id_t doc_id_begin, doc_id_t doc_id_end,
     std::span<const segment_writer::update_context> update_contexts,
-    std::span<const IndexWriter::ModificationContext> modification_contexts)
+    std::span<const IndexWriter::ModificationContext> modification_contexts,
+    doc_map&& old2new)
     : doc_id_begin_{doc_id_begin},
       doc_id_end_{doc_id_end},
       segment_{std::move(segment)},
       docs_mask_{std::move(docs_mask)},
+      old2new_{std::move(old2new)},
       modification_contexts_{modification_contexts},
       update_contexts_{update_contexts},
       reader_{std::move(reader)} {
-    IRS_ASSERT(doc_id_begin_ <= doc_id_end_);
-    IRS_ASSERT(doc_id_end_ - doc_limits::min() <= segment_.meta.docs_count);
+    IRS_ASSERT(reader_ != nullptr);
     IRS_ASSERT(update_contexts.size() == segment_.meta.docs_count);
+    IRS_ASSERT(segment_.meta.docs_count < doc_limits::eof());
+    const auto first_doc_id = doc_limits::min();
+    const auto last_doc_id =
+      first_doc_id + static_cast<doc_id_t>(segment_.meta.docs_count);
+    IRS_ASSERT(doc_id_begin_ < doc_id_end_);
+    IRS_ASSERT(first_doc_id <= doc_id_begin_);
+    IRS_ASSERT(doc_id_end_ <= last_doc_id);
+
+    auto update_docs_mask = [&](auto&& visitor) {
+      for (doc_id_t doc_id = first_doc_id; doc_id < doc_id_begin_; ++doc_id) {
+        docs_mask.emplace(visitor(doc_id));
+      }
+      for (doc_id_t doc_id = doc_id_end_; doc_id < last_doc_id; ++doc_id) {
+        docs_mask.emplace(visitor(doc_id));
+      }
+    };
+
+    if (old2new_.empty()) {
+      update_docs_mask([](doc_id_t old_id) { return old_id; });
+    } else {
+      update_docs_mask([&](doc_id_t old_id) { return old2new_[old_id]; });
+
+      new2old_.resize(old2new.size());
+      for (doc_id_t old_id = 0; const auto new_id : old2new) {
+        new2old_[new_id] = old_id++;
+      }
+    }
   }
 };
 
@@ -195,11 +225,6 @@ void RemoveFromNewSegment(
   std::span<IndexWriter::ModificationContext> modifications,
   FlushSegmentContext& ctx) {
   IRS_ASSERT(!modifications.empty());
-  IRS_ASSERT(ctx.reader_);
-  IRS_ASSERT(ctx.doc_id_begin_ <= ctx.doc_id_end_);
-  IRS_ASSERT(ctx.doc_id_end_ <=
-             ctx.update_contexts_.size() + doc_limits::min());
-  IRS_ASSERT(doc_limits::valid(ctx.doc_id_begin_));
 
   auto& reader = *ctx.reader_;
   auto& docs_mask = ctx.docs_mask_;
@@ -222,19 +247,25 @@ void RemoveFromNewSegment(
     }
 
     while (itr->next()) {
-      const auto doc_id = itr->value();
+      const auto new_doc = itr->value();
+      const auto old_doc = [&] {
+        if (ctx.new2old_.empty()) {
+          return new_doc;
+        }
+        return ctx.new2old_[new_doc];
+      }();
 
-      if (doc_id < ctx.doc_id_begin_ || doc_id >= ctx.doc_id_end_) {
+      if (old_doc < ctx.doc_id_begin_ || ctx.doc_id_end_ <= old_doc) {
         continue;  // doc_id is not part of the current flush_context
       }
 
       // Valid because of asserts above
-      const auto& doc_ctx = ctx.update_contexts_[doc_id - doc_limits::min()];
+      const auto& doc_ctx = ctx.update_contexts_[old_doc - doc_limits::min()];
 
       // If the indexed doc_id was insert()ed after the request for modification
       // or the indexed doc_id was already masked then it should be skipped
       if (modification.generation < doc_ctx.generation ||
-          !docs_mask.insert(doc_id).second) {
+          !docs_mask.insert(new_doc).second) {
         continue;  // the current modification query does not match any records
       }
 
@@ -260,33 +291,34 @@ void MaskUnusedUpdatesInNewSegment(FlushSegmentContext& ctx) {
   if (ctx.modification_contexts_.empty()) {
     return;  // nothing new to add
   }
-  IRS_ASSERT(doc_limits::valid(ctx.doc_id_begin_));
-  IRS_ASSERT(ctx.doc_id_begin_ <= ctx.doc_id_end_);
-  IRS_ASSERT(ctx.doc_id_end_ <=
-             ctx.update_contexts_.size() + doc_limits::min());
 
   auto& docs_mask = ctx.docs_mask_;
 
-  for (auto doc_id = ctx.doc_id_begin_; doc_id < ctx.doc_id_end_; ++doc_id) {
+  for (auto old_doc = ctx.doc_id_begin_; old_doc < ctx.doc_id_end_; ++old_doc) {
     // valid because of asserts above
-    const auto& doc_ctx = ctx.update_contexts_[doc_id - doc_limits::min()];
+    const auto& doc_ctx = ctx.update_contexts_[old_doc - doc_limits::min()];
 
     if (doc_ctx.update_id == kNonUpdateRecord) {
       continue;  // not an update operation
     }
+    const auto new_doc = [&] {
+      if (ctx.old2new_.empty()) {
+        return old_doc;
+      }
+      return ctx.old2new_[old_doc];
+    }();
 
-    IRS_ASSERT(ctx.modification_contexts_.size() > doc_ctx.update_id);
+    IRS_ASSERT(doc_ctx.update_id < ctx.modification_contexts_.size());
 
-    // If it's an update record placeholder who's query already match some
-    // record
+    // it's an update record placeholder who's query already match some record
     if (!ctx.modification_contexts_[doc_ctx.update_id].seen) {
-      docs_mask.insert(doc_id);
+      docs_mask.insert(new_doc);
     }
   }
 }
 
 // Write the specified document mask and adjust version and
-// live documents count of the specifed meta.
+// live documents count of the specified meta.
 // Return index of the mask file withing segment file list
 size_t WriteDocumentMask(directory& dir, SegmentMeta& meta,
                          const document_mask& docs_mask,
@@ -752,15 +784,15 @@ bool IndexWriter::Transaction::Commit() noexcept {
     return true;  // nothing to do
   }
 
-  if (auto& writer = *ctx->writer_; writer.tick() < last_operation_tick_) {
-    writer.tick(last_operation_tick_);
+  if (auto& writer = *ctx->writer_; writer.tick() < last_trx_tick_) {
+    writer.tick(last_trx_tick_);
   }
 
   try {
     // FIXME move emplace into active_segment_context destructor commit segment
     const auto& flush_ctx = writer_.GetFlushContext();
     IRS_ASSERT(flush_ctx);
-    flush_ctx->Emplace(std::move(segment_), first_operation_tick_);
+    flush_ctx->Emplace(std::move(segment_), first_trx_tick_, last_trx_tick_);
     return true;
   } catch (...) {
     Reset();  // abort segment
@@ -769,7 +801,7 @@ bool IndexWriter::Transaction::Commit() noexcept {
 }
 
 void IndexWriter::Transaction::Reset() noexcept {
-  last_operation_tick_ = 0;  // reset tick
+  last_trx_tick_ = 0;  // reset tick
 
   const auto& ctx = segment_.ctx();
 
@@ -792,6 +824,7 @@ void IndexWriter::Transaction::Reset() noexcept {
     return ctx->uncommitted_docs_ < flushed.GetDocsEnd();
   });
   if (it != end) {
+    IRS_ASSERT(ctx->last_trx_buffered_docs_ == 0);
     if (it->SetCommitted(ctx->uncommitted_docs_)) {
       const auto docs_end = it->GetDocsEnd();
       ctx->flushed_.erase(it + 1, end);
@@ -907,7 +940,8 @@ IndexWriter::FlushContextPtr IndexWriter::Transaction::UpdateSegment(
 }
 
 void IndexWriter::FlushContext::Emplace(ActiveSegmentContext&& segment,
-                                        uint64_t generation_base) {
+                                        uint64_t first_trx_tick,
+                                        uint64_t last_trx_tick) {
   if (segment.ctx_ == nullptr) {
     return;  // nothing to do
   }
@@ -931,20 +965,18 @@ void IndexWriter::FlushContext::Emplace(ActiveSegmentContext&& segment,
   //       are applied to documents with generation <= removal
   IRS_ASSERT(ctx.uncommitted_modification_queries_ <=
              ctx.modification_queries_.size());
-  const size_t modification_count =
-    ctx.modification_queries_.size() - ctx.uncommitted_modification_queries_;
-  if (generation_base == 0) {
-    // atomic increment to end of unique generation range
-    // fetch_add return start of generation range
+  if (first_trx_tick == 0) {
+    const auto modification_count =
+      ctx.modification_queries_.size() - ctx.uncommitted_modification_queries_;
     if (is_null) {
-      generation_base = generation_.fetch_add(modification_count);
+      first_trx_tick = generation_.fetch_add(modification_count);
     } else {
-      generation_base = flush_ctx->generation_.fetch_add(modification_count);
+      first_trx_tick = flush_ctx->generation_.fetch_add(modification_count);
     }
   }
 
   // Update generation of segment operation
-  ctx.UpdateGeneration(generation_base);
+  ctx.UpdateGeneration(first_trx_tick);
 
   if (flush_lock.owns_lock()) {
     return;
@@ -1060,7 +1092,8 @@ IndexWriter::SegmentContext::SegmentContext(
   IRS_ASSERT(meta_generator_);
 }
 
-void IndexWriter::SegmentContext::UpdateGeneration(uint64_t base) noexcept {
+void IndexWriter::SegmentContext::UpdateGeneration(
+  uint64_t first_trx_tick) noexcept {
   IRS_ASSERT(writer_);
   IRS_ASSERT(writer_->docs_cached() < doc_limits::eof());
 
@@ -1072,7 +1105,7 @@ void IndexWriter::SegmentContext::UpdateGeneration(uint64_t base) noexcept {
       IRS_ASSERT(v.generation < modification_queries_.size() -
                                   uncommitted_modification_queries_);
       // Update to flush_context generation
-      v.generation += base;
+      v.generation += first_trx_tick;
     });
 
   // Update generations for insertions
@@ -1082,7 +1115,7 @@ void IndexWriter::SegmentContext::UpdateGeneration(uint64_t base) noexcept {
         // Can be == to 'count' if inserts come after modification
         IRS_ASSERT(update.generation <= modification_queries_.size() -
                                           uncommitted_modification_queries_);
-        update.generation += base;
+        update.generation += first_trx_tick;
       }
     };
 
@@ -1111,6 +1144,10 @@ void IndexWriter::SegmentContext::UpdateGeneration(uint64_t base) noexcept {
 uint64_t IndexWriter::SegmentContext::Flush() {
   // Must be already locked to prevent concurrent flush related modifications
   IRS_ASSERT(!flush_mutex_.try_lock());
+  Finally reset_uncommitted = [&]() noexcept {
+    uncommitted_docs_ -= last_trx_buffered_docs_;
+    last_trx_buffered_docs_ = 0;
+  };
 
   if (!writer_ || !writer_->initialized() || writer_->docs_cached() == 0) {
     return 0;  // Skip flushing an empty writer
@@ -1122,18 +1159,17 @@ uint64_t IndexWriter::SegmentContext::Flush() {
   Finally reset_writer = [&]() noexcept { writer_->reset(); };
 
   document_mask docs_mask;
-  const std::span ctxs = writer_->flush(writer_meta_, docs_mask);
+  auto docmap = writer_->flush(writer_meta_, docs_mask);
 
   if (writer_meta_.meta.live_docs_count == 0) {
-    uncommitted_docs_ -= last_trx_buffered_docs_;
-    last_trx_buffered_docs_ = 0;
     return 0;  // Skip flushing an empty writer
   }
+  const auto ctxs = writer_->docs_context();
   IRS_ASSERT(writer_meta_.meta.live_docs_count <= writer_meta_.meta.docs_count);
   IRS_ASSERT(writer_meta_.meta.docs_count == ctxs.size());
 
-  flushed_.emplace_back(std::move(writer_meta_), std::move(docs_mask),
-                        flushed_update_contexts_.size());
+  flushed_.emplace_back(std::move(writer_meta_), std::move(docmap),
+                        std::move(docs_mask), flushed_update_contexts_.size());
   try {
     flushed_update_contexts_.insert(flushed_update_contexts_.end(),
                                     ctxs.begin(), ctxs.end());
@@ -1142,6 +1178,7 @@ uint64_t IndexWriter::SegmentContext::Flush() {
     throw;
   }
 
+  last_trx_buffered_docs_ = 0;
   return writer_->tick();
 }
 
@@ -1849,7 +1886,7 @@ bool IndexWriter::Import(const IndexReader& reader,
 
   ctx->pending_segments_.emplace_back(
     std::move(segment),
-    ctx->generation_.load(),  // current modification generation
+    ctx->generation_.load(),      // current modification generation
     std::move(refs),
     std::move(imported_reader));  // do not forget to track refs
 
@@ -2366,25 +2403,12 @@ IndexWriter::PendingContext IndexWriter::FlushAll(
         // beginning doc_id in this SegmentMeta
         const auto valid_doc_id_begin = doc_limits::min();
         const auto valid_doc_id_end = flushed.GetValidEnd();
-        IRS_ASSERT(valid_doc_id_begin < valid_doc_id_end);
 
         auto& flush_segment_ctx = segment_ctxs.emplace_back(
           std::move(reader), std::move(flushed), std::move(flushed.docs_mask),
           valid_doc_id_begin, valid_doc_id_end,
           flushed.GetContexts(segment->flushed_update_contexts_),
-          segment->modification_queries_);
-
-        // read document_mask as was originally flushed
-        // could be due to truncated records due to rollback of uncommitted data
-        auto& docs_mask = flush_segment_ctx.docs_mask_;
-
-        // add tail doc_ids not part of this flush_context to documents_mask
-        // (including truncated)
-        for (doc_id_t doc_id = valid_doc_id_end,
-                      doc_id_end = flushed.meta.docs_count + doc_limits::min();
-             doc_id < doc_id_end; ++doc_id) {
-          docs_mask.emplace(doc_id);
-        }
+          segment->modification_queries_, std::move(flushed.old2new));
 
         // mask documents matching filters from all flushed segment_contexts
         // (i.e. from new operations)

--- a/core/index/index_writer.cpp
+++ b/core/index/index_writer.cpp
@@ -119,8 +119,8 @@ struct FlushSegmentContext {
     } else {
       update_docs_mask([&](doc_id_t old_id) { return old2new_[old_id]; });
 
-      new2old_.resize(old2new.size());
-      for (doc_id_t old_id = 0; const auto new_id : old2new) {
+      new2old_.resize(old2new_.size());
+      for (doc_id_t old_id = 0; const auto new_id : old2new_) {
         new2old_[new_id] = old_id++;
       }
     }
@@ -1886,7 +1886,7 @@ bool IndexWriter::Import(const IndexReader& reader,
 
   ctx->pending_segments_.emplace_back(
     std::move(segment),
-    ctx->generation_.load(),      // current modification generation
+    ctx->generation_.load(),  // current modification generation
     std::move(refs),
     std::move(imported_reader));  // do not forget to track refs
 

--- a/core/index/index_writer.hpp
+++ b/core/index/index_writer.hpp
@@ -502,7 +502,7 @@ class IndexWriter : private util::noncopyable {
   // payload arbitrary user supplied data to store in the index
   // Returns true if transaction has been successflully started.
   bool Begin(uint64_t tick = std::numeric_limits<uint64_t>::max(),
-             ProgressReportCallback const& progress = {}) {
+             const ProgressReportCallback& progress = {}) {
     // cppcheck-suppress unreadVariable
     std::lock_guard lock{commit_lock_};
 
@@ -525,7 +525,7 @@ class IndexWriter : private util::noncopyable {
   // relatively lightweight operation.
   // FIXME(gnusi): Commit() should return committed index snapshot
   bool Commit(uint64_t tick = std::numeric_limits<uint64_t>::max(),
-              ProgressReportCallback const& progress = {}) {
+              const ProgressReportCallback& progress = {}) {
     // cppcheck-suppress unreadVariable
     std::lock_guard lock{commit_lock_};
 
@@ -885,7 +885,7 @@ class IndexWriter : private util::noncopyable {
     FlushContext& ctx, std::unique_lock<std::mutex>& ctx_lock);
 
   PendingContext FlushAll(uint64_t tick,
-                          ProgressReportCallback const& progress_callback);
+                          const ProgressReportCallback& progress_callback);
 
   FlushContextPtr GetFlushContext(bool shared = true);
 
@@ -901,7 +901,7 @@ class IndexWriter : private util::noncopyable {
   void InitMeta(IndexMeta& meta, uint64_t tick) const;
 
   // Start transaction
-  bool Start(uint64_t tick, ProgressReportCallback const& progress);
+  bool Start(uint64_t tick, const ProgressReportCallback& progress);
   void StartImpl(FlushContextPtr&& ctx, DirectoryMeta&& to_commit,
                  std::vector<SegmentReader>&& readers,
                  std::vector<std::string_view>&& files_to_sync);
@@ -943,7 +943,7 @@ class IndexWriter : private util::noncopyable {
   std::atomic_uint64_t seg_counter_;  // segment counter
   uint64_t last_gen_;                 // last committed index meta generation
   index_meta_writer::ptr writer_;
-  index_lock::ptr write_lock_;        // exclusive write lock for directory
+  index_lock::ptr write_lock_;  // exclusive write lock for directory
   index_file_refs::ref_t write_lock_file_ref_;  // file ref for lock file
 };
 

--- a/core/index/merge_writer.cpp
+++ b/core/index/merge_writer.cpp
@@ -1313,8 +1313,9 @@ const MergeWriter::FlushProgress kProgressNoop = []() { return true; };
 }  // namespace
 
 MergeWriter::ReaderCtx::ReaderCtx(const SubReader* reader) noexcept
-  : reader{reader},
-    doc_map{[](doc_id_t) noexcept { return doc_limits::eof(); }} {
+  : reader{reader}, doc_map{[](doc_id_t) noexcept {
+      return doc_limits::eof();
+    }} {
   IRS_ASSERT(this->reader);
 }
 

--- a/core/index/merge_writer.cpp
+++ b/core/index/merge_writer.cpp
@@ -328,7 +328,7 @@ class SortingCompoundDocIterator : public doc_iterator {
     bool operator()(const size_t i) const {
       IRS_ASSERT(i < itrs_->size());
       auto& doc_it = (*itrs_)[i];
-      auto const& map = doc_it.second.get();
+      const auto& map = doc_it.second.get();
       while (doc_it.first->next()) {
         if (!doc_limits::eof(map(doc_it.first->value()))) {
           return true;
@@ -1676,7 +1676,7 @@ bool MergeWriter::Flush(SegmentMeta& segment,
   REGISTER_TIMER_DETAILED();
   IRS_ASSERT(segment.codec);  // Must be set outside
 
-  bool result = false;        // Flush result
+  bool result = false;  // Flush result
 
   Finally segment_invalidator = [&result, &segment]() noexcept {
     if (IRS_UNLIKELY(!result)) {

--- a/core/index/merge_writer.cpp
+++ b/core/index/merge_writer.cpp
@@ -1313,9 +1313,8 @@ const MergeWriter::FlushProgress kProgressNoop = []() { return true; };
 }  // namespace
 
 MergeWriter::ReaderCtx::ReaderCtx(const SubReader* reader) noexcept
-  : reader{reader}, doc_map{[](doc_id_t) noexcept {
-      return doc_limits::eof();
-    }} {
+  : reader{reader},
+    doc_map{[](doc_id_t) noexcept { return doc_limits::eof(); }} {
   IRS_ASSERT(this->reader);
 }
 
@@ -1416,12 +1415,13 @@ bool MergeWriter::FlushUnsorted(TrackingDirectory& dir, SegmentMeta& segment,
     return false;  // progress callback requested termination
   }
 
-  flush_state state;
-  state.dir = &dir;
-  state.doc_count = segment.docs_count;
-  state.features = &fields_features;
-  state.index_features = index_features;
-  state.name = segment.name;
+  flush_state state{
+    .dir = &dir,
+    .features = &fields_features,
+    .name = segment.name,
+    .doc_count = segment.docs_count,
+    .index_features = index_features,
+  };
 
   // write field meta and field term data
   if (!write_fields(cs, remapping_itrs, state, segment, *feature_info_,
@@ -1645,12 +1645,13 @@ bool MergeWriter::FlushSorted(TrackingDirectory& dir, SegmentMeta& segment,
     return false;  // progress callback requested termination
   }
 
-  flush_state state;
-  state.dir = &dir;
-  state.doc_count = segment.docs_count;
-  state.index_features = index_features;
-  state.features = &fields_features;
-  state.name = segment.name;
+  flush_state state{
+    .dir = &dir,
+    .features = &fields_features,
+    .name = segment.name,
+    .doc_count = segment.docs_count,
+    .index_features = index_features,
+  };
 
   // write field meta and field term data
   if (!write_fields(cs, sorting_doc_it, state, segment, *feature_info_,
@@ -1675,7 +1676,7 @@ bool MergeWriter::Flush(SegmentMeta& segment,
   REGISTER_TIMER_DETAILED();
   IRS_ASSERT(segment.codec);  // Must be set outside
 
-  bool result = false;  // Flush result
+  bool result = false;        // Flush result
 
   Finally segment_invalidator = [&result, &segment]() noexcept {
     if (IRS_UNLIKELY(!result)) {

--- a/core/index/segment_writer.cpp
+++ b/core/index/segment_writer.cpp
@@ -49,19 +49,6 @@ namespace {
   return true;
 }
 
-// Please will be accurate with trying to make this function in-place
-// During my small research I consider it's impossible without mutable docmap
-void reorder(std::vector<segment_writer::update_context>& ctxs,
-             const doc_map& docmap) {
-  std::vector<segment_writer::update_context> new_ctxs;
-  new_ctxs.resize(ctxs.size());
-  for (size_t i = 0, size = ctxs.size(); i < size; ++i) {
-    new_ctxs[docmap[i + doc_limits::min()] - doc_limits::min()] =
-      std::move(ctxs[i]);
-  }
-  ctxs = std::move(new_ctxs);
-}
-
 }  // namespace
 
 segment_writer::stored_column::stored_column(
@@ -223,18 +210,11 @@ column_output& segment_writer::stream(const hashed_string_view& name,
     ->writer(doc_id);
 }
 
-void segment_writer::flush_fields(const doc_map& docmap) {
-  flush_state state;
-  state.dir = &dir_;
-  state.doc_count = docs_cached();
-  state.name = seg_name_;
-  state.docmap = fields_.comparator() && !docmap.empty() ? &docmap : nullptr;
-
+void segment_writer::FlushFields(flush_state& state) {
   try {
     fields_.flush(*field_writer_, state);
   } catch (...) {
     field_writer_.reset();  // invalidate field writer
-
     throw;
   }
 }
@@ -268,24 +248,23 @@ document_mask segment_writer::get_doc_mask(const doc_map& docmap) {
   return docs_mask;
 }
 
-std::span<segment_writer::update_context> segment_writer::flush(
-  IndexSegment& segment, document_mask& docs_mask) {
+doc_map segment_writer::flush(IndexSegment& segment, document_mask& docs_mask) {
   REGISTER_TIMER_DETAILED();
   IRS_ASSERT(docs_mask.empty());
 
   auto& meta = segment.meta;
 
-  doc_map docmap;
-  flush_state state;
-  state.dir = &dir_;
-  state.doc_count = docs_cached();
-  state.name = seg_name_;
-  state.docmap = nullptr;
+  flush_state state{
+    .dir = &dir_,
+    .name = seg_name_,
+    .doc_count = docs_cached(),
+  };
 
-  if (fields_.comparator()) {
-    std::tie(docmap, sort_.id) =
-      sort_.stream.flush(*col_writer_, std::move(sort_.finalizer),
-                         doc_id_t(docs_cached()), *fields_.comparator());
+  doc_map docmap;
+  if (fields_.comparator() != nullptr) {
+    std::tie(docmap, sort_.id) = sort_.stream.flush(
+      *col_writer_, std::move(sort_.finalizer),
+      static_cast<doc_id_t>(state.doc_count), *fields_.comparator());
 
     // flush all cached columns
     irs::sorted_column::flush_buffer_t buffer;
@@ -300,7 +279,6 @@ std::span<segment_writer::update_context> segment_writer::flush(
 
     if (!docmap.empty()) {
       state.docmap = &docmap;
-      reorder(docs_context_, docmap);
     }
   }
 
@@ -308,18 +286,20 @@ std::span<segment_writer::update_context> segment_writer::flush(
   meta.column_store = col_writer_->commit(state);
 
   // flush fields metadata & inverted data,
-  if (docs_cached()) {
-    flush_fields(docmap);
+  if (state.doc_count != 0) {
+    FlushFields(state);
   }
 
-  // get non-empty document mask
-  if (docs_mask_.any()) {
+  // TODO(MBkkt) Move docs_mask_ remapping to the end of FlashAll Stage 4.
+  //  In such case we will avoid all old2new remappings, only new2old remain.
+  //  Also it will be lazy in such case.
+  if (docs_mask_.any()) {  // get non-empty document mask
     docs_mask = get_doc_mask(docmap);
   }
 
   // update segment metadata
-  IRS_ASSERT(docs_cached() >= docs_mask.size());
-  meta.docs_count = docs_cached();
+  IRS_ASSERT(docs_mask.size() <= state.doc_count);
+  meta.docs_count = state.doc_count;
   meta.live_docs_count = meta.docs_count - docs_mask.size();
   meta.files = dir_.FlushTracked(meta.byte_size);
 
@@ -327,7 +307,7 @@ std::span<segment_writer::update_context> segment_writer::flush(
   // be changed by removals accumulated in IndexWriter.
   index_utils::FlushIndexSegment(dir_, segment);
 
-  return docs_context_;
+  return docmap;
 }
 
 void segment_writer::reset() noexcept {

--- a/core/index/segment_writer.hpp
+++ b/core/index/segment_writer.hpp
@@ -146,8 +146,7 @@ class segment_writer : util::noncopyable {
 
   std::span<update_context> docs_context() noexcept { return docs_context_; }
 
-  std::span<update_context> flush(IndexSegment& segment,
-                                  document_mask& docs_mask);
+  doc_map flush(IndexSegment& segment, document_mask& docs_mask);
 
   const std::string& name() const noexcept { return seg_name_; }
   size_t docs_cached() const noexcept { return docs_context_.size(); }
@@ -363,7 +362,7 @@ class segment_writer : util::noncopyable {
   // Flushes document mask to directory, returns number of masked documens
   document_mask get_doc_mask(const doc_map& docmap);
   // Flushes indexed fields to directory
-  void flush_fields(const doc_map& docmap);
+  void FlushFields(flush_state& state);
 
   std::deque<cached_column> cached_columns_;  // pointers remain valid
   sorted_column sort_;

--- a/tests/formats/columnstore2_test.cpp
+++ b/tests/formats/columnstore2_test.cpp
@@ -148,9 +148,10 @@ TEST_P(columnstore2_test_case, empty_columnstore) {
   irs::SegmentMeta meta;
   meta.name = "test";
 
-  irs::flush_state state;
-  state.doc_count = kMax;
-  state.name = meta.name;
+  irs::flush_state state{
+    .name = meta.name,
+    .doc_count = kMax,
+  };
 
   auto finalizer = [](auto&) {
     // Must not be called
@@ -175,9 +176,10 @@ TEST_P(columnstore2_test_case, empty_column) {
   irs::SegmentMeta meta;
   meta.name = "test";
 
-  irs::flush_state state;
-  state.doc_count = kMax;
-  state.name = meta.name;
+  irs::flush_state state{
+    .name = meta.name,
+    .doc_count = kMax,
+  };
 
   irs::columnstore2::writer writer(version(), consolidation());
   writer.prepare(dir(), meta);
@@ -281,9 +283,10 @@ TEST_P(columnstore2_test_case, sparse_mask_column) {
   irs::SegmentMeta meta;
   meta.name = "test";
 
-  irs::flush_state state;
-  state.doc_count = kMax;
-  state.name = meta.name;
+  irs::flush_state state{
+    .name = meta.name,
+    .doc_count = kMax,
+  };
 
   {
     irs::columnstore2::writer writer(version(), consolidation());
@@ -428,9 +431,10 @@ TEST_P(columnstore2_test_case, sparse_column_m) {
   meta.name = "test_m";
   const bool has_encryption = bool(dir().attributes().encryption());
 
-  irs::flush_state state;
-  state.doc_count = MAX;
-  state.name = meta.name;
+  irs::flush_state state{
+    .name = meta.name,
+    .doc_count = MAX,
+  };
   int64_t memory{0};
   auto mem = [&memory](int64_t diff) noexcept {
     memory += diff;
@@ -488,9 +492,10 @@ TEST_P(columnstore2_test_case, sparse_column_mr) {
   meta.name = "test";
   const bool has_encryption = bool(dir().attributes().encryption());
 
-  irs::flush_state state;
-  state.doc_count = MAX;
-  state.name = meta.name;
+  irs::flush_state state{
+    .name = meta.name,
+    .doc_count = MAX,
+  };
   int64_t memory{0};
   auto mem = [&memory](int64_t diff) noexcept {
     memory += diff;
@@ -553,9 +558,10 @@ TEST_P(columnstore2_test_case, sparse_column) {
   irs::SegmentMeta meta;
   meta.name = "test";
 
-  irs::flush_state state;
-  state.doc_count = kMax;
-  state.name = meta.name;
+  irs::flush_state state{
+    .name = meta.name,
+    .doc_count = kMax,
+  };
 
   {
     irs::columnstore2::writer writer(version(), consolidation());
@@ -770,9 +776,10 @@ TEST_P(columnstore2_test_case, sparse_column_gap) {
   irs::SegmentMeta meta;
   meta.name = "test";
 
-  irs::flush_state state;
-  state.doc_count = kMax;
-  state.name = meta.name;
+  irs::flush_state state{
+    .name = meta.name,
+    .doc_count = kMax,
+  };
 
   {
     irs::columnstore2::writer writer(version(), consolidation());
@@ -950,9 +957,10 @@ TEST_P(columnstore2_test_case, sparse_column_tail_block) {
   irs::SegmentMeta meta;
   meta.name = "test";
 
-  irs::flush_state state;
-  state.doc_count = kMax;
-  state.name = meta.name;
+  irs::flush_state state{
+    .name = meta.name,
+    .doc_count = kMax,
+  };
 
   {
     auto write_payload = [](irs::doc_id_t doc, irs::data_output& stream) {
@@ -1134,9 +1142,10 @@ TEST_P(columnstore2_test_case, sparse_column_tail_block_last_value) {
   irs::SegmentMeta meta;
   meta.name = "test";
 
-  irs::flush_state state;
-  state.doc_count = kMax;
-  state.name = meta.name;
+  irs::flush_state state{
+    .name = meta.name,
+    .doc_count = kMax,
+  };
 
   {
     auto write_payload = [](irs::doc_id_t doc, irs::data_output& stream) {
@@ -1319,9 +1328,10 @@ TEST_P(columnstore2_test_case, sparse_column_full_blocks) {
   irs::SegmentMeta meta;
   meta.name = "test";
 
-  irs::flush_state state;
-  state.doc_count = kMax;
-  state.name = meta.name;
+  irs::flush_state state{
+    .name = meta.name,
+    .doc_count = kMax,
+  };
 
   constexpr std::string_view kValue{"aaaaaaaaaaaaaaaaaaaaaaaaaaa"};
   static_assert(kValue.size() == 27);
@@ -1506,9 +1516,10 @@ TEST_P(columnstore2_test_case, sparse_column_full_blocks_all_equal) {
   irs::SegmentMeta meta;
   meta.name = "test";
 
-  irs::flush_state state;
-  state.doc_count = kMax;
-  state.name = meta.name;
+  irs::flush_state state{
+    .name = meta.name,
+    .doc_count = kMax,
+  };
 
   constexpr std::string_view kValue{"aaaaaaaaaaaaaaaaaaaaaaaaaaa"};
   static_assert(kValue.size() == 27);
@@ -1690,9 +1701,10 @@ TEST_P(columnstore2_test_case, dense_mask_column) {
   irs::SegmentMeta meta;
   meta.name = "test";
 
-  irs::flush_state state;
-  state.doc_count = kMax;
-  state.name = meta.name;
+  irs::flush_state state{
+    .name = meta.name,
+    .doc_count = kMax,
+  };
 
   {
     irs::columnstore2::writer writer(version(), consolidation());
@@ -1846,9 +1858,10 @@ TEST_P(columnstore2_test_case, dense_column) {
   irs::SegmentMeta meta;
   meta.name = "test";
 
-  irs::flush_state state;
-  state.doc_count = kMax;
-  state.name = meta.name;
+  irs::flush_state state{
+    .name = meta.name,
+    .doc_count = kMax,
+  };
 
   {
     irs::columnstore2::writer writer(version(), consolidation());
@@ -2049,9 +2062,10 @@ TEST_P(columnstore2_test_case, dense_column_range) {
   irs::SegmentMeta meta;
   meta.name = "test";
 
-  irs::flush_state state;
-  state.doc_count = kMax;
-  state.name = meta.name;
+  irs::flush_state state{
+    .name = meta.name,
+    .doc_count = kMax,
+  };
 
   {
     irs::columnstore2::writer writer(version(), consolidation());
@@ -2227,9 +2241,10 @@ TEST_P(columnstore2_test_case, dense_fixed_length_column_m) {
   meta.name = "test_m";
   const bool has_encryption = bool(dir().attributes().encryption());
 
-  irs::flush_state state;
-  state.doc_count = MAX;
-  state.name = meta.name;
+  irs::flush_state state{
+    .name = meta.name,
+    .doc_count = MAX,
+  };
   int64_t memory{0};
   auto mem = [&memory](int64_t diff) noexcept {
     memory += diff;
@@ -2305,9 +2320,10 @@ TEST_P(columnstore2_test_case, dense_fixed_length_column_mr) {
   meta.name = "test_mr";
   const bool has_encryption = bool(dir().attributes().encryption());
 
-  irs::flush_state state;
-  state.doc_count = MAX;
-  state.name = meta.name;
+  irs::flush_state state{
+    .name = meta.name,
+    .doc_count = MAX,
+  };
   int64_t memory{0};
   auto mem = [&memory](int64_t diff) noexcept {
     memory += diff;
@@ -2388,9 +2404,10 @@ TEST_P(columnstore2_test_case, dense_fixed_length_column) {
   irs::SegmentMeta meta;
   meta.name = "test";
 
-  irs::flush_state state;
-  state.doc_count = kMax;
-  state.name = meta.name;
+  irs::flush_state state{
+    .name = meta.name,
+    .doc_count = kMax,
+  };
 
   {
     irs::columnstore2::writer writer(version(), consolidation());
@@ -2702,9 +2719,10 @@ TEST_P(columnstore2_test_case, dense_fixed_length_column_empty_tail) {
   irs::SegmentMeta meta;
   meta.name = "test";
 
-  irs::flush_state state;
-  state.doc_count = kMax;
-  state.name = meta.name;
+  irs::flush_state state{
+    .name = meta.name,
+    .doc_count = kMax,
+  };
 
   {
     irs::columnstore2::writer writer(version(), consolidation());
@@ -2883,9 +2901,10 @@ TEST_P(columnstore2_test_case, empty_columns) {
   irs::SegmentMeta meta;
   meta.name = "test";
 
-  irs::flush_state state;
-  state.doc_count = kMax;
-  state.name = meta.name;
+  irs::flush_state state{
+    .name = meta.name,
+    .doc_count = kMax,
+  };
 
   {
     irs::columnstore2::writer writer(version(), consolidation());

--- a/tests/formats/formats_10_tests.cpp
+++ b/tests/formats/formats_10_tests.cpp
@@ -55,7 +55,7 @@ class format_10_test_case : public tests::format_test_case {
   };
 
   void AssertFrequencyAndPositions(irs::doc_iterator& expected,
-                                      irs::doc_iterator& actual) {
+                                   irs::doc_iterator& actual) {
     auto* expected_freq = irs::get_mutable<irs::frequency>(&expected);
     auto* actual_freq = irs::get_mutable<irs::frequency>(&actual);
     ASSERT_EQ(!expected_freq, !actual_freq);
@@ -114,11 +114,12 @@ class format_10_test_case : public tests::format_test_case {
 
     // write postings for field
     {
-      irs::flush_state state;
-      state.dir = dir.get();
-      state.doc_count = docs.back().first + 1;
-      state.name = "segment_name";
-      state.index_features = field.index_features;
+      irs::flush_state state{
+        .dir = dir.get(),
+        .name = "segment_name",
+        .doc_count = docs.back().first + 1,
+        .index_features = field.index_features,
+      };
 
       auto out = dir->create("attributes");
       ASSERT_FALSE(!out);
@@ -303,11 +304,12 @@ TEST_P(format_10_test_case, postings_read_write_single_doc) {
 
   // write postings
   {
-    irs::flush_state state;
-    state.dir = &dir();
-    state.doc_count = 100;
-    state.name = "segment_name";
-    state.index_features = field.index_features;
+    irs::flush_state state{
+      .dir = &dir(),
+      .name = "segment_name",
+      .doc_count = 100,
+      .index_features = field.index_features,
+    };
 
     auto out = dir().create("attributes");
     ASSERT_FALSE(!out);
@@ -466,11 +468,12 @@ TEST_P(format_10_test_case, postings_read_write) {
 
   // write postings
   {
-    irs::flush_state state;
-    state.dir = &dir();
-    state.doc_count = 150;
-    state.name = "segment_name";
-    state.index_features = field.index_features;
+    irs::flush_state state{
+      .dir = &dir(),
+      .name = "segment_name",
+      .doc_count = 150,
+      .index_features = field.index_features,
+    };
 
     auto out = dir().create("attributes");
     ASSERT_FALSE(!out);
@@ -614,12 +617,13 @@ TEST_P(format_10_test_case, postings_writer_reuse) {
     field.name = "field";
     field.index_features = features;
 
-    irs::flush_state state;
-    state.dir = &dir();
-    state.doc_count = 10000;
-    state.name = "0";
-    state.index_features =
-      field.index_features;  // all possible features in segment
+    irs::flush_state state{
+      .dir = &dir(),
+      .name = "0",
+      .doc_count = 10000,
+      // all possible features in segment
+      .index_features = field.index_features,
+    };
 
     auto out = dir().create(std::string("postings") + state.name.data());
     ASSERT_FALSE(!out);
@@ -642,12 +646,13 @@ TEST_P(format_10_test_case, postings_writer_reuse) {
     field.name = "field";
     field.index_features = features;
 
-    irs::flush_state state;
-    state.dir = &dir();
-    state.doc_count = 10000;
-    state.name = "1";
-    state.index_features =
-      field.index_features;  // all possible features in segment
+    irs::flush_state state{
+      .dir = &dir(),
+      .name = "1",
+      .doc_count = 10000,
+      // all possible features in segment
+      .index_features = field.index_features,
+    };
 
     auto out = dir().create(std::string("postings") + state.name.data());
     ASSERT_FALSE(!out);
@@ -670,12 +675,13 @@ TEST_P(format_10_test_case, postings_writer_reuse) {
     field.name = "field";
     field.index_features = features;
 
-    irs::flush_state state;
-    state.dir = &dir();
-    state.doc_count = 10000;
-    state.name = "2";
-    state.index_features =
-      field.index_features;  // all possible features in segment
+    irs::flush_state state{
+      .dir = &dir(),
+      .name = "2",
+      .doc_count = 10000,
+      // all possible features in segment
+      .index_features = field.index_features,
+    };
 
     auto out = dir().create(std::string("postings") + state.name.data());
     ASSERT_FALSE(!out);
@@ -697,12 +703,13 @@ TEST_P(format_10_test_case, postings_writer_reuse) {
     field.name = "field";
     field.index_features = features;
 
-    irs::flush_state state;
-    state.dir = &dir();
-    state.doc_count = 10000;
-    state.name = "3";
-    state.index_features =
-      field.index_features;  // all possible features in segment
+    irs::flush_state state{
+      .dir = &dir(),
+      .name = "3",
+      .doc_count = 10000,
+      // all possible features in segment
+      .index_features = field.index_features,
+    };
 
     auto out = dir().create(std::string("postings") + state.name.data());
     ASSERT_FALSE(!out);
@@ -723,12 +730,13 @@ TEST_P(format_10_test_case, postings_writer_reuse) {
     field.name = "field";
     field.index_features = features;
 
-    irs::flush_state state;
-    state.dir = &dir();
-    state.doc_count = 10000;
-    state.name = "4";
-    state.index_features =
-      field.index_features;  // all possible features in segment
+    irs::flush_state state{
+      .dir = &dir(),
+      .name = "4",
+      .doc_count = 10000,
+      // all possible features in segment
+      .index_features = field.index_features,
+    };
 
     auto out = dir().create(std::string("postings") + state.name.data());
     ASSERT_FALSE(!out);
@@ -749,10 +757,11 @@ TEST_P(format_10_test_case, postings_writer_reuse) {
     field.name = "field";
     field.index_features = features;
 
-    irs::flush_state state;
-    state.dir = &dir();
-    state.doc_count = 10000;
-    state.name = "5";
+    irs::flush_state state{
+      .dir = &dir(),
+      .name = "5",
+      .doc_count = 10000,
+    };
 
     auto out = dir().create(std::string("postings") + state.name.data());
     ASSERT_FALSE(!out);
@@ -787,10 +796,11 @@ TEST_P(format_10_test_case, ires336) {
   tests::format_test_case::terms<decltype(terms.begin())> trms(
     terms.begin(), terms.end(), docs.begin(), docs.end());
 
-  irs::flush_state flush_state;
-  flush_state.dir = dir.get();
-  flush_state.doc_count = 10000;
-  flush_state.name = segment_name;
+  irs::flush_state flush_state{
+    .dir = dir.get(),
+    .name = segment_name,
+    .doc_count = 10000,
+  };
 
   irs::field_meta field_meta;
   field_meta.name = field;

--- a/tests/formats/formats_15_tests.cpp
+++ b/tests/formats/formats_15_tests.cpp
@@ -655,7 +655,17 @@ TEST_P(Format15TestCase, LongPostingsThreshold100) {
   AssertPostings(docs, kThreshold);
 }
 
+TEST_P(Format15TestCase, MediumPostingsThreshold0) {
+  static constexpr size_t kCount = 319;
+  static_assert(kCount > kVersion10PostingsWriterBlockSize);
+  static constexpr uint32_t kThreshold = 0;
+  const auto docs = GenerateDocs(kCount, 50.f, 13.f, 1);
+
+  AssertPostings(docs, kThreshold);
+}
+
 TEST_P(Format15TestCase, LongPostingsThreshold0) {
+  GTEST_SKIP() << "too long for our CI";
   static constexpr size_t kCount = 10000;
   static constexpr uint32_t kThreshold = 0;
   const auto docs = GenerateDocs(kCount, 50.f, 13.f, 1);
@@ -663,14 +673,14 @@ TEST_P(Format15TestCase, LongPostingsThreshold0) {
   AssertPostings(docs, kThreshold);
 }
 
-/* Long test
 TEST_P(Format15TestCase, VeryLongPostingsThreshold0) {
+  GTEST_SKIP() << "too long for our CI";
   static constexpr size_t kCount = size_t{1} << 15;
   static constexpr uint32_t kThreshold = 0;
   const auto docs = GenerateDocs(kCount, 1000.f, 20.f, 2);
 
   AssertPostings(docs, kThreshold);
-}*/
+}
 
 static constexpr auto kTestDirs15 =
   tests::getDirectories<tests::kTypesDefault>();

--- a/tests/formats/formats_test_case_base.cpp
+++ b/tests/formats/formats_test_case_base.cpp
@@ -779,12 +779,13 @@ TEST_P(format_test_case, fields_read_write) {
 
   // write fields
   {
-    irs::flush_state state;
-    state.dir = &dir();
-    state.doc_count = 100;
-    state.name = "segment_name";
-    state.features = &features;
-    state.index_features = field.index_features;
+    irs::flush_state state{
+      .dir = &dir(),
+      .features = &features,
+      .name = "segment_name",
+      .doc_count = 100,
+      .index_features = field.index_features,
+    };
 
     // should use sorted terms on write
     terms<sorted_terms_t::iterator> terms(sorted_terms.begin(),
@@ -1208,10 +1209,11 @@ TEST_P(format_test_case, columns_rw_sparse_column_dense_block) {
       stream.write_bytes(payload.data(), payload.size());
     }
 
-    irs::flush_state state;
-    state.dir = &dir();
-    state.doc_count = id - 1;
-    state.name = seg.name;
+    irs::flush_state state{
+      .dir = &dir(),
+      .name = seg.name,
+      .doc_count = id - 1,
+    };
 
     ASSERT_TRUE(writer->commit(state));
   }
@@ -1263,10 +1265,11 @@ TEST_P(format_test_case, columns_rw_dense_mask) {
       column_handler(id);
     }
 
-    irs::flush_state state;
-    state.dir = &dir();
-    state.doc_count = MAX_DOC;
-    state.name = seg.name;
+    irs::flush_state state{
+      .dir = &dir(),
+      .name = seg.name,
+      .doc_count = MAX_DOC,
+    };
 
     ASSERT_TRUE(writer->commit(state));
   }
@@ -1319,10 +1322,11 @@ TEST_P(format_test_case, columns_rw_bit_mask) {
     // we don't support irs::type_limits<<irs::type_t::doc_id_t>::eof() key
     // value
 
-    irs::flush_state state;
-    state.dir = &dir();
-    state.doc_count = segment.docs_count;
-    state.name = segment.name;
+    irs::flush_state state{
+      .dir = &dir(),
+      .name = segment.name,
+      .doc_count = segment.docs_count,
+    };
 
     ASSERT_TRUE(writer->commit(state));
   }
@@ -1582,10 +1586,11 @@ TEST_P(format_test_case, columns_rw_empty) {
       writer->push_column(lz4_column_info(), column_finalizer(43)).first;
     ASSERT_EQ(1, column1_id);
 
-    irs::flush_state state;
-    state.dir = &dir();
-    state.doc_count = meta0.docs_count;
-    state.name = meta0.name;
+    irs::flush_state state{
+      .dir = &dir(),
+      .name = meta0.name,
+      .doc_count = meta0.docs_count,
+    };
 
     ASSERT_FALSE(writer->commit(state));  // flush empty columns
   }
@@ -1666,10 +1671,11 @@ TEST_P(format_test_case, columns_rw_same_col_empty_repeat) {
       ++seg.docs_count;
     }
 
-    irs::flush_state state;
-    state.dir = &dir();
-    state.doc_count = seg.docs_count;
-    state.name = seg.name;
+    irs::flush_state state{
+      .dir = &dir(),
+      .name = seg.name,
+      .doc_count = seg.docs_count,
+    };
 
     ASSERT_TRUE(writer->commit(state));
 
@@ -1755,10 +1761,11 @@ TEST_P(format_test_case, columns_rw_big_document) {
       ++segment.docs_count;
     }
 
-    irs::flush_state state;
-    state.dir = &dir();
-    state.doc_count = segment.docs_count;
-    state.name = segment.name;
+    irs::flush_state state{
+      .dir = &dir(),
+      .name = segment.name,
+      .doc_count = segment.docs_count,
+    };
 
     ASSERT_TRUE(writer->commit(state));
   }
@@ -1927,10 +1934,11 @@ TEST_P(format_test_case, columns_rw_writer_reuse) {
     }
 
     {
-      irs::flush_state state;
-      state.dir = &dir();
-      state.doc_count = seg_1.docs_count;
-      state.name = seg_1.name;
+      irs::flush_state state{
+        .dir = &dir(),
+        .name = seg_1.name,
+        .doc_count = seg_1.docs_count,
+      };
 
       ASSERT_TRUE(writer->commit(state));
     }
@@ -1963,10 +1971,11 @@ TEST_P(format_test_case, columns_rw_writer_reuse) {
     }
 
     {
-      irs::flush_state state;
-      state.dir = &dir();
-      state.doc_count = seg_2.docs_count;
-      state.name = seg_2.name;
+      irs::flush_state state{
+        .dir = &dir(),
+        .name = seg_2.name,
+        .doc_count = seg_2.docs_count,
+      };
 
       ASSERT_TRUE(writer->commit(state));
     }
@@ -1997,10 +2006,11 @@ TEST_P(format_test_case, columns_rw_writer_reuse) {
     }
 
     {
-      irs::flush_state state;
-      state.dir = &dir();
-      state.doc_count = seg_3.docs_count;
-      state.name = seg_3.name;
+      irs::flush_state state{
+        .dir = &dir(),
+        .name = seg_3.name,
+        .doc_count = seg_3.docs_count,
+      };
 
       ASSERT_TRUE(writer->commit(state));
     }
@@ -2213,10 +2223,11 @@ TEST_P(format_test_case, columns_rw_typed) {
       ++meta.docs_count;
     }
 
-    irs::flush_state state;
-    state.dir = &dir();
-    state.doc_count = meta.docs_count;
-    state.name = meta.name;
+    irs::flush_state state{
+      .dir = &dir(),
+      .name = meta.name,
+      .doc_count = meta.docs_count,
+    };
 
     ASSERT_TRUE(writer->commit(state));
   }
@@ -2460,10 +2471,11 @@ TEST_P(format_test_case, columns_issue700) {
                          str.size());
     }
 
-    irs::flush_state state;
-    state.dir = &dir();
-    state.doc_count = meta.docs_count;
-    state.name = meta.name;
+    irs::flush_state state{
+      .dir = &dir(),
+      .name = meta.name,
+      .doc_count = meta.docs_count,
+    };
 
     ASSERT_TRUE(writer->commit(state));
   }
@@ -2536,10 +2548,11 @@ TEST_P(format_test_case, columns_rw_sparse_dense_offset_column_border_case) {
       }
     }
 
-    irs::flush_state state;
-    state.dir = &dir();
-    state.doc_count = meta0.docs_count;
-    state.name = meta0.name;
+    irs::flush_state state{
+      .dir = &dir(),
+      .name = meta0.name,
+      .doc_count = meta0.docs_count,
+    };
 
     ASSERT_TRUE(writer->commit(state));
   }
@@ -2735,700 +2748,708 @@ TEST_P(format_test_case, columns_rw) {
     }
 
     // column==field2
-    {                                   // rollback
-     {auto& stream = field2_writer(1);  // doc==1
-    irs::write_string(stream, std::string_view("invalid_string"));
-    stream.reset();  // rollback changes
-    stream.reset();  // rollback changes
-  }
-  {
-    auto& stream = field2_writer(1);  // doc==1
-    irs::write_string(stream, std::string_view("field2_doc1"));
-  }
-}
-
-// column==field0, rollback
-{
-  auto& stream = field0_writer(2);  // doc==2
-  irs::write_string(stream, std::string_view("field0_doc1"));
-  stream.reset();
-}
-
-// column==field0
-{
-  auto& stream = field0_writer(2);  // doc==2
-  irs::write_string(stream, std::string_view("field0_doc2"));
-}
-
-// column==field0
-{
-  auto& stream = field0_writer(33);  // doc==33
-  irs::write_string(stream, std::string_view("field0_doc33"));
-}
-
-// column==field1, multivalued attribute
-{
-  // Get stream by the same key. In this case written values
-  // will be concatenated and accessible via the specified key
-  // (e.g. 'field1_doc12_1', 'field1_doc12_2' in this case)
-  {
-    auto& stream = field1_writer(12);  // doc==12
-    irs::write_string(stream, std::string_view("field1_doc12_1"));
-  }
-  {
-    auto& stream = field1_writer(12);  // doc==12
-    irs::write_string(stream, std::string_view("field1_doc12_2"));
-  }
-}
-
-irs::flush_state state;
-state.dir = &dir();
-state.doc_count = meta0.docs_count;
-state.name = meta0.name;
-
-ASSERT_TRUE(writer->commit(state));
-}  // namespace tests
-
-// write _2 segment, reuse writer
-{
-  writer->prepare(dir(), meta1);
-
-  auto field0 = writer->push_column(lz4_column_info(), {});
-  segment1_field0_id = field0.first;
-  auto& field0_writer = field0.second;
-  ASSERT_EQ(0, segment1_field0_id);
-  auto field1 = writer->push_column(lz4_column_info(), {});
-  segment1_field1_id = field1.first;
-  auto& field1_writer = field1.second;
-  ASSERT_EQ(1, segment1_field1_id);
-  auto field2 = writer->push_column(lz4_column_info(), {});
-  segment1_field2_id = field2.first;
-  auto& field2_writer = field2.second;
-  ASSERT_EQ(2, segment1_field2_id);
-
-  // column==field3
-  {
-    auto& stream = field2_writer(1);  // doc==1
-    irs::write_string(stream, std::string_view("segment_2_field3_doc0"));
-  }
-
-  // column==field1, multivalued attribute
-  {
-    auto& stream = field0_writer(1);  // doc==1
-    irs::write_string(stream, std::string_view("segment_2_field1_doc0"));
-  }
-
-  // column==field2, rollback
-  {
-    auto& stream = field1_writer(1);
-    irs::write_string(stream, std::string_view("segment_2_field2_doc0"));
-    stream.reset();  // rollback
-  }
-
-  // column==field3, rollback
-  {
-    auto& stream = field2_writer(2);  // doc==2
-    irs::write_string(stream, std::string_view("segment_2_field0_doc1"));
-    stream.reset();  // rollback
-  }
-
-  // colum==field1
-  {
-    auto& stream = field0_writer(12);  // doc==12
-    irs::write_string(stream, std::string_view("segment_2_field1_doc12"));
-  }
-
-  // colum==field3
-  {
-    auto& stream = field2_writer(23);  // doc==23
-    irs::write_string(stream, std::string_view("segment_2_field3_doc23"));
-    stream.reset();  // rollback
-  }
-
-  irs::flush_state state;
-  state.dir = &dir();
-  state.doc_count = meta1.docs_count;
-  state.name = meta1.name;
-
-  ASSERT_TRUE(writer->commit(state));
-}
-
-// read columns values from segment _1
-{
-  auto reader = codec()->get_columnstore_reader();
-  ASSERT_TRUE(reader->prepare(dir(), meta0));
-
-  // try to get invalild column
-  ASSERT_EQ(nullptr, reader->column(irs::field_limits::invalid()));
-
-  // check field4
-  {
-    auto column_reader = reader->column(segment0_field4_id);
-    ASSERT_NE(nullptr, column_reader);
-    auto column = column_reader->iterator(irs::ColumnHint::kNormal);
-    ASSERT_NE(nullptr, column);
-    auto* actual_value = irs::get<irs::payload>(*column);
-    ASSERT_NE(nullptr, actual_value);
-
-    ASSERT_EQ(1, column->seek(1));  // check doc==1, column==field4
-    ASSERT_EQ("field4_doc_min",
-              irs::to_string<std::string_view>(actual_value->value.data()));
-  }
-
-  // visit field0 values (not cached)
-  {
-    std::unordered_map<std::string_view, irs::doc_id_t> expected_values = {
-      {"field0_doc0", 1}, {"field0_doc2", 2}, {"field0_doc33", 33}};
-
-    auto visitor = [&expected_values](irs::doc_id_t doc,
-                                      irs::bytes_view value) {
-      const auto actual_value = irs::to_string<std::string_view>(value.data());
-
-      auto it = expected_values.find(actual_value);
-      if (it == expected_values.end()) {
-        // can't find value
-        return false;
-      }
-
-      if (it->second != doc) {
-        // wrong document
-        return false;
-      }
-
-      expected_values.erase(it);
-      return true;
-    };
-
-    auto column = reader->column(segment0_field0_id);
-    ASSERT_NE(nullptr, column);
-    ASSERT_TRUE(visit(*column, visitor));
-    ASSERT_TRUE(expected_values.empty());
-  }
-
-  // partailly visit field0 values (not cached)
-  {
-    std::unordered_map<std::string_view, irs::doc_id_t> expected_values = {
-      {"field0_doc0", 1}, {"field0_doc2", 2}, {"field0_doc33", 33}};
-
-    size_t calls_count = 0;
-    auto visitor = [&expected_values, &calls_count](irs::doc_id_t doc,
-                                                    irs::bytes_view in) {
-      ++calls_count;
-
-      if (calls_count > 2) {
-        // break the loop
-        return false;
-      }
-
-      const auto actual_value = irs::to_string<std::string_view>(in.data());
-
-      auto it = expected_values.find(actual_value);
-      if (it == expected_values.end()) {
-        // can't find value
-        return false;
-      }
-
-      if (it->second != doc) {
-        // wrong document
-        return false;
-      }
-
-      expected_values.erase(it);
-      return true;
-    };
-
-    auto column = reader->column(segment0_field0_id);
-    ASSERT_NE(nullptr, column);
-    ASSERT_FALSE(visit(*column, visitor));
-    ASSERT_FALSE(expected_values.empty());
-    ASSERT_EQ(1, expected_values.size());
-    ASSERT_NE(expected_values.end(), expected_values.find("field0_doc33"));
-  }
-
-  // check field0
-  {
-    auto column_reader = reader->column(segment0_field0_id);
-    ASSERT_NE(nullptr, column_reader);
-
-    // read (not cached)
     {
+      (void)1;
+      // rollback
+      {
+        auto& stream = field2_writer(1);  // doc==1
+        irs::write_string(stream, std::string_view("invalid_string"));
+        stream.reset();                   // rollback changes
+        stream.reset();                   // rollback changes
+      }
+      {
+        auto& stream = field2_writer(1);  // doc==1
+        irs::write_string(stream, std::string_view("field2_doc1"));
+      }
+    }
+
+    // column==field0, rollback
+    {
+      auto& stream = field0_writer(2);  // doc==2
+      irs::write_string(stream, std::string_view("field0_doc1"));
+      stream.reset();
+    }
+
+    // column==field0
+    {
+      auto& stream = field0_writer(2);  // doc==2
+      irs::write_string(stream, std::string_view("field0_doc2"));
+    }
+
+    // column==field0
+    {
+      auto& stream = field0_writer(33);  // doc==33
+      irs::write_string(stream, std::string_view("field0_doc33"));
+    }
+
+    // column==field1, multivalued attribute
+    {
+      // Get stream by the same key. In this case written values
+      // will be concatenated and accessible via the specified key
+      // (e.g. 'field1_doc12_1', 'field1_doc12_2' in this case)
+      {
+        auto& stream = field1_writer(12);  // doc==12
+        irs::write_string(stream, std::string_view("field1_doc12_1"));
+      }
+      {
+        auto& stream = field1_writer(12);  // doc==12
+        irs::write_string(stream, std::string_view("field1_doc12_2"));
+      }
+    }
+
+    irs::flush_state state{
+      .dir = &dir(),
+      .name = meta0.name,
+      .doc_count = meta0.docs_count,
+    };
+
+    ASSERT_TRUE(writer->commit(state));
+  }
+
+  // write _2 segment, reuse writer
+  {
+    writer->prepare(dir(), meta1);
+
+    auto field0 = writer->push_column(lz4_column_info(), {});
+    segment1_field0_id = field0.first;
+    auto& field0_writer = field0.second;
+    ASSERT_EQ(0, segment1_field0_id);
+    auto field1 = writer->push_column(lz4_column_info(), {});
+    segment1_field1_id = field1.first;
+    auto& field1_writer = field1.second;
+    ASSERT_EQ(1, segment1_field1_id);
+    auto field2 = writer->push_column(lz4_column_info(), {});
+    segment1_field2_id = field2.first;
+    auto& field2_writer = field2.second;
+    ASSERT_EQ(2, segment1_field2_id);
+
+    // column==field3
+    {
+      auto& stream = field2_writer(1);  // doc==1
+      irs::write_string(stream, std::string_view("segment_2_field3_doc0"));
+    }
+
+    // column==field1, multivalued attribute
+    {
+      auto& stream = field0_writer(1);  // doc==1
+      irs::write_string(stream, std::string_view("segment_2_field1_doc0"));
+    }
+
+    // column==field2, rollback
+    {
+      auto& stream = field1_writer(1);
+      irs::write_string(stream, std::string_view("segment_2_field2_doc0"));
+      stream.reset();  // rollback
+    }
+
+    // column==field3, rollback
+    {
+      auto& stream = field2_writer(2);  // doc==2
+      irs::write_string(stream, std::string_view("segment_2_field0_doc1"));
+      stream.reset();                   // rollback
+    }
+
+    // colum==field1
+    {
+      auto& stream = field0_writer(12);  // doc==12
+      irs::write_string(stream, std::string_view("segment_2_field1_doc12"));
+    }
+
+    // colum==field3
+    {
+      auto& stream = field2_writer(23);  // doc==23
+      irs::write_string(stream, std::string_view("segment_2_field3_doc23"));
+      stream.reset();                    // rollback
+    }
+
+    irs::flush_state state{
+      .dir = &dir(),
+      .name = meta1.name,
+      .doc_count = meta1.docs_count,
+    };
+
+    ASSERT_TRUE(writer->commit(state));
+  }
+
+  // read columns values from segment _1
+  {
+    auto reader = codec()->get_columnstore_reader();
+    ASSERT_TRUE(reader->prepare(dir(), meta0));
+
+    // try to get invalild column
+    ASSERT_EQ(nullptr, reader->column(irs::field_limits::invalid()));
+
+    // check field4
+    {
+      auto column_reader = reader->column(segment0_field4_id);
+      ASSERT_NE(nullptr, column_reader);
       auto column = column_reader->iterator(irs::ColumnHint::kNormal);
       ASSERT_NE(nullptr, column);
       auto* actual_value = irs::get<irs::payload>(*column);
       ASSERT_NE(nullptr, actual_value);
 
+      ASSERT_EQ(1, column->seek(1));  // check doc==1, column==field4
+      ASSERT_EQ("field4_doc_min",
+                irs::to_string<std::string_view>(actual_value->value.data()));
+    }
+
+    // visit field0 values (not cached)
+    {
+      std::unordered_map<std::string_view, irs::doc_id_t> expected_values = {
+        {"field0_doc0", 1}, {"field0_doc2", 2}, {"field0_doc33", 33}};
+
+      auto visitor = [&expected_values](irs::doc_id_t doc,
+                                        irs::bytes_view value) {
+        const auto actual_value =
+          irs::to_string<std::string_view>(value.data());
+
+        auto it = expected_values.find(actual_value);
+        if (it == expected_values.end()) {
+          // can't find value
+          return false;
+        }
+
+        if (it->second != doc) {
+          // wrong document
+          return false;
+        }
+
+        expected_values.erase(it);
+        return true;
+      };
+
+      auto column = reader->column(segment0_field0_id);
+      ASSERT_NE(nullptr, column);
+      ASSERT_TRUE(visit(*column, visitor));
+      ASSERT_TRUE(expected_values.empty());
+    }
+
+    // partailly visit field0 values (not cached)
+    {
+      std::unordered_map<std::string_view, irs::doc_id_t> expected_values = {
+        {"field0_doc0", 1}, {"field0_doc2", 2}, {"field0_doc33", 33}};
+
+      size_t calls_count = 0;
+      auto visitor = [&expected_values, &calls_count](irs::doc_id_t doc,
+                                                      irs::bytes_view in) {
+        ++calls_count;
+
+        if (calls_count > 2) {
+          // break the loop
+          return false;
+        }
+
+        const auto actual_value = irs::to_string<std::string_view>(in.data());
+
+        auto it = expected_values.find(actual_value);
+        if (it == expected_values.end()) {
+          // can't find value
+          return false;
+        }
+
+        if (it->second != doc) {
+          // wrong document
+          return false;
+        }
+
+        expected_values.erase(it);
+        return true;
+      };
+
+      auto column = reader->column(segment0_field0_id);
+      ASSERT_NE(nullptr, column);
+      ASSERT_FALSE(visit(*column, visitor));
+      ASSERT_FALSE(expected_values.empty());
+      ASSERT_EQ(1, expected_values.size());
+      ASSERT_NE(expected_values.end(), expected_values.find("field0_doc33"));
+    }
+
+    // check field0
+    {
+      auto column_reader = reader->column(segment0_field0_id);
+      ASSERT_NE(nullptr, column_reader);
+
+      // read (not cached)
+      {
+        auto column = column_reader->iterator(irs::ColumnHint::kNormal);
+        ASSERT_NE(nullptr, column);
+        auto* actual_value = irs::get<irs::payload>(*column);
+        ASSERT_NE(nullptr, actual_value);
+
+        ASSERT_EQ(1, column->seek(1));  // check doc==1, column==field0
+        ASSERT_EQ("field0_doc0",
+                  irs::to_string<std::string_view>(actual_value->value.data()));
+        ASSERT_EQ(33, column->seek(5));   // doc without value in field0
+        ASSERT_EQ(33, column->seek(33));  // check doc==33, column==field0
+        ASSERT_EQ("field0_doc33",
+                  irs::to_string<std::string_view>(actual_value->value.data()));
+      }
+
+      // read (cached)
+      {
+        auto column = column_reader->iterator(irs::ColumnHint::kNormal);
+        ASSERT_NE(nullptr, column);
+        auto* actual_value = irs::get<irs::payload>(*column);
+        ASSERT_NE(nullptr, actual_value);
+
+        ASSERT_EQ(1, column->seek(1));  // check doc==0, column==field0
+        ASSERT_EQ("field0_doc0",
+                  irs::to_string<std::string_view>(actual_value->value.data()));
+        ASSERT_EQ(33, column->seek(5));   // doc without value in field0
+        ASSERT_EQ(33, column->seek(33));  // check doc==33, column==field0
+        ASSERT_EQ("field0_doc33",
+                  irs::to_string<std::string_view>(actual_value->value.data()));
+      }
+    }
+
+    // visit field0 values (cached)
+    {
+      std::unordered_map<std::string_view, irs::doc_id_t> expected_values = {
+        {"field0_doc0", 1}, {"field0_doc2", 2}, {"field0_doc33", 33}};
+
+      auto visitor = [&expected_values](irs::doc_id_t doc,
+                                        const irs::bytes_view& in) {
+        const auto actual_value = irs::to_string<std::string_view>(in.data());
+
+        auto it = expected_values.find(actual_value);
+        if (it == expected_values.end()) {
+          // can't find value
+          return false;
+        }
+
+        if (it->second != doc) {
+          // wrong document
+          return false;
+        }
+
+        expected_values.erase(it);
+        return true;
+      };
+
+      auto column_reader = reader->column(segment0_field0_id);
+      ASSERT_NE(nullptr, column_reader);
+      ASSERT_TRUE(visit(*column_reader, visitor));
+      ASSERT_TRUE(expected_values.empty());
+    }
+
+    // iterate over field0 values (cached)
+    {
+      auto column_reader = reader->column(segment0_field0_id);
+      ASSERT_NE(nullptr, column_reader);
+      auto it = column_reader->iterator(irs::ColumnHint::kNormal);
+      ASSERT_NE(nullptr, it);
+
+      auto* payload = irs::get<irs::payload>(*it);
+      ASSERT_FALSE(!payload);
+      ASSERT_EQ(irs::doc_limits::invalid(), it->value());
+      ASSERT_EQ(irs::bytes_view{}, payload->value);
+
+      std::vector<std::pair<std::string_view, irs::doc_id_t>> expected_values =
+        {{"field0_doc0", 1}, {"field0_doc2", 2}, {"field0_doc33", 33}};
+
+      size_t i = 0;
+      for (; it->next(); ++i) {
+        const auto& expected_value = expected_values[i];
+        const auto actual_str_value =
+          irs::to_string<std::string_view>(payload->value.data());
+
+        ASSERT_EQ(expected_value.second, it->value());
+        ASSERT_EQ(expected_value.first, actual_str_value);
+      }
+
+      ASSERT_FALSE(it->next());
+      ASSERT_EQ(i, expected_values.size());
+      ASSERT_EQ(irs::doc_limits::eof(), it->value());
+      ASSERT_EQ(irs::bytes_view{}, payload->value);
+    }
+
+    // seek over field0 values (cached)
+    {
+      auto column_reader = reader->column(segment0_field0_id);
+      ASSERT_NE(nullptr, column_reader);
+      auto it = column_reader->iterator(irs::ColumnHint::kNormal);
+      ASSERT_NE(nullptr, it);
+
+      auto* payload = irs::get<irs::payload>(*it);
+      ASSERT_FALSE(!payload);
+      ASSERT_EQ(irs::doc_limits::invalid(), it->value());
+      ASSERT_EQ(irs::bytes_view{}, payload->value);
+
+      std::vector<
+        std::pair<std::string_view, std::pair<irs::doc_id_t, irs::doc_id_t>>>
+        expected_values = {{"field0_doc0", {0, 1}},
+                           {"field0_doc2", {2, 2}},
+                           {"field0_doc33", {22, 33}},
+                           {"field0_doc33", {33, 33}}};
+
+      for (auto& expected : expected_values) {
+        const auto expected_doc = expected.second.second;
+        const auto expected_value = expected.first;
+
+        ASSERT_EQ(expected_doc, it->seek(expected_doc));
+        ASSERT_EQ(expected_value,
+                  irs::to_string<std::string_view>(payload->value.data()));
+      }
+
+      ASSERT_FALSE(it->next());
+      ASSERT_EQ(irs::doc_limits::eof(), it->value());
+      ASSERT_EQ(irs::bytes_view{}, payload->value);
+    }
+
+    // iterate over field1 values (not cached)
+    {
+      auto column_reader = reader->column(segment0_field1_id);
+      ASSERT_NE(nullptr, column_reader);
+      auto it = column_reader->iterator(irs::ColumnHint::kNormal);
+      ASSERT_NE(nullptr, it);
+
+      auto* payload = irs::get<irs::payload>(*it);
+      ASSERT_FALSE(!payload);
+      ASSERT_EQ(irs::doc_limits::invalid(), it->value());
+      ASSERT_EQ(irs::bytes_view{}, payload->value);
+
+      std::vector<std::pair<std::vector<std::string_view>, irs::doc_id_t>>
+        expected_values = {{{"field1_doc0", "field1_doc0_1"}, 1},
+                           {{"field1_doc12_1", "field1_doc12_2"}, 12}};
+
+      size_t i = 0;
+      for (; it->next(); ++i) {
+        const auto& expected_value = expected_values[i];
+
+        std::vector<std::string_view> actual_str_values;
+        actual_str_values.push_back(
+          irs::to_string<std::string_view>(payload->value.data()));
+        actual_str_values.push_back(irs::to_string<std::string_view>(
+          reinterpret_cast<const irs::byte_type*>(
+            actual_str_values.back().data() +
+            actual_str_values.back().size())));
+
+        ASSERT_EQ(expected_value.second, it->value());
+        ASSERT_EQ(expected_value.first, actual_str_values);
+      }
+      ASSERT_FALSE(it->next());
+      ASSERT_EQ(i, expected_values.size());
+      ASSERT_EQ(irs::doc_limits::eof(), it->value());
+      ASSERT_EQ(irs::bytes_view{}, payload->value);
+    }
+
+    // seek over field1 values (cached)
+    {
+      auto column_reader = reader->column(segment0_field1_id);
+      ASSERT_NE(nullptr, column_reader);
+      auto it = column_reader->iterator(irs::ColumnHint::kNormal);
+      ASSERT_NE(nullptr, it);
+
+      auto* payload = irs::get<irs::payload>(*it);
+      ASSERT_FALSE(!payload);
+      ASSERT_EQ(irs::doc_limits::invalid(), it->value());
+      ASSERT_EQ(irs::bytes_view{}, payload->value);
+
+      std::vector<std::pair<std::vector<std::string_view>,
+                            std::pair<irs::doc_id_t, irs::doc_id_t>>>
+        expected_values = {{{"field1_doc0", "field1_doc0_1"}, {0, 1}},
+                           {{"field1_doc12_1", "field1_doc12_2"}, {1, 12}},
+                           {{"field1_doc12_1", "field1_doc12_2"}, {3, 12}},
+                           {{"field1_doc12_1", "field1_doc12_2"}, {12, 12}}};
+
+      for (auto& expected : expected_values) {
+        const auto expected_doc = expected.second.second;
+        const auto& expected_value = expected.first;
+
+        ASSERT_EQ(expected_doc, it->seek(expected_doc));
+
+        std::vector<std::string_view> actual_str_values;
+        actual_str_values.push_back(
+          irs::to_string<std::string_view>(payload->value.data()));
+        actual_str_values.push_back(irs::to_string<std::string_view>(
+          reinterpret_cast<const irs::byte_type*>(
+            actual_str_values.back().data() +
+            actual_str_values.back().size())));
+
+        ASSERT_EQ(expected_value, actual_str_values);
+      }
+
+      ASSERT_FALSE(it->next());
+      ASSERT_EQ(irs::doc_limits::eof(), it->value());
+      ASSERT_EQ(irs::bytes_view{}, payload->value);
+    }
+
+    // check field1 (multiple values per document - cached)
+    {
+      irs::bytes_view_input in;
+      auto column_reader = reader->column(segment0_field1_id);
+      ASSERT_NE(nullptr, column_reader);
+      auto column = column_reader->iterator(irs::ColumnHint::kNormal);
+      ASSERT_NE(nullptr, column);
+      auto* actual_value = irs::get<irs::payload>(*column);
+      ASSERT_NE(nullptr, actual_value);
+
+      // read compound column value
+      // check doc==0, column==field1
+      ASSERT_EQ(1, column->seek(1));
+      in.reset(actual_value->value);
+      ASSERT_EQ("field1_doc0", irs::read_string<std::string>(in));
+      ASSERT_EQ("field1_doc0_1", irs::read_string<std::string>(in));
+
+      ASSERT_EQ(12, column->seek(2));
+
+      // read overwritten compund value
+      // check doc==12, column==field1
+      ASSERT_EQ(12, column->seek(12));
+      in.reset(actual_value->value);
+      ASSERT_EQ("field1_doc12_1", irs::read_string<std::string>(in));
+      ASSERT_EQ("field1_doc12_2", irs::read_string<std::string>(in));
+
+      ASSERT_TRUE(irs::doc_limits::eof(column->seek(13)));
+    }
+
+    // visit empty column
+    {
+      size_t calls_count = 0;
+      auto visitor = [&calls_count](irs::doc_id_t /*doc*/,
+                                    const irs::bytes_view& /*in*/) {
+        ++calls_count;
+        return true;
+      };
+
+      auto column_reader = reader->column(segment0_empty_column_id);
+      ASSERT_NE(nullptr, column_reader);
+      ASSERT_TRUE(visit(*column_reader, visitor));
+      ASSERT_EQ(0, calls_count);
+    }
+
+    // iterate over empty column
+    {
+      auto column_reader = reader->column(segment0_empty_column_id);
+      ASSERT_NE(nullptr, column_reader);
+      auto it = column_reader->iterator(irs::ColumnHint::kNormal);
+      ASSERT_NE(nullptr, it);
+
+      ASSERT_TRUE(!irs::get<irs::payload>(*it));
+      ASSERT_EQ(irs::doc_limits::eof(), it->value());
+
+      ASSERT_FALSE(it->next());
+      ASSERT_EQ(irs::doc_limits::eof(), it->value());
+
+      ASSERT_FALSE(it->next());
+      ASSERT_EQ(irs::doc_limits::eof(), it->value());
+    }
+
+    // visit field2 values (field after an the field)
+    {
+      std::unordered_map<std::string_view, irs::doc_id_t> expected_values = {
+        {"field2_doc1", 1},
+      };
+
+      auto visitor = [&expected_values](irs::doc_id_t doc,
+                                        const irs::bytes_view& in) {
+        const auto actual_value = irs::to_string<std::string_view>(in.data());
+
+        auto it = expected_values.find(actual_value);
+        if (it == expected_values.end()) {
+          // can't find value
+          return false;
+        }
+
+        if (it->second != doc) {
+          // wrong document
+          return false;
+        }
+
+        expected_values.erase(it);
+        return true;
+      };
+
+      auto column_reader = reader->column(segment0_field2_id);
+      ASSERT_NE(nullptr, column_reader);
+      ASSERT_TRUE(visit(*column_reader, visitor));
+      ASSERT_TRUE(expected_values.empty());
+    }
+
+    // iterate over field2 values (not cached)
+    {
+      auto column_reader = reader->column(segment0_field2_id);
+      ASSERT_NE(nullptr, column_reader);
+      auto it = column_reader->iterator(irs::ColumnHint::kNormal);
+      ASSERT_NE(nullptr, it);
+
+      auto* payload = irs::get<irs::payload>(*it);
+      ASSERT_FALSE(!payload);
+      ASSERT_EQ(irs::doc_limits::invalid(), it->value());
+      ASSERT_EQ(irs::bytes_view{}, payload->value);
+
+      std::vector<std::pair<std::string_view, irs::doc_id_t>> expected_values =
+        {{"field2_doc1", 1}};
+
+      size_t i = 0;
+      for (; it->next(); ++i) {
+        const auto& expected_value = expected_values[i];
+        const auto actual_str_value =
+          irs::to_string<std::string_view>(payload->value.data());
+
+        ASSERT_EQ(expected_value.second, it->value());
+        ASSERT_EQ(expected_value.first, actual_str_value);
+      }
+
+      ASSERT_FALSE(it->next());
+      ASSERT_EQ(i, expected_values.size());
+      ASSERT_EQ(irs::doc_limits::eof(), it->value());
+      ASSERT_EQ(irs::bytes_view{}, payload->value);
+    }
+
+    // seek over field2 values (cached)
+    {
+      auto column_reader = reader->column(segment0_field2_id);
+      ASSERT_NE(nullptr, column_reader);
+      auto it = column_reader->iterator(irs::ColumnHint::kNormal);
+      ASSERT_NE(nullptr, it);
+
+      auto* payload = irs::get<irs::payload>(*it);
+      ASSERT_FALSE(!payload);
+      ASSERT_EQ(irs::doc_limits::invalid(), it->value());
+      ASSERT_EQ(irs::bytes_view{}, payload->value);
+
+      std::vector<
+        std::pair<std::string_view, std::pair<irs::doc_id_t, irs::doc_id_t>>>
+        expected_values = {{"field2_doc1", {1, 1}}};
+
+      for (auto& expected : expected_values) {
+        const auto expected_doc = expected.second.second;
+        const auto expected_value = expected.first;
+
+        ASSERT_EQ(expected_doc, it->seek(expected_doc));
+        const auto actual_str_value =
+          irs::to_string<std::string_view>(payload->value.data());
+        ASSERT_EQ(expected_value, actual_str_value);
+      }
+
+      ASSERT_FALSE(it->next());
+      ASSERT_EQ(irs::doc_limits::eof(), it->value());
+      ASSERT_EQ(irs::bytes_view{}, payload->value);
+    }
+  }
+
+  // read columns values from segment _2
+  {
+    auto reader = codec()->get_columnstore_reader();
+    ASSERT_TRUE(reader->prepare(dir(), meta1));
+
+    // try to read invalild column
+    { ASSERT_EQ(nullptr, reader->column(irs::field_limits::invalid())); }
+
+    // iterate over field0 values (not cached)
+    {
+      auto column_reader = reader->column(segment1_field0_id);
+      ASSERT_NE(nullptr, column_reader);
+      auto it = column_reader->iterator(irs::ColumnHint::kNormal);
+      ASSERT_NE(nullptr, it);
+
+      auto* payload = irs::get<irs::payload>(*it);
+      ASSERT_FALSE(!payload);
+      ASSERT_EQ(irs::doc_limits::invalid(), it->value());
+      ASSERT_EQ(irs::bytes_view{}, payload->value);
+
+      std::vector<std::pair<std::string_view, irs::doc_id_t>> expected_values =
+        {{"segment_2_field1_doc0", 1}, {"segment_2_field1_doc12", 12}};
+
+      size_t i = 0;
+      for (; it->next(); ++i) {
+        const auto& expected_value = expected_values[i];
+        const auto actual_str_value =
+          irs::to_string<std::string_view>(payload->value.data());
+
+        ASSERT_EQ(expected_value.second, it->value());
+        ASSERT_EQ(expected_value.first, actual_str_value);
+      }
+
+      ASSERT_FALSE(it->next());
+      ASSERT_EQ(i, expected_values.size());
+      ASSERT_EQ(irs::doc_limits::eof(), it->value());
+      ASSERT_EQ(irs::bytes_view{}, payload->value);
+    }
+
+    // seek over field0 values (cached)
+    {
+      auto column_reader = reader->column(segment1_field0_id);
+      ASSERT_NE(nullptr, column_reader);
+      auto it = column_reader->iterator(irs::ColumnHint::kNormal);
+      ASSERT_NE(nullptr, it);
+
+      auto* payload = irs::get<irs::payload>(*it);
+      ASSERT_FALSE(!payload);
+      ASSERT_EQ(irs::doc_limits::invalid(), it->value());
+      ASSERT_EQ(irs::bytes_view{}, payload->value);
+
+      std::vector<
+        std::pair<std::string_view, std::pair<irs::doc_id_t, irs::doc_id_t>>>
+        expected_values = {{"segment_2_field1_doc0", {0, 1}},
+                           {"segment_2_field1_doc12", {12, 12}}};
+
+      for (auto& expected : expected_values) {
+        const auto expected_doc = expected.second.second;
+        const auto expected_value = expected.first;
+
+        ASSERT_EQ(expected_doc, it->seek(expected_doc));
+        const auto actual_str_value =
+          irs::to_string<std::string_view>(payload->value.data());
+        ASSERT_EQ(expected_value, actual_str_value);
+      }
+
+      ASSERT_EQ(irs::doc_limits::eof(), it->seek(13));
+      ASSERT_EQ(irs::bytes_view{}, payload->value);
+
+      ASSERT_FALSE(it->next());
+      ASSERT_EQ(irs::doc_limits::eof(), it->value());
+      ASSERT_EQ(irs::bytes_view{}, payload->value);
+    }
+
+    // check field0 (cached)
+    {
+      auto column_reader = reader->column(segment1_field0_id);
+      ASSERT_NE(nullptr, column_reader);
+      auto column = column_reader->iterator(irs::ColumnHint::kNormal);
+      ASSERT_NE(nullptr, column);
+      auto* actual_value = irs::get<irs::payload>(*column);
+      ASSERT_NE(nullptr, actual_value);
       ASSERT_EQ(1, column->seek(1));  // check doc==1, column==field0
-      ASSERT_EQ("field0_doc0",
+      ASSERT_EQ("segment_2_field1_doc0",
                 irs::to_string<std::string_view>(actual_value->value.data()));
-      ASSERT_EQ(33, column->seek(5));   // doc without value in field0
-      ASSERT_EQ(33, column->seek(33));  // check doc==33, column==field0
-      ASSERT_EQ("field0_doc33",
+      ASSERT_EQ(12, column->seek(12));  // check doc==12, column==field1
+      ASSERT_EQ("segment_2_field1_doc12",
                 irs::to_string<std::string_view>(actual_value->value.data()));
     }
 
-    // read (cached)
+    // iterate over field0 values (cached)
     {
-      auto column = column_reader->iterator(irs::ColumnHint::kNormal);
-      ASSERT_NE(nullptr, column);
-      auto* actual_value = irs::get<irs::payload>(*column);
-      ASSERT_NE(nullptr, actual_value);
+      auto column_reader = reader->column(segment1_field0_id);
+      ASSERT_NE(nullptr, column_reader);
+      auto it = column_reader->iterator(irs::ColumnHint::kNormal);
+      ASSERT_NE(nullptr, it);
 
-      ASSERT_EQ(1, column->seek(1));  // check doc==0, column==field0
-      ASSERT_EQ("field0_doc0",
-                irs::to_string<std::string_view>(actual_value->value.data()));
-      ASSERT_EQ(33, column->seek(5));   // doc without value in field0
-      ASSERT_EQ(33, column->seek(33));  // check doc==33, column==field0
-      ASSERT_EQ("field0_doc33",
-                irs::to_string<std::string_view>(actual_value->value.data()));
-    }
-  }
+      auto* payload = irs::get<irs::payload>(*it);
+      ASSERT_FALSE(!payload);
+      ASSERT_EQ(irs::doc_limits::invalid(), it->value());
+      ASSERT_EQ(irs::bytes_view{}, payload->value);
 
-  // visit field0 values (cached)
-  {
-    std::unordered_map<std::string_view, irs::doc_id_t> expected_values = {
-      {"field0_doc0", 1}, {"field0_doc2", 2}, {"field0_doc33", 33}};
+      std::vector<std::pair<std::string_view, irs::doc_id_t>> expected_values =
+        {{"segment_2_field1_doc0", 1}, {"segment_2_field1_doc12", 12}};
 
-    auto visitor = [&expected_values](irs::doc_id_t doc,
-                                      const irs::bytes_view& in) {
-      const auto actual_value = irs::to_string<std::string_view>(in.data());
+      size_t i = 0;
+      for (; it->next(); ++i) {
+        const auto& expected_value = expected_values[i];
+        const auto actual_str_value =
+          irs::to_string<std::string_view>(payload->value.data());
 
-      auto it = expected_values.find(actual_value);
-      if (it == expected_values.end()) {
-        // can't find value
-        return false;
+        ASSERT_EQ(expected_value.second, it->value());
+        ASSERT_EQ(expected_value.first, actual_str_value);
       }
 
-      if (it->second != doc) {
-        // wrong document
-        return false;
-      }
-
-      expected_values.erase(it);
-      return true;
-    };
-
-    auto column_reader = reader->column(segment0_field0_id);
-    ASSERT_NE(nullptr, column_reader);
-    ASSERT_TRUE(visit(*column_reader, visitor));
-    ASSERT_TRUE(expected_values.empty());
-  }
-
-  // iterate over field0 values (cached)
-  {
-    auto column_reader = reader->column(segment0_field0_id);
-    ASSERT_NE(nullptr, column_reader);
-    auto it = column_reader->iterator(irs::ColumnHint::kNormal);
-    ASSERT_NE(nullptr, it);
-
-    auto* payload = irs::get<irs::payload>(*it);
-    ASSERT_FALSE(!payload);
-    ASSERT_EQ(irs::doc_limits::invalid(), it->value());
-    ASSERT_EQ(irs::bytes_view{}, payload->value);
-
-    std::vector<std::pair<std::string_view, irs::doc_id_t>> expected_values = {
-      {"field0_doc0", 1}, {"field0_doc2", 2}, {"field0_doc33", 33}};
-
-    size_t i = 0;
-    for (; it->next(); ++i) {
-      const auto& expected_value = expected_values[i];
-      const auto actual_str_value =
-        irs::to_string<std::string_view>(payload->value.data());
-
-      ASSERT_EQ(expected_value.second, it->value());
-      ASSERT_EQ(expected_value.first, actual_str_value);
+      ASSERT_FALSE(it->next());
+      ASSERT_EQ(i, expected_values.size());
+      ASSERT_EQ(irs::doc_limits::eof(), it->value());
+      ASSERT_EQ(irs::bytes_view{}, payload->value);
     }
-
-    ASSERT_FALSE(it->next());
-    ASSERT_EQ(i, expected_values.size());
-    ASSERT_EQ(irs::doc_limits::eof(), it->value());
-    ASSERT_EQ(irs::bytes_view{}, payload->value);
   }
-
-  // seek over field0 values (cached)
-  {
-    auto column_reader = reader->column(segment0_field0_id);
-    ASSERT_NE(nullptr, column_reader);
-    auto it = column_reader->iterator(irs::ColumnHint::kNormal);
-    ASSERT_NE(nullptr, it);
-
-    auto* payload = irs::get<irs::payload>(*it);
-    ASSERT_FALSE(!payload);
-    ASSERT_EQ(irs::doc_limits::invalid(), it->value());
-    ASSERT_EQ(irs::bytes_view{}, payload->value);
-
-    std::vector<
-      std::pair<std::string_view, std::pair<irs::doc_id_t, irs::doc_id_t>>>
-      expected_values = {{"field0_doc0", {0, 1}},
-                         {"field0_doc2", {2, 2}},
-                         {"field0_doc33", {22, 33}},
-                         {"field0_doc33", {33, 33}}};
-
-    for (auto& expected : expected_values) {
-      const auto expected_doc = expected.second.second;
-      const auto expected_value = expected.first;
-
-      ASSERT_EQ(expected_doc, it->seek(expected_doc));
-      ASSERT_EQ(expected_value,
-                irs::to_string<std::string_view>(payload->value.data()));
-    }
-
-    ASSERT_FALSE(it->next());
-    ASSERT_EQ(irs::doc_limits::eof(), it->value());
-    ASSERT_EQ(irs::bytes_view{}, payload->value);
-  }
-
-  // iterate over field1 values (not cached)
-  {
-    auto column_reader = reader->column(segment0_field1_id);
-    ASSERT_NE(nullptr, column_reader);
-    auto it = column_reader->iterator(irs::ColumnHint::kNormal);
-    ASSERT_NE(nullptr, it);
-
-    auto* payload = irs::get<irs::payload>(*it);
-    ASSERT_FALSE(!payload);
-    ASSERT_EQ(irs::doc_limits::invalid(), it->value());
-    ASSERT_EQ(irs::bytes_view{}, payload->value);
-
-    std::vector<std::pair<std::vector<std::string_view>, irs::doc_id_t>>
-      expected_values = {{{"field1_doc0", "field1_doc0_1"}, 1},
-                         {{"field1_doc12_1", "field1_doc12_2"}, 12}};
-
-    size_t i = 0;
-    for (; it->next(); ++i) {
-      const auto& expected_value = expected_values[i];
-
-      std::vector<std::string_view> actual_str_values;
-      actual_str_values.push_back(
-        irs::to_string<std::string_view>(payload->value.data()));
-      actual_str_values.push_back(irs::to_string<std::string_view>(
-        reinterpret_cast<const irs::byte_type*>(
-          actual_str_values.back().data() + actual_str_values.back().size())));
-
-      ASSERT_EQ(expected_value.second, it->value());
-      ASSERT_EQ(expected_value.first, actual_str_values);
-    }
-    ASSERT_FALSE(it->next());
-    ASSERT_EQ(i, expected_values.size());
-    ASSERT_EQ(irs::doc_limits::eof(), it->value());
-    ASSERT_EQ(irs::bytes_view{}, payload->value);
-  }
-
-  // seek over field1 values (cached)
-  {
-    auto column_reader = reader->column(segment0_field1_id);
-    ASSERT_NE(nullptr, column_reader);
-    auto it = column_reader->iterator(irs::ColumnHint::kNormal);
-    ASSERT_NE(nullptr, it);
-
-    auto* payload = irs::get<irs::payload>(*it);
-    ASSERT_FALSE(!payload);
-    ASSERT_EQ(irs::doc_limits::invalid(), it->value());
-    ASSERT_EQ(irs::bytes_view{}, payload->value);
-
-    std::vector<std::pair<std::vector<std::string_view>,
-                          std::pair<irs::doc_id_t, irs::doc_id_t>>>
-      expected_values = {{{"field1_doc0", "field1_doc0_1"}, {0, 1}},
-                         {{"field1_doc12_1", "field1_doc12_2"}, {1, 12}},
-                         {{"field1_doc12_1", "field1_doc12_2"}, {3, 12}},
-                         {{"field1_doc12_1", "field1_doc12_2"}, {12, 12}}};
-
-    for (auto& expected : expected_values) {
-      const auto expected_doc = expected.second.second;
-      const auto& expected_value = expected.first;
-
-      ASSERT_EQ(expected_doc, it->seek(expected_doc));
-
-      std::vector<std::string_view> actual_str_values;
-      actual_str_values.push_back(
-        irs::to_string<std::string_view>(payload->value.data()));
-      actual_str_values.push_back(irs::to_string<std::string_view>(
-        reinterpret_cast<const irs::byte_type*>(
-          actual_str_values.back().data() + actual_str_values.back().size())));
-
-      ASSERT_EQ(expected_value, actual_str_values);
-    }
-
-    ASSERT_FALSE(it->next());
-    ASSERT_EQ(irs::doc_limits::eof(), it->value());
-    ASSERT_EQ(irs::bytes_view{}, payload->value);
-  }
-
-  // check field1 (multiple values per document - cached)
-  {
-    irs::bytes_view_input in;
-    auto column_reader = reader->column(segment0_field1_id);
-    ASSERT_NE(nullptr, column_reader);
-    auto column = column_reader->iterator(irs::ColumnHint::kNormal);
-    ASSERT_NE(nullptr, column);
-    auto* actual_value = irs::get<irs::payload>(*column);
-    ASSERT_NE(nullptr, actual_value);
-
-    // read compound column value
-    // check doc==0, column==field1
-    ASSERT_EQ(1, column->seek(1));
-    in.reset(actual_value->value);
-    ASSERT_EQ("field1_doc0", irs::read_string<std::string>(in));
-    ASSERT_EQ("field1_doc0_1", irs::read_string<std::string>(in));
-
-    ASSERT_EQ(12, column->seek(2));
-
-    // read overwritten compund value
-    // check doc==12, column==field1
-    ASSERT_EQ(12, column->seek(12));
-    in.reset(actual_value->value);
-    ASSERT_EQ("field1_doc12_1", irs::read_string<std::string>(in));
-    ASSERT_EQ("field1_doc12_2", irs::read_string<std::string>(in));
-
-    ASSERT_TRUE(irs::doc_limits::eof(column->seek(13)));
-  }
-
-  // visit empty column
-  {
-    size_t calls_count = 0;
-    auto visitor = [&calls_count](irs::doc_id_t /*doc*/,
-                                  const irs::bytes_view& /*in*/) {
-      ++calls_count;
-      return true;
-    };
-
-    auto column_reader = reader->column(segment0_empty_column_id);
-    ASSERT_NE(nullptr, column_reader);
-    ASSERT_TRUE(visit(*column_reader, visitor));
-    ASSERT_EQ(0, calls_count);
-  }
-
-  // iterate over empty column
-  {
-    auto column_reader = reader->column(segment0_empty_column_id);
-    ASSERT_NE(nullptr, column_reader);
-    auto it = column_reader->iterator(irs::ColumnHint::kNormal);
-    ASSERT_NE(nullptr, it);
-
-    ASSERT_TRUE(!irs::get<irs::payload>(*it));
-    ASSERT_EQ(irs::doc_limits::eof(), it->value());
-
-    ASSERT_FALSE(it->next());
-    ASSERT_EQ(irs::doc_limits::eof(), it->value());
-
-    ASSERT_FALSE(it->next());
-    ASSERT_EQ(irs::doc_limits::eof(), it->value());
-  }
-
-  // visit field2 values (field after an the field)
-  {
-    std::unordered_map<std::string_view, irs::doc_id_t> expected_values = {
-      {"field2_doc1", 1},
-    };
-
-    auto visitor = [&expected_values](irs::doc_id_t doc,
-                                      const irs::bytes_view& in) {
-      const auto actual_value = irs::to_string<std::string_view>(in.data());
-
-      auto it = expected_values.find(actual_value);
-      if (it == expected_values.end()) {
-        // can't find value
-        return false;
-      }
-
-      if (it->second != doc) {
-        // wrong document
-        return false;
-      }
-
-      expected_values.erase(it);
-      return true;
-    };
-
-    auto column_reader = reader->column(segment0_field2_id);
-    ASSERT_NE(nullptr, column_reader);
-    ASSERT_TRUE(visit(*column_reader, visitor));
-    ASSERT_TRUE(expected_values.empty());
-  }
-
-  // iterate over field2 values (not cached)
-  {
-    auto column_reader = reader->column(segment0_field2_id);
-    ASSERT_NE(nullptr, column_reader);
-    auto it = column_reader->iterator(irs::ColumnHint::kNormal);
-    ASSERT_NE(nullptr, it);
-
-    auto* payload = irs::get<irs::payload>(*it);
-    ASSERT_FALSE(!payload);
-    ASSERT_EQ(irs::doc_limits::invalid(), it->value());
-    ASSERT_EQ(irs::bytes_view{}, payload->value);
-
-    std::vector<std::pair<std::string_view, irs::doc_id_t>> expected_values = {
-      {"field2_doc1", 1}};
-
-    size_t i = 0;
-    for (; it->next(); ++i) {
-      const auto& expected_value = expected_values[i];
-      const auto actual_str_value =
-        irs::to_string<std::string_view>(payload->value.data());
-
-      ASSERT_EQ(expected_value.second, it->value());
-      ASSERT_EQ(expected_value.first, actual_str_value);
-    }
-
-    ASSERT_FALSE(it->next());
-    ASSERT_EQ(i, expected_values.size());
-    ASSERT_EQ(irs::doc_limits::eof(), it->value());
-    ASSERT_EQ(irs::bytes_view{}, payload->value);
-  }
-
-  // seek over field2 values (cached)
-  {
-    auto column_reader = reader->column(segment0_field2_id);
-    ASSERT_NE(nullptr, column_reader);
-    auto it = column_reader->iterator(irs::ColumnHint::kNormal);
-    ASSERT_NE(nullptr, it);
-
-    auto* payload = irs::get<irs::payload>(*it);
-    ASSERT_FALSE(!payload);
-    ASSERT_EQ(irs::doc_limits::invalid(), it->value());
-    ASSERT_EQ(irs::bytes_view{}, payload->value);
-
-    std::vector<
-      std::pair<std::string_view, std::pair<irs::doc_id_t, irs::doc_id_t>>>
-      expected_values = {{"field2_doc1", {1, 1}}};
-
-    for (auto& expected : expected_values) {
-      const auto expected_doc = expected.second.second;
-      const auto expected_value = expected.first;
-
-      ASSERT_EQ(expected_doc, it->seek(expected_doc));
-      const auto actual_str_value =
-        irs::to_string<std::string_view>(payload->value.data());
-      ASSERT_EQ(expected_value, actual_str_value);
-    }
-
-    ASSERT_FALSE(it->next());
-    ASSERT_EQ(irs::doc_limits::eof(), it->value());
-    ASSERT_EQ(irs::bytes_view{}, payload->value);
-  }
-}
-
-// read columns values from segment _2
-{
-  auto reader = codec()->get_columnstore_reader();
-  ASSERT_TRUE(reader->prepare(dir(), meta1));
-
-  // try to read invalild column
-  { ASSERT_EQ(nullptr, reader->column(irs::field_limits::invalid())); }
-
-  // iterate over field0 values (not cached)
-  {
-    auto column_reader = reader->column(segment1_field0_id);
-    ASSERT_NE(nullptr, column_reader);
-    auto it = column_reader->iterator(irs::ColumnHint::kNormal);
-    ASSERT_NE(nullptr, it);
-
-    auto* payload = irs::get<irs::payload>(*it);
-    ASSERT_FALSE(!payload);
-    ASSERT_EQ(irs::doc_limits::invalid(), it->value());
-    ASSERT_EQ(irs::bytes_view{}, payload->value);
-
-    std::vector<std::pair<std::string_view, irs::doc_id_t>> expected_values = {
-      {"segment_2_field1_doc0", 1}, {"segment_2_field1_doc12", 12}};
-
-    size_t i = 0;
-    for (; it->next(); ++i) {
-      const auto& expected_value = expected_values[i];
-      const auto actual_str_value =
-        irs::to_string<std::string_view>(payload->value.data());
-
-      ASSERT_EQ(expected_value.second, it->value());
-      ASSERT_EQ(expected_value.first, actual_str_value);
-    }
-
-    ASSERT_FALSE(it->next());
-    ASSERT_EQ(i, expected_values.size());
-    ASSERT_EQ(irs::doc_limits::eof(), it->value());
-    ASSERT_EQ(irs::bytes_view{}, payload->value);
-  }
-
-  // seek over field0 values (cached)
-  {
-    auto column_reader = reader->column(segment1_field0_id);
-    ASSERT_NE(nullptr, column_reader);
-    auto it = column_reader->iterator(irs::ColumnHint::kNormal);
-    ASSERT_NE(nullptr, it);
-
-    auto* payload = irs::get<irs::payload>(*it);
-    ASSERT_FALSE(!payload);
-    ASSERT_EQ(irs::doc_limits::invalid(), it->value());
-    ASSERT_EQ(irs::bytes_view{}, payload->value);
-
-    std::vector<
-      std::pair<std::string_view, std::pair<irs::doc_id_t, irs::doc_id_t>>>
-      expected_values = {{"segment_2_field1_doc0", {0, 1}},
-                         {"segment_2_field1_doc12", {12, 12}}};
-
-    for (auto& expected : expected_values) {
-      const auto expected_doc = expected.second.second;
-      const auto expected_value = expected.first;
-
-      ASSERT_EQ(expected_doc, it->seek(expected_doc));
-      const auto actual_str_value =
-        irs::to_string<std::string_view>(payload->value.data());
-      ASSERT_EQ(expected_value, actual_str_value);
-    }
-
-    ASSERT_EQ(irs::doc_limits::eof(), it->seek(13));
-    ASSERT_EQ(irs::bytes_view{}, payload->value);
-
-    ASSERT_FALSE(it->next());
-    ASSERT_EQ(irs::doc_limits::eof(), it->value());
-    ASSERT_EQ(irs::bytes_view{}, payload->value);
-  }
-
-  // check field0 (cached)
-  {
-    auto column_reader = reader->column(segment1_field0_id);
-    ASSERT_NE(nullptr, column_reader);
-    auto column = column_reader->iterator(irs::ColumnHint::kNormal);
-    ASSERT_NE(nullptr, column);
-    auto* actual_value = irs::get<irs::payload>(*column);
-    ASSERT_NE(nullptr, actual_value);
-    ASSERT_EQ(1, column->seek(1));  // check doc==1, column==field0
-    ASSERT_EQ("segment_2_field1_doc0",
-              irs::to_string<std::string_view>(actual_value->value.data()));
-    ASSERT_EQ(12, column->seek(12));  // check doc==12, column==field1
-    ASSERT_EQ("segment_2_field1_doc12",
-              irs::to_string<std::string_view>(actual_value->value.data()));
-  }
-
-  // iterate over field0 values (cached)
-  {
-    auto column_reader = reader->column(segment1_field0_id);
-    ASSERT_NE(nullptr, column_reader);
-    auto it = column_reader->iterator(irs::ColumnHint::kNormal);
-    ASSERT_NE(nullptr, it);
-
-    auto* payload = irs::get<irs::payload>(*it);
-    ASSERT_FALSE(!payload);
-    ASSERT_EQ(irs::doc_limits::invalid(), it->value());
-    ASSERT_EQ(irs::bytes_view{}, payload->value);
-
-    std::vector<std::pair<std::string_view, irs::doc_id_t>> expected_values = {
-      {"segment_2_field1_doc0", 1}, {"segment_2_field1_doc12", 12}};
-
-    size_t i = 0;
-    for (; it->next(); ++i) {
-      const auto& expected_value = expected_values[i];
-      const auto actual_str_value =
-        irs::to_string<std::string_view>(payload->value.data());
-
-      ASSERT_EQ(expected_value.second, it->value());
-      ASSERT_EQ(expected_value.first, actual_str_value);
-    }
-
-    ASSERT_FALSE(it->next());
-    ASSERT_EQ(i, expected_values.size());
-    ASSERT_EQ(irs::doc_limits::eof(), it->value());
-    ASSERT_EQ(irs::bytes_view{}, payload->value);
-  }
-}
 }
 
 TEST_P(format_test_case, document_mask_rw) {
@@ -3580,13 +3601,14 @@ TEST_P(format_test_case_with_encryption,
 
     const std::set<irs::type_info::type_id> features;
 
-    irs::flush_state state;
-    state.dir = &dir();
-    state.docmap = nullptr;
-    state.features = &features;
-    state.name = meta.name;
-    state.doc_count = 3;
-    state.index_features = irs::IndexFeatures::NONE;
+    irs::flush_state state{
+      .dir = &dir(),
+      .docmap = nullptr,
+      .features = &features,
+      .name = meta.name,
+      .doc_count = 3,
+      .index_features = irs::IndexFeatures::NONE,
+    };
 
     writer->commit(state);
   }
@@ -3673,11 +3695,12 @@ TEST_P(format_test_case_with_encryption, fields_read_write_wrong_encryption) {
   {
     const irs::feature_set_t features{irs::type<irs::Norm>::id()};
 
-    irs::flush_state state;
-    state.dir = &dir();
-    state.doc_count = 100;
-    state.name = "segment_name";
-    state.features = &features;
+    irs::flush_state state{
+      .dir = &dir(),
+      .features = &features,
+      .name = "segment_name",
+      .doc_count = 100,
+    };
 
     // should use sorted terms on write
     tests::format_test_case::terms<sorted_terms_t::iterator> terms(
@@ -3832,4 +3855,4 @@ TEST_P(format_test_case_with_encryption, open_non_ecnrypted_with_encrypted) {
     ASSERT_TRUE(expectedName.empty());
   }
 }
-}
+}  // namespace tests

--- a/tests/formats/formats_test_case_base.cpp
+++ b/tests/formats/formats_test_case_base.cpp
@@ -199,10 +199,10 @@ auto MakeByTerm(std::string_view name, std::string_view value) {
 TEST_P(format_test_case, directory_artifact_cleaner) {
   tests::json_doc_generator gen{resource("simple_sequential.json"),
                                 &tests::generic_json_field_factory};
-  tests::document const* doc1 = gen.next();
-  tests::document const* doc2 = gen.next();
-  tests::document const* doc3 = gen.next();
-  tests::document const* doc4 = gen.next();
+  const tests::document* doc1 = gen.next();
+  const tests::document* doc2 = gen.next();
+  const tests::document* doc3 = gen.next();
+  const tests::document* doc4 = gen.next();
   auto query_doc1 = MakeByTerm("name", "A");
   auto query_doc2 = MakeByTerm("name", "B");
   auto query_doc3 = MakeByTerm("name", "C");
@@ -2754,8 +2754,8 @@ TEST_P(format_test_case, columns_rw) {
       {
         auto& stream = field2_writer(1);  // doc==1
         irs::write_string(stream, std::string_view("invalid_string"));
-        stream.reset();                   // rollback changes
-        stream.reset();                   // rollback changes
+        stream.reset();  // rollback changes
+        stream.reset();  // rollback changes
       }
       {
         auto& stream = field2_writer(1);  // doc==1
@@ -2846,7 +2846,7 @@ TEST_P(format_test_case, columns_rw) {
     {
       auto& stream = field2_writer(2);  // doc==2
       irs::write_string(stream, std::string_view("segment_2_field0_doc1"));
-      stream.reset();                   // rollback
+      stream.reset();  // rollback
     }
 
     // colum==field1
@@ -2859,7 +2859,7 @@ TEST_P(format_test_case, columns_rw) {
     {
       auto& stream = field2_writer(23);  // doc==23
       irs::write_string(stream, std::string_view("segment_2_field3_doc23"));
-      stream.reset();                    // rollback
+      stream.reset();  // rollback
     }
 
     irs::flush_state state{
@@ -3635,7 +3635,7 @@ TEST_P(format_test_case_with_encryption, read_zero_block_encryption) {
   tests::json_doc_generator gen(resource("simple_sequential.json"),
                                 &tests::generic_json_field_factory);
 
-  tests::document const* doc1 = gen.next();
+  const tests::document* doc1 = gen.next();
 
   // replace encryption
   ASSERT_NE(nullptr, dir().attributes().encryption());
@@ -3738,7 +3738,7 @@ TEST_P(format_test_case_with_encryption, open_ecnrypted_with_wrong_encryption) {
   tests::json_doc_generator gen(resource("simple_sequential.json"),
                                 &tests::generic_json_field_factory);
 
-  tests::document const* doc1 = gen.next();
+  const tests::document* doc1 = gen.next();
 
   ASSERT_NE(nullptr, dir().attributes().encryption());
 
@@ -3767,7 +3767,7 @@ TEST_P(format_test_case_with_encryption, open_ecnrypted_with_non_encrypted) {
   tests::json_doc_generator gen(resource("simple_sequential.json"),
                                 &tests::generic_json_field_factory);
 
-  tests::document const* doc1 = gen.next();
+  const tests::document* doc1 = gen.next();
 
   ASSERT_NE(nullptr, dir().attributes().encryption());
 
@@ -3797,7 +3797,7 @@ TEST_P(format_test_case_with_encryption, open_non_ecnrypted_with_encrypted) {
   tests::json_doc_generator gen(resource("simple_sequential.json"),
                                 &tests::generic_json_field_factory);
 
-  tests::document const* doc1 = gen.next();
+  const tests::document* doc1 = gen.next();
 
   dir().attributes() = irs::directory_attributes{0, nullptr};
 

--- a/tests/index/index_tests.cpp
+++ b/tests/index/index_tests.cpp
@@ -1015,7 +1015,7 @@ class index_test_case : public tests::index_test_base {
       auto writer = irs::IndexWriter::Make(dir(), codec(), irs::OM_CREATE);
       ASSERT_TRUE(insert(*writer, doc2->indexed.begin(), doc2->indexed.end(),
                          doc2->stored.begin(), doc2->stored.end()));
-      ASSERT_TRUE(writer->Begin());     // prepare for commit tx #1
+      ASSERT_TRUE(writer->Begin());  // prepare for commit tx #1
       writer->Commit();
       AssertSnapshotEquality(*writer);  // commit tx #1
       auto file_count = 0;
@@ -2608,7 +2608,7 @@ TEST_P(index_test_case, writer_begin_clear) {
     ASSERT_TRUE(writer->Begin());  // start transaction
     ASSERT_EQ(0, writer->BufferedDocs());
 
-    writer->Clear();                // rollback and clear index contents
+    writer->Clear();  // rollback and clear index contents
     ASSERT_EQ(0, writer->BufferedDocs());
     ASSERT_FALSE(writer->Begin());  // nothing to commit
 
@@ -2671,7 +2671,7 @@ TEST_P(index_test_case, writer_commit_clear) {
       ASSERT_NE(reader.begin(), reader.end());
     }
 
-    writer->Clear();                // clear index contents
+    writer->Clear();  // clear index contents
     ASSERT_EQ(0, writer->BufferedDocs());
     ASSERT_FALSE(writer->Begin());  // nothing to commit
 
@@ -7519,8 +7519,8 @@ TEST_P(index_test_case, consolidate_single_segment) {
     ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
       irs::index_utils::ConsolidateCount())));  // nothing to consolidate
     ASSERT_TRUE(writer->Consolidate(
-      check_consolidating_segments));           // check segments registered for
-                                                // consolidation
+      check_consolidating_segments));  // check segments registered for
+                                       // consolidation
     writer->Commit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(0, irs::directory_cleaner::clean(dir()));
@@ -7737,7 +7737,7 @@ TEST_P(index_test_case, segment_consolidate_long_running) {
     AssertSnapshotEquality(*writer);                   // commit transaction
     ASSERT_EQ(1, irs::directory_cleaner::clean(dir));  // segments_3
 
-    dir.intermediate_commits_lock.unlock();            // finish consolidation
+    dir.intermediate_commits_lock.unlock();  // finish consolidation
     consolidation_thread.join();  // wait for the consolidation to complete
 
     // finished consolidation holds a reference to segments_3
@@ -7913,14 +7913,14 @@ TEST_P(index_test_case, segment_consolidate_long_running) {
     AssertSnapshotEquality(*writer);                   // commit transaction
     ASSERT_EQ(1, irs::directory_cleaner::clean(dir));  // segments_3
 
-    dir.intermediate_commits_lock.unlock();            // finish consolidation
+    dir.intermediate_commits_lock.unlock();  // finish consolidation
     consolidation_thread.join();  // wait for the consolidation to complete
     ASSERT_EQ(2 * count - 1 + 1,
               irs::directory_cleaner::clean(
                 dir));  // files from segment 1 and 3 (without segment meta)
                         // + segments_3
     writer->Commit();
-    AssertSnapshotEquality(*writer);                // commit consolidation
+    AssertSnapshotEquality(*writer);  // commit consolidation
     ASSERT_EQ(0,
               irs::directory_cleaner::clean(dir));  // consolidation failed
 
@@ -8414,7 +8414,7 @@ TEST_P(index_test_case, segment_consolidate_clear_commit) {
     ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
       irs::index_utils::ConsolidateCount())));  // consolidate
     writer->Commit();
-    AssertSnapshotEquality(*writer);            // commit transaction
+    AssertSnapshotEquality(*writer);  // commit transaction
 
     auto reader = irs::DirectoryReader(dir(), codec());
     ASSERT_EQ(0, reader.size());
@@ -8614,7 +8614,7 @@ TEST_P(index_test_case, segment_consolidate_commit) {
 
     writer->Commit();
     AssertSnapshotEquality(
-      *writer);                      // commit transaction (will commit nothing)
+      *writer);  // commit transaction (will commit nothing)
     ASSERT_EQ(1 + count, irs::directory_cleaner::clean(
                            dir()));  // +1 for corresponding segments_* file
     ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
@@ -8815,7 +8815,7 @@ TEST_P(index_test_case, segment_consolidate_commit) {
 
     ASSERT_EQ(0, irs::directory_cleaner::clean(dir()));  // segments_1
     ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-      irs::index_utils::ConsolidateCount())));           // consolidate
+      irs::index_utils::ConsolidateCount())));  // consolidate
 
     // check consolidating segments
     expected_consolidating_segments = {0, 1};
@@ -9288,7 +9288,7 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
     ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
 
     writer->Commit();
-    AssertSnapshotEquality(*writer);                  // commit pending merge
+    AssertSnapshotEquality(*writer);  // commit pending merge
     ASSERT_EQ(1 + 1 + count,
               irs::directory_cleaner::clean(dir()));  // segments_2
 
@@ -9626,7 +9626,7 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
     AssertSnapshotEquality(*writer);  // commit pending merge
     ASSERT_EQ(count + 2 + 2,  // +2 for  segments_2 + stale segment 1 meta
               irs::directory_cleaner::clean(
-                dir()));      // +1 for segments, +1 for segment 1 doc mask
+                dir()));  // +1 for segments, +1 for segment 1 doc mask
 
     // check consolidating segments
     expected_consolidating_segments = {};
@@ -9951,7 +9951,7 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
         auto& segment = reader[0];
         const auto* column = segment.column("name");
         ASSERT_NE(nullptr, column);
-        ASSERT_EQ(4, segment.docs_count());    // total count of documents
+        ASSERT_EQ(4, segment.docs_count());  // total count of documents
         ASSERT_EQ(2,
                   segment.live_docs_count());  // total count of live documents
         auto terms = segment.field("same");
@@ -13782,7 +13782,7 @@ TEST_P(index_test_case, segment_consolidate_policy) {
     {
       std::unordered_set<std::string_view> expectedName = {"A", "B", "C", "D"};
 
-      auto& segment = reader[0];        // assume 0 is id of first segment
+      auto& segment = reader[0];  // assume 0 is id of first segment
       ASSERT_EQ(expectedName.size(),
                 segment.docs_count());  // total count of documents
       auto terms = segment.field("same");
@@ -13809,7 +13809,7 @@ TEST_P(index_test_case, segment_consolidate_policy) {
     {
       std::unordered_set<std::string_view> expectedName = {"E"};
 
-      auto& segment = reader[1];        // assume 1 is id of second segment
+      auto& segment = reader[1];  // assume 1 is id of second segment
       ASSERT_EQ(expectedName.size(),
                 segment.docs_count());  // total count of documents
       auto terms = segment.field("same");
@@ -13859,7 +13859,7 @@ TEST_P(index_test_case, segment_consolidate_policy) {
 
     auto reader = irs::DirectoryReader(dir(), codec());
     ASSERT_EQ(1, reader.size());
-    auto& segment = reader[0];        // assume 0 is id of first/only segment
+    auto& segment = reader[0];  // assume 0 is id of first/only segment
     ASSERT_EQ(expectedName.size(),
               segment.docs_count());  // total count of documents
     auto terms = segment.field("same");
@@ -13908,7 +13908,7 @@ TEST_P(index_test_case, segment_consolidate_policy) {
     {
       std::unordered_set<std::string_view> expectedName = {"A"};
 
-      auto& segment = reader[0];        // assume 0 is id of first segment
+      auto& segment = reader[0];  // assume 0 is id of first segment
       ASSERT_EQ(expectedName.size(),
                 segment.docs_count());  // total count of documents
       auto terms = segment.field("same");
@@ -13991,7 +13991,7 @@ TEST_P(index_test_case, segment_consolidate_policy) {
 
     auto reader = irs::DirectoryReader(dir(), codec());
     ASSERT_EQ(1, reader.size());
-    auto& segment = reader[0];        // assume 0 is id of first/only segment
+    auto& segment = reader[0];  // assume 0 is id of first/only segment
     ASSERT_EQ(expectedName.size(),
               segment.docs_count());  // total count of documents
     auto terms = segment.field("same");
@@ -14049,7 +14049,7 @@ TEST_P(index_test_case, segment_consolidate_policy) {
     {
       std::unordered_set<std::string_view> expectedName = {"A"};
 
-      auto& segment = reader[0];        // assume 0 is id of first segment
+      auto& segment = reader[0];  // assume 0 is id of first segment
       ASSERT_EQ(expectedName.size() + 3,
                 segment.docs_count());  // total count of documents (+3 ==
                                         // B, C, D masked)
@@ -14078,7 +14078,7 @@ TEST_P(index_test_case, segment_consolidate_policy) {
     {
       std::unordered_set<std::string_view> expectedName = {"E"};
 
-      auto& segment = reader[1];        // assume 1 is id of second segment
+      auto& segment = reader[1];  // assume 1 is id of second segment
       ASSERT_EQ(expectedName.size(),
                 segment.docs_count());  // total count of documents
       auto terms = segment.field("same");
@@ -14134,7 +14134,7 @@ TEST_P(index_test_case, segment_consolidate_policy) {
 
     auto reader = irs::DirectoryReader(dir(), codec());
     ASSERT_EQ(1, reader.size());
-    auto& segment = reader[0];        // assume 0 is id of first/only segment
+    auto& segment = reader[0];  // assume 0 is id of first/only segment
     ASSERT_EQ(expectedName.size(),
               segment.docs_count());  // total count of documents
     auto terms = segment.field("same");

--- a/tests/index/index_tests.cpp
+++ b/tests/index/index_tests.cpp
@@ -32,6 +32,7 @@
 #include "index/norm.hpp"
 #include "search/boolean_filter.hpp"
 #include "search/term_filter.hpp"
+#include "store/fs_directory.hpp"
 #include "store/memory_directory.hpp"
 #include "tests_shared.hpp"
 #include "utils/delta_compression.hpp"
@@ -310,12 +311,12 @@ class index_test_case : public tests::index_test_base {
         }
       });
 
-    tests::document const* doc1 = gen.next();
-    tests::document const* doc2 = gen.next();
-    tests::document const* doc3 = gen.next();
-    tests::document const* doc4 = gen.next();
-    tests::document const* doc5 = gen.next();
-    tests::document const* doc6 = gen.next();
+    const tests::document* doc1 = gen.next();
+    const tests::document* doc2 = gen.next();
+    const tests::document* doc3 = gen.next();
+    const tests::document* doc4 = gen.next();
+    const tests::document* doc5 = gen.next();
+    const tests::document* doc6 = gen.next();
 
     // test import/insert/deletes/existing all empty after clear
     {
@@ -827,7 +828,7 @@ class index_test_case : public tests::index_test_base {
       auto writer = irs::IndexWriter::Make(dir(), codec(), irs::OM_APPEND);
       tests::json_doc_generator gen(resource("simple_sequential.json"),
                                     &tests::generic_json_field_factory);
-      tests::document const* doc1 = gen.next();
+      const tests::document* doc1 = gen.next();
       ASSERT_EQ(0, writer->BufferedDocs());
       ASSERT_TRUE(insert(*writer, doc1->indexed.begin(), doc1->indexed.end(),
                          doc1->stored.begin(), doc1->stored.end()));
@@ -852,7 +853,7 @@ class index_test_case : public tests::index_test_base {
         irs::IndexWriter::Make(dir(), codec(), irs::OM_APPEND | irs::OM_CREATE);
       tests::json_doc_generator gen(resource("simple_sequential.json"),
                                     &tests::generic_json_field_factory);
-      tests::document const* doc1 = gen.next();
+      const tests::document* doc1 = gen.next();
       ASSERT_EQ(0, writer->BufferedDocs());
       ASSERT_TRUE(insert(*writer, doc1->indexed.begin(), doc1->indexed.end(),
                          doc1->stored.begin(), doc1->stored.end()));
@@ -881,8 +882,8 @@ class index_test_case : public tests::index_test_base {
           doc.insert(std::make_shared<tests::string_field>(name, data.str));
         }
       });
-    tests::document const* doc1 = gen.next();
-    tests::document const* doc2 = gen.next();
+    const tests::document* doc1 = gen.next();
+    const tests::document* doc2 = gen.next();
 
     auto writer = irs::IndexWriter::Make(dir(), codec(), irs::OM_CREATE);
 
@@ -974,9 +975,9 @@ class index_test_case : public tests::index_test_base {
     tests::json_doc_generator gen(resource("simple_sequential.json"),
                                   &tests::generic_json_field_factory);
 
-    tests::document const* doc1 = gen.next();
-    tests::document const* doc2 = gen.next();
-    tests::document const* doc3 = gen.next();
+    const tests::document* doc1 = gen.next();
+    const tests::document* doc2 = gen.next();
+    const tests::document* doc3 = gen.next();
 
     {
       auto writer = irs::IndexWriter::Make(dir(), codec(), irs::OM_CREATE);
@@ -1014,7 +1015,7 @@ class index_test_case : public tests::index_test_base {
       auto writer = irs::IndexWriter::Make(dir(), codec(), irs::OM_CREATE);
       ASSERT_TRUE(insert(*writer, doc2->indexed.begin(), doc2->indexed.end(),
                          doc2->stored.begin(), doc2->stored.end()));
-      ASSERT_TRUE(writer->Begin());  // prepare for commit tx #1
+      ASSERT_TRUE(writer->Begin());     // prepare for commit tx #1
       writer->Commit();
       AssertSnapshotEquality(*writer);  // commit tx #1
       auto file_count = 0;
@@ -2191,10 +2192,10 @@ class index_test_case : public tests::index_test_base {
 
       tests::json_doc_generator gen(resource("simple_sequential.json"),
                                     &tests::generic_json_field_factory);
-      tests::document const* doc1 = gen.next();
-      tests::document const* doc2 = gen.next();
-      tests::document const* doc3 = gen.next();
-      tests::document const* doc4 = gen.next();
+      const tests::document* doc1 = gen.next();
+      const tests::document* doc2 = gen.next();
+      const tests::document* doc3 = gen.next();
+      const tests::document* doc4 = gen.next();
 
       auto writer =
         irs::IndexWriter::Make(override_dir, codec(), irs::OM_APPEND);
@@ -2222,10 +2223,10 @@ class index_test_case : public tests::index_test_base {
 
       tests::json_doc_generator gen(resource("simple_sequential.json"),
                                     &tests::generic_json_field_factory);
-      tests::document const* doc1 = gen.next();
-      tests::document const* doc2 = gen.next();
-      tests::document const* doc3 = gen.next();
-      tests::document const* doc4 = gen.next();
+      const tests::document* doc1 = gen.next();
+      const tests::document* doc2 = gen.next();
+      const tests::document* doc3 = gen.next();
+      const tests::document* doc4 = gen.next();
 
       auto writer =
         irs::IndexWriter::Make(override_dir, codec(), irs::OM_APPEND);
@@ -2461,8 +2462,8 @@ TEST_P(index_test_case, s2sequence) {
 TEST_P(index_test_case, reopen_reader_after_writer_is_closed) {
   tests::json_doc_generator gen(resource("simple_sequential.json"),
                                 &tests::generic_json_field_factory);
-  tests::document const* doc1 = gen.next();
-  tests::document const* doc2 = gen.next();
+  const tests::document* doc1 = gen.next();
+  const tests::document* doc2 = gen.next();
 
   irs::DirectoryReader reader0;
   irs::DirectoryReader reader1;
@@ -2553,7 +2554,7 @@ TEST_P(index_test_case, writer_begin_clear_empty_index) {
   tests::json_doc_generator gen(resource("simple_sequential.json"),
                                 &tests::generic_json_field_factory);
 
-  tests::document const* doc1 = gen.next();
+  const tests::document* doc1 = gen.next();
 
   {
     auto writer = irs::IndexWriter::Make(dir(), codec(), irs::OM_CREATE);
@@ -2580,7 +2581,7 @@ TEST_P(index_test_case, writer_begin_clear) {
   tests::json_doc_generator gen(resource("simple_sequential.json"),
                                 &tests::generic_json_field_factory);
 
-  tests::document const* doc1 = gen.next();
+  const tests::document* doc1 = gen.next();
 
   {
     auto writer = irs::IndexWriter::Make(dir(), codec(), irs::OM_CREATE);
@@ -2607,7 +2608,7 @@ TEST_P(index_test_case, writer_begin_clear) {
     ASSERT_TRUE(writer->Begin());  // start transaction
     ASSERT_EQ(0, writer->BufferedDocs());
 
-    writer->Clear();  // rollback and clear index contents
+    writer->Clear();                // rollback and clear index contents
     ASSERT_EQ(0, writer->BufferedDocs());
     ASSERT_FALSE(writer->Begin());  // nothing to commit
 
@@ -2649,7 +2650,7 @@ TEST_P(index_test_case, writer_commit_clear) {
   tests::json_doc_generator gen(resource("simple_sequential.json"),
                                 &tests::generic_json_field_factory);
 
-  tests::document const* doc1 = gen.next();
+  const tests::document* doc1 = gen.next();
 
   {
     auto writer = irs::IndexWriter::Make(dir(), codec(), irs::OM_CREATE);
@@ -2670,7 +2671,7 @@ TEST_P(index_test_case, writer_commit_clear) {
       ASSERT_NE(reader.begin(), reader.end());
     }
 
-    writer->Clear();  // clear index contents
+    writer->Clear();                // clear index contents
     ASSERT_EQ(0, writer->BufferedDocs());
     ASSERT_FALSE(writer->Begin());  // nothing to commit
 
@@ -2728,6 +2729,9 @@ TEST_P(index_test_case, europarl_docs_automaton) {
 }
 
 TEST_P(index_test_case, europarl_docs_big) {
+  if (dynamic_cast<irs::FSDirectory*>(&dir()) != nullptr) {
+    GTEST_SKIP() << "too long for our CI";
+  }
   {
     tests::europarl_doc_template doc;
     tests::delim_doc_generator gen(resource("europarl.subset.big.txt"), doc);
@@ -2736,18 +2740,11 @@ TEST_P(index_test_case, europarl_docs_big) {
   assert_index();
 }
 
-#ifndef IRESEARCH_DEBUG
-
-// TEST_P(index_test_case, europarl_docs_big) {
-//   {
-//     tests::europarl_doc_template doc;
-//     tests::delim_doc_generator gen(resource("europarl.subset.big.txt"), doc);
-//     add_segment(gen);
-//   }
-//   assert_index();
-// }
-
 TEST_P(index_test_case, europarl_docs_big_automaton) {
+#ifdef IRESEARCH_DEBUG
+  GTEST_SKIP() << "too long for our CI";
+#endif
+
   {
     tests::europarl_doc_template doc;
     tests::delim_doc_generator gen(resource("europarl.subset.txt"), doc);
@@ -2775,8 +2772,6 @@ TEST_P(index_test_case, europarl_docs_big_automaton) {
     assert_index(0, &matcher);
   }
 }
-
-#endif
 
 TEST_P(index_test_case, docs_bit_union) {
   docs_bit_union(irs::IndexFeatures::NONE);
@@ -2940,8 +2935,8 @@ TEST_P(index_test_case, concurrent_add_remove_overlap_commit_mt) {
       }
     });
 
-  tests::document const* doc1 = gen.next();
-  tests::document const* doc2 = gen.next();
+  const tests::document* doc1 = gen.next();
+  const tests::document* doc2 = gen.next();
 
   // remove added docs, add same docs again commit separate thread before end of
   // add
@@ -3078,10 +3073,10 @@ TEST_P(index_test_case, document_context) {
       }
     });
 
-  tests::document const* doc1 = gen.next();
-  tests::document const* doc2 = gen.next();
-  tests::document const* doc3 = gen.next();
-  tests::document const* doc4 = gen.next();
+  const tests::document* doc1 = gen.next();
+  const tests::document* doc2 = gen.next();
+  const tests::document* doc3 = gen.next();
+  const tests::document* doc4 = gen.next();
 
   struct {
     std::condition_variable cond;
@@ -4615,15 +4610,15 @@ TEST_P(index_test_case, doc_removal) {
       }
     });
 
-  tests::document const* doc1 = gen.next();
-  tests::document const* doc2 = gen.next();
-  tests::document const* doc3 = gen.next();
-  tests::document const* doc4 = gen.next();
-  tests::document const* doc5 = gen.next();
-  tests::document const* doc6 = gen.next();
-  tests::document const* doc7 = gen.next();
-  tests::document const* doc8 = gen.next();
-  tests::document const* doc9 = gen.next();
+  const tests::document* doc1 = gen.next();
+  const tests::document* doc2 = gen.next();
+  const tests::document* doc3 = gen.next();
+  const tests::document* doc4 = gen.next();
+  const tests::document* doc5 = gen.next();
+  const tests::document* doc6 = gen.next();
+  const tests::document* doc7 = gen.next();
+  const tests::document* doc8 = gen.next();
+  const tests::document* doc9 = gen.next();
 
   // new segment: add
   {
@@ -5169,10 +5164,10 @@ TEST_P(index_test_case, doc_update) {
       }
     });
 
-  tests::document const* doc1 = gen.next();
-  tests::document const* doc2 = gen.next();
-  tests::document const* doc3 = gen.next();
-  tests::document const* doc4 = gen.next();
+  const tests::document* doc1 = gen.next();
+  const tests::document* doc2 = gen.next();
+  const tests::document* doc3 = gen.next();
+  const tests::document* doc4 = gen.next();
 
   // new segment update (as reference)
   {
@@ -5860,10 +5855,10 @@ TEST_P(index_test_case, import_reader) {
       }
     });
 
-  tests::document const* doc1 = gen.next();
-  tests::document const* doc2 = gen.next();
-  tests::document const* doc3 = gen.next();
-  tests::document const* doc4 = gen.next();
+  const tests::document* doc1 = gen.next();
+  const tests::document* doc2 = gen.next();
+  const tests::document* doc3 = gen.next();
+  const tests::document* doc4 = gen.next();
 
   // add a reader with 1 segment no docs
   {
@@ -6293,10 +6288,10 @@ TEST_P(index_test_case, refresh_reader) {
       }
     });
 
-  tests::document const* doc1 = gen.next();
-  tests::document const* doc2 = gen.next();
-  tests::document const* doc3 = gen.next();
-  tests::document const* doc4 = gen.next();
+  const tests::document* doc1 = gen.next();
+  const tests::document* doc2 = gen.next();
+  const tests::document* doc3 = gen.next();
+  const tests::document* doc4 = gen.next();
 
   // initial state (1st segment 2 docs)
   {
@@ -6686,8 +6681,8 @@ TEST_P(index_test_case, segment_column_user_system) {
                 true, false);
   }
 
-  tests::document const* doc1 = gen.next();
-  tests::document const* doc2 = gen.next();
+  const tests::document* doc1 = gen.next();
+  const tests::document* doc2 = gen.next();
 
   irs::IndexWriterOptions opts;
   opts.features = features_with_norms();
@@ -7426,7 +7421,7 @@ TEST_P(index_test_case, consolidate_invalid_candidate) {
       }
     });
 
-  tests::document const* doc1 = gen.next();
+  const tests::document* doc1 = gen.next();
 
   // segment 1
   ASSERT_TRUE(insert(*writer, doc1->indexed.begin(), doc1->indexed.end(),
@@ -7487,8 +7482,8 @@ TEST_P(index_test_case, consolidate_single_segment) {
       }
     });
 
-  tests::document const* doc1 = gen.next();
-  tests::document const* doc2 = gen.next();
+  const tests::document* doc1 = gen.next();
+  const tests::document* doc2 = gen.next();
 
   constexpr irs::IndexFeatures all_features =
     irs::IndexFeatures::FREQ | irs::IndexFeatures::POS |
@@ -7524,8 +7519,8 @@ TEST_P(index_test_case, consolidate_single_segment) {
     ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
       irs::index_utils::ConsolidateCount())));  // nothing to consolidate
     ASSERT_TRUE(writer->Consolidate(
-      check_consolidating_segments));  // check segments registered for
-                                       // consolidation
+      check_consolidating_segments));           // check segments registered for
+                                                // consolidation
     writer->Commit();
     AssertSnapshotEquality(*writer);
     ASSERT_EQ(0, irs::directory_cleaner::clean(dir()));
@@ -7639,10 +7634,10 @@ TEST_P(index_test_case, segment_consolidate_long_running) {
       }
     });
 
-  tests::document const* doc1 = gen.next();
-  tests::document const* doc2 = gen.next();
-  tests::document const* doc3 = gen.next();
-  tests::document const* doc4 = gen.next();
+  const tests::document* doc1 = gen.next();
+  const tests::document* doc2 = gen.next();
+  const tests::document* doc3 = gen.next();
+  const tests::document* doc4 = gen.next();
 
   constexpr irs::IndexFeatures all_features =
     irs::IndexFeatures::FREQ | irs::IndexFeatures::POS |
@@ -7742,7 +7737,7 @@ TEST_P(index_test_case, segment_consolidate_long_running) {
     AssertSnapshotEquality(*writer);                   // commit transaction
     ASSERT_EQ(1, irs::directory_cleaner::clean(dir));  // segments_3
 
-    dir.intermediate_commits_lock.unlock();  // finish consolidation
+    dir.intermediate_commits_lock.unlock();            // finish consolidation
     consolidation_thread.join();  // wait for the consolidation to complete
 
     // finished consolidation holds a reference to segments_3
@@ -7918,14 +7913,14 @@ TEST_P(index_test_case, segment_consolidate_long_running) {
     AssertSnapshotEquality(*writer);                   // commit transaction
     ASSERT_EQ(1, irs::directory_cleaner::clean(dir));  // segments_3
 
-    dir.intermediate_commits_lock.unlock();  // finish consolidation
+    dir.intermediate_commits_lock.unlock();            // finish consolidation
     consolidation_thread.join();  // wait for the consolidation to complete
     ASSERT_EQ(2 * count - 1 + 1,
               irs::directory_cleaner::clean(
                 dir));  // files from segment 1 and 3 (without segment meta)
                         // + segments_3
     writer->Commit();
-    AssertSnapshotEquality(*writer);  // commit consolidation
+    AssertSnapshotEquality(*writer);                // commit consolidation
     ASSERT_EQ(0,
               irs::directory_cleaner::clean(dir));  // consolidation failed
 
@@ -8389,9 +8384,9 @@ TEST_P(index_test_case, segment_consolidate_clear_commit) {
       }
     });
 
-  tests::document const* doc1 = gen.next();
-  tests::document const* doc2 = gen.next();
-  tests::document const* doc3 = gen.next();
+  const tests::document* doc1 = gen.next();
+  const tests::document* doc2 = gen.next();
+  const tests::document* doc3 = gen.next();
 
   // 2-phase: clear + consolidate
   {
@@ -8419,7 +8414,7 @@ TEST_P(index_test_case, segment_consolidate_clear_commit) {
     ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
       irs::index_utils::ConsolidateCount())));  // consolidate
     writer->Commit();
-    AssertSnapshotEquality(*writer);  // commit transaction
+    AssertSnapshotEquality(*writer);            // commit transaction
 
     auto reader = irs::DirectoryReader(dir(), codec());
     ASSERT_EQ(0, reader.size());
@@ -8558,11 +8553,11 @@ TEST_P(index_test_case, segment_consolidate_commit) {
       }
     });
 
-  tests::document const* doc1 = gen.next();
-  tests::document const* doc2 = gen.next();
-  tests::document const* doc3 = gen.next();
-  tests::document const* doc4 = gen.next();
-  tests::document const* doc5 = gen.next();
+  const tests::document* doc1 = gen.next();
+  const tests::document* doc2 = gen.next();
+  const tests::document* doc3 = gen.next();
+  const tests::document* doc4 = gen.next();
+  const tests::document* doc5 = gen.next();
 
   constexpr irs::IndexFeatures all_features =
     irs::IndexFeatures::FREQ | irs::IndexFeatures::POS |
@@ -8619,7 +8614,7 @@ TEST_P(index_test_case, segment_consolidate_commit) {
 
     writer->Commit();
     AssertSnapshotEquality(
-      *writer);  // commit transaction (will commit nothing)
+      *writer);                      // commit transaction (will commit nothing)
     ASSERT_EQ(1 + count, irs::directory_cleaner::clean(
                            dir()));  // +1 for corresponding segments_* file
     ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
@@ -8820,7 +8815,7 @@ TEST_P(index_test_case, segment_consolidate_commit) {
 
     ASSERT_EQ(0, irs::directory_cleaner::clean(dir()));  // segments_1
     ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-      irs::index_utils::ConsolidateCount())));  // consolidate
+      irs::index_utils::ConsolidateCount())));           // consolidate
 
     // check consolidating segments
     expected_consolidating_segments = {0, 1};
@@ -9104,12 +9099,12 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
       }
     });
 
-  tests::document const* doc1 = gen.next();
-  tests::document const* doc2 = gen.next();
-  tests::document const* doc3 = gen.next();
-  tests::document const* doc4 = gen.next();
-  tests::document const* doc5 = gen.next();
-  tests::document const* doc6 = gen.next();
+  const tests::document* doc1 = gen.next();
+  const tests::document* doc2 = gen.next();
+  const tests::document* doc3 = gen.next();
+  const tests::document* doc4 = gen.next();
+  const tests::document* doc5 = gen.next();
+  const tests::document* doc6 = gen.next();
 
   constexpr irs::IndexFeatures all_features =
     irs::IndexFeatures::FREQ | irs::IndexFeatures::POS |
@@ -9293,7 +9288,7 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
     ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
 
     writer->Commit();
-    AssertSnapshotEquality(*writer);  // commit pending merge
+    AssertSnapshotEquality(*writer);                  // commit pending merge
     ASSERT_EQ(1 + 1 + count,
               irs::directory_cleaner::clean(dir()));  // segments_2
 
@@ -9631,7 +9626,7 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
     AssertSnapshotEquality(*writer);  // commit pending merge
     ASSERT_EQ(count + 2 + 2,  // +2 for  segments_2 + stale segment 1 meta
               irs::directory_cleaner::clean(
-                dir()));  // +1 for segments, +1 for segment 1 doc mask
+                dir()));      // +1 for segments, +1 for segment 1 doc mask
 
     // check consolidating segments
     expected_consolidating_segments = {};
@@ -9956,7 +9951,7 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
         auto& segment = reader[0];
         const auto* column = segment.column("name");
         ASSERT_NE(nullptr, column);
-        ASSERT_EQ(4, segment.docs_count());  // total count of documents
+        ASSERT_EQ(4, segment.docs_count());    // total count of documents
         ASSERT_EQ(2,
                   segment.live_docs_count());  // total count of live documents
         auto terms = segment.field("same");
@@ -12775,12 +12770,12 @@ TEST_P(index_test_case, segment_consolidate) {
       }
     });
 
-  tests::document const* doc1 = gen.next();
-  tests::document const* doc2 = gen.next();
-  tests::document const* doc3 = gen.next();
-  tests::document const* doc4 = gen.next();
-  tests::document const* doc5 = gen.next();
-  tests::document const* doc6 = gen.next();
+  const tests::document* doc1 = gen.next();
+  const tests::document* doc2 = gen.next();
+  const tests::document* doc3 = gen.next();
+  const tests::document* doc4 = gen.next();
+  const tests::document* doc5 = gen.next();
+  const tests::document* doc6 = gen.next();
 
   auto always_merge =
     irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount());
@@ -13662,12 +13657,12 @@ TEST_P(index_test_case, segment_consolidate_policy) {
       }
     });
 
-  tests::document const* doc1 = gen.next();
-  tests::document const* doc2 = gen.next();
-  tests::document const* doc3 = gen.next();
-  tests::document const* doc4 = gen.next();
-  tests::document const* doc5 = gen.next();
-  tests::document const* doc6 = gen.next();
+  const tests::document* doc1 = gen.next();
+  const tests::document* doc2 = gen.next();
+  const tests::document* doc3 = gen.next();
+  const tests::document* doc4 = gen.next();
+  const tests::document* doc5 = gen.next();
+  const tests::document* doc6 = gen.next();
 
   // bytes size policy (merge)
   {
@@ -13787,7 +13782,7 @@ TEST_P(index_test_case, segment_consolidate_policy) {
     {
       std::unordered_set<std::string_view> expectedName = {"A", "B", "C", "D"};
 
-      auto& segment = reader[0];  // assume 0 is id of first segment
+      auto& segment = reader[0];        // assume 0 is id of first segment
       ASSERT_EQ(expectedName.size(),
                 segment.docs_count());  // total count of documents
       auto terms = segment.field("same");
@@ -13814,7 +13809,7 @@ TEST_P(index_test_case, segment_consolidate_policy) {
     {
       std::unordered_set<std::string_view> expectedName = {"E"};
 
-      auto& segment = reader[1];  // assume 1 is id of second segment
+      auto& segment = reader[1];        // assume 1 is id of second segment
       ASSERT_EQ(expectedName.size(),
                 segment.docs_count());  // total count of documents
       auto terms = segment.field("same");
@@ -13864,7 +13859,7 @@ TEST_P(index_test_case, segment_consolidate_policy) {
 
     auto reader = irs::DirectoryReader(dir(), codec());
     ASSERT_EQ(1, reader.size());
-    auto& segment = reader[0];  // assume 0 is id of first/only segment
+    auto& segment = reader[0];        // assume 0 is id of first/only segment
     ASSERT_EQ(expectedName.size(),
               segment.docs_count());  // total count of documents
     auto terms = segment.field("same");
@@ -13913,7 +13908,7 @@ TEST_P(index_test_case, segment_consolidate_policy) {
     {
       std::unordered_set<std::string_view> expectedName = {"A"};
 
-      auto& segment = reader[0];  // assume 0 is id of first segment
+      auto& segment = reader[0];        // assume 0 is id of first segment
       ASSERT_EQ(expectedName.size(),
                 segment.docs_count());  // total count of documents
       auto terms = segment.field("same");
@@ -13996,7 +13991,7 @@ TEST_P(index_test_case, segment_consolidate_policy) {
 
     auto reader = irs::DirectoryReader(dir(), codec());
     ASSERT_EQ(1, reader.size());
-    auto& segment = reader[0];  // assume 0 is id of first/only segment
+    auto& segment = reader[0];        // assume 0 is id of first/only segment
     ASSERT_EQ(expectedName.size(),
               segment.docs_count());  // total count of documents
     auto terms = segment.field("same");
@@ -14054,7 +14049,7 @@ TEST_P(index_test_case, segment_consolidate_policy) {
     {
       std::unordered_set<std::string_view> expectedName = {"A"};
 
-      auto& segment = reader[0];  // assume 0 is id of first segment
+      auto& segment = reader[0];        // assume 0 is id of first segment
       ASSERT_EQ(expectedName.size() + 3,
                 segment.docs_count());  // total count of documents (+3 ==
                                         // B, C, D masked)
@@ -14083,7 +14078,7 @@ TEST_P(index_test_case, segment_consolidate_policy) {
     {
       std::unordered_set<std::string_view> expectedName = {"E"};
 
-      auto& segment = reader[1];  // assume 1 is id of second segment
+      auto& segment = reader[1];        // assume 1 is id of second segment
       ASSERT_EQ(expectedName.size(),
                 segment.docs_count());  // total count of documents
       auto terms = segment.field("same");
@@ -14139,7 +14134,7 @@ TEST_P(index_test_case, segment_consolidate_policy) {
 
     auto reader = irs::DirectoryReader(dir(), codec());
     ASSERT_EQ(1, reader.size());
-    auto& segment = reader[0];  // assume 0 is id of first/only segment
+    auto& segment = reader[0];        // assume 0 is id of first/only segment
     ASSERT_EQ(expectedName.size(),
               segment.docs_count());  // total count of documents
     auto terms = segment.field("same");
@@ -14263,8 +14258,8 @@ TEST_P(index_test_case, segment_options) {
       }
     });
 
-  tests::document const* doc1 = gen.next();
-  tests::document const* doc2 = gen.next();
+  const tests::document* doc1 = gen.next();
+  const tests::document* doc2 = gen.next();
 
   // segment_count_max
   {
@@ -16227,8 +16222,8 @@ TEST_P(index_test_case_11, consolidate_old_format) {
         doc.insert(std::make_shared<tests::string_field>(name, data.str));
       }
     });
-  tests::document const* doc1 = gen.next();
-  tests::document const* doc2 = gen.next();
+  const tests::document* doc1 = gen.next();
+  const tests::document* doc2 = gen.next();
 
   auto validate_codec = [&](auto codec, size_t size) {
     auto reader = irs::DirectoryReader(dir());
@@ -16274,7 +16269,7 @@ TEST_P(index_test_case_11, clean_writer_with_payload) {
       }
     });
 
-  tests::document const* doc1 = gen.next();
+  const tests::document* doc1 = gen.next();
 
   irs::IndexWriterOptions writer_options;
   uint64_t payload_committed_tick{0};

--- a/tests/index/segment_writer_tests.cpp
+++ b/tests/index/segment_writer_tests.cpp
@@ -528,7 +528,7 @@ class StringComparer final : public irs::Comparer {
   }
 };
 
-void reorder(std::span<tests::document const*> docs,
+void reorder(std::span<const tests::document*> docs,
              std::span<irs::segment_writer::update_context> ctxs,
              std::vector<size_t> order) {
   for (size_t i = 0; i < order.size(); ++i) {
@@ -569,7 +569,7 @@ TEST_F(segment_writer_tests, reorder) {
       }
     });
   static constexpr size_t kLen = 5;
-  std::array<tests::document const*, kLen> docs;
+  std::array<const tests::document*, kLen> docs;
   std::array<irs::segment_writer::update_context, kLen> ctxs;
   for (size_t i = 0; i < kLen; ++i) {
     docs[i] = gen.next();

--- a/tests/index/sorted_column_test.cpp
+++ b/tests/index/sorted_column_test.cpp
@@ -129,10 +129,11 @@ TEST_P(SortedColumnTestCase, FlushEmpty) {
     ASSERT_EQ(0, order.size());
     ASSERT_FALSE(irs::field_limits::valid(column_id));
 
-    irs::flush_state state;
-    state.dir = &dir;
-    state.doc_count = 0;
-    state.name = segment.name;
+    irs::flush_state state{
+      .dir = &dir,
+      .name = segment.name,
+      .doc_count = 0,
+    };
 
     ASSERT_FALSE(writer->commit(state));  // nothing to commit
   }
@@ -213,10 +214,11 @@ TEST_P(SortedColumnTestCase, InsertDuplicates) {
     ASSERT_EQ(0, order.size());  // already sorted
     ASSERT_FALSE(irs::field_limits::valid(column_id));
 
-    irs::flush_state state;
-    state.dir = &dir;
-    state.doc_count = std::size(values);
-    state.name = segment.name;
+    irs::flush_state state{
+      .dir = &dir,
+      .name = segment.name,
+      .doc_count = std::size(values),
+    };
 
     ASSERT_FALSE(writer->commit(state));
   }
@@ -294,10 +296,11 @@ TEST_P(SortedColumnTestCase, Sort) {
     ASSERT_EQ(1 + std::size(values), order.size());
     ASSERT_TRUE(irs::field_limits::valid(column_id));
 
-    irs::flush_state state;
-    state.dir = &dir;
-    state.doc_count = std::size(values);
-    state.name = segment.name;
+    irs::flush_state state{
+      .dir = &dir,
+      .name = segment.name,
+      .doc_count = std::size(values),
+    };
 
     ASSERT_TRUE(writer->commit(state));
   }


### PR DESCRIPTION
C -- Transaction::Commit
F -- Segment::Flush

`... C F 1 4 5 C 2 3 F C`

after second flush in current master it will be looks like

`... C F 1 2 3 C 4 5 F C`

second commit will increment generation for `4 5` instead of `2 3`.

