### PR TITLE
Small improvements

### DIFF
--- a/core/formats/skip_list.hpp
+++ b/core/formats/skip_list.hpp
@@ -26,20 +26,15 @@
 #include "utils/type_limits.hpp"
 
 namespace irs {
-
 // Writer for storing skip-list in a directory
 // Example (skip_0 = skip_n = 3):
-//
-//                                                        c         (skip level
-//                                                        2)
-//                    c                 c                 c         (skip level
-//                    1)
-//        x     x     x     x     x     x     x     x     x     x   (skip level
-//        0)
-//  d d d d d d d d d d d d d d d d d d d d d d d d d d d d d d d d (posting
-//  list)
+// clang-format off
+//                                                        c         (skip level 2)
+//                    c                 c                 c         (skip level 1)
+//        x     x     x     x     x     x     x     x     x     x   (skip level 0)
+//  d d d d d d d d d d d d d d d d d d d d d d d d d d d d d d d d (posting list)
 //        3     6     9     12    15    18    21    24    27    30  (doc_count)
-//
+// clang-format on
 // d - document
 // x - skip data
 // c - skip data with child pointer

--- a/core/search/bm25.cpp
+++ b/core/search/bm25.cpp
@@ -30,12 +30,12 @@
 #include <cstdint>
 
 #include "analysis/token_attributes.hpp"
+#include "formats/wand_writer.hpp"
 #include "index/field_meta.hpp"
 #include "index/index_reader.hpp"
 #include "index/norm.hpp"
 #include "scorer.hpp"
 #include "search/scorer_impl.hpp"
-#include "search/wand_writer.hpp"
 #include "utils/math_utils.hpp"
 #include "utils/misc.hpp"
 

--- a/core/search/conjunction.hpp
+++ b/core/search/conjunction.hpp
@@ -114,12 +114,8 @@ class conjunction : public doc_iterator, private Merger, private score_ctx {
                     return cost::extract(lhs, cost::kMax) <
                            cost::extract(rhs, cost::kMax);
                   });
-#if defined(__GNUC__) && (__GNUC__ < 11)
-        // Circumvent GCC10 compilation issue.
+        // NRVO doesn't work for function parameters
         return std::move(itrs);
-#else
-        return itrs;
-#endif
       }(std::move(itrs))},
       front_{itrs_.front().it.get()},
       front_doc_{irs::get_mutable<document>(front_)} {

--- a/core/search/disjunction.hpp
+++ b/core/search/disjunction.hpp
@@ -1402,11 +1402,8 @@ doc_iterator::ptr MakeWeakDisjunction(
     IRS_ASSERT(min_match == size);
     using Conjunction = typename RebindIterator<WeakConjunction>::Conjunction;
 
-    return memory::make_managed<Conjunction>(
-      typename Conjunction::doc_iterators_t{
-        std::make_move_iterator(std::begin(itrs)),
-        std::make_move_iterator(std::end(itrs))},
-      std::forward<Merger>(merger));
+    return memory::make_managed<Conjunction>(std::move(itrs),
+                                             std::forward<Merger>(merger));
   }
 
   return memory::make_managed<WeakConjunction>(std::move(itrs), min_match,

--- a/core/search/tfidf.cpp
+++ b/core/search/tfidf.cpp
@@ -31,12 +31,12 @@
 #include <string_view>
 
 #include "analysis/token_attributes.hpp"
+#include "formats/wand_writer.hpp"
 #include "index/field_meta.hpp"
 #include "index/index_reader.hpp"
 #include "index/norm.hpp"
 #include "search/scorer_impl.hpp"
 #include "search/scorers.hpp"
-#include "search/wand_writer.hpp"
 #include "utils/math_utils.hpp"
 #include "utils/misc.hpp"
 

--- a/tests/formats/formats_15_tests.cpp
+++ b/tests/formats/formats_15_tests.cpp
@@ -22,8 +22,8 @@
 
 #include "formats/formats_10.hpp"
 #include "formats/formats_10_attributes.hpp"
+#include "formats/wand_writer.hpp"
 #include "formats_test_case_base.hpp"
-#include "search/wand_writer.hpp"
 #include "tests_shared.hpp"
 
 namespace {


### PR DESCRIPTION
1. Write norm - freq instead of just norm, to make it smaller on disk
2. Avoid two unnecessary copies for conjunction
