### PR TITLE
I fixed this empty commit ****

### DIFF
--- a/tests/index/sorted_index_tests.cpp
+++ b/tests/index/sorted_index_tests.cpp
@@ -2901,7 +2901,8 @@ TEST_P(SortedIndexStressTestCase, doc_removal_same_key_within_trx) {
           continue;
         }
         ASSERT_EQ(1, reader.size());
-        ASSERT_EQ(kLen, reader->docs_count());
+        // less possible when Reset/Rollback is first
+        ASSERT_LE(reader->docs_count(), kLen);
         ASSERT_EQ(in_store_count, reader->live_docs_count());
         const auto& segment = reader[0];
         const auto* column = segment.sort();


### PR DESCRIPTION
Few fixes:
1. If was empty commit but we need reopen_columnstore we need to recreate index reader
2. If some segment was split by commit and it was in reader in first commit, but it will be empty in second commit. It's not empty commit at all
3. If was rollback to some segment and wasn't commit in this segment writer we can reset it instead of masking