### PR TITLE
Backport IndexWriter::Emplace update generation regression

### DIFF
--- a/core/index/index_writer.cpp
+++ b/core/index/index_writer.cpp
@@ -1077,7 +1077,7 @@ void index_writer::flush_context::emplace(active_segment_context&& segment,
   auto& flushed_update_contexts = ctx.flushed_update_contexts_;
 
   // update generations of segment_context::flushed_update_contexts_
-  size_t commit_start = uncomitted_doc_id_begin_ - doc_limits::min();
+  size_t commit_start = ctx.uncomitted_doc_id_begin_ - doc_limits::min();
   if (commit_start < flushed_update_contexts.size()) {
     update_generation({flushed_update_contexts.data() + commit_start,
                        flushed_update_contexts.size() - commit_start});

--- a/core/index/index_writer.cpp
+++ b/core/index/index_writer.cpp
@@ -1086,8 +1086,9 @@ void index_writer::flush_context::emplace(active_segment_context&& segment,
     commit_start -= flushed_update_contexts.size();
   }
 
+  auto const writer_docs = ctx.writer_->docs_cached();
   assert(ctx.writer_);
-  assert(ctx.writer_->docs_cached() <= doc_limits::eof());
+  assert(writer_docs <= doc_limits::eof());
   if (auto docs = ctx.writer_->docs_context(); commit_start < docs.size()) {
     IRS_ASSERT(writer_->initialized());
     update_generation({docs.data() + commit_start, docs.size() - commit_start});
@@ -1096,8 +1097,8 @@ void index_writer::flush_context::emplace(active_segment_context&& segment,
   // reset counters for segment reuse
 
   ctx.uncomitted_generation_offset_ = 0;
-  ctx.uncomitted_doc_id_begin_ =
-    flushed_update_contexts.size() + writer_docs + doc_limits::min();
+  ctx.uncomitted_doc_id_begin_ = flushed_update_contexts.size() +
+                                 writer_docs + doc_limits::min();
   ctx.uncomitted_modification_queries_ = ctx.modification_queries_.size();
 
   if (!freelist_node) {

--- a/core/index/index_writer.cpp
+++ b/core/index/index_writer.cpp
@@ -1066,11 +1066,11 @@ void index_writer::flush_context::emplace(active_segment_context&& segment,
                 });
 
   auto update_generation = [&](std::span<segment_writer::update_context> ctxs) {
-    for (auto& ctx : ctxs) {
+    for (auto& ctx_i : ctxs) {
       // can == modification_count if inserts come after modification
-      assert(ctxs[i].generation <= modification_count);
+      assert(ctx_i.generation <= modification_count);
       // update to flush_context generation
-      ctx.generation += generation_base;
+      ctx_i.generation += generation_base;
     }
   };
 


### PR DESCRIPTION
This is only a fix for the October/September regression.
Segment::Flush/Transaction::Reset fixes still need to be backported.
