### PR TITLE
Add ability to Remove without increment tick

### DIFF
--- a/core/index/index_writer.cpp
+++ b/core/index/index_writer.cpp
@@ -284,12 +284,14 @@ void FlushedSegmentContext::MaskUnusedReplace(uint64_t first_tick,
   const std::span docs{segment.flushed_docs_.data() + begin,
                        segment.flushed_docs_.data() + end};
   for (const auto& doc : docs) {
-    if (doc.query_id == writer_limits::kInvalidOffset ||
-        doc.tick <= first_tick) {
+    if (doc.tick <= first_tick) {
       continue;
     }
     if (last_tick < doc.tick) {
       break;
+    }
+    if (doc.query_id == writer_limits::kInvalidOffset) {
+      continue;
     }
     IRS_ASSERT(doc.query_id < segment.queries_.size());
     if (!segment.queries_[doc.query_id].IsDone()) {

--- a/core/utils/bitset.hpp
+++ b/core/utils/bitset.hpp
@@ -44,8 +44,7 @@ class dynamic_bitset {
   using word_ptr_t = std::unique_ptr<word_t[], word_ptr_deleter_t>;
 
   constexpr IRS_FORCE_INLINE static size_t bits_to_words(size_t bits) noexcept {
-    return bits / bits_required<word_t>() +
-           static_cast<size_t>((bits % bits_required<word_t>()) != 0);
+    return (bits + bits_required<word_t>() - 1) / bits_required<word_t>();
   }
 
   // returns corresponding bit index within a word for the


### PR DESCRIPTION
Before we had a requirement for the tick provider to have a separate tick for each Remove. But sometimes removes could be "fake" and does not produce a separate tick. So we added the ability to have Remove that does not require additional tick 