### PR TITLE
Fix wand data skipping

### DIFF
--- a/core/formats/formats.hpp
+++ b/core/formats/formats.hpp
@@ -167,8 +167,8 @@ struct field_writer {
 };
 
 struct WandInfo {
-  byte_type mapped_index;
-  byte_type count;
+  byte_type mapped_index{WandContext::kDisable};
+  byte_type count{0};
 };
 
 struct postings_reader {

--- a/core/formats/formats_10.cpp
+++ b/core/formats/formats_10.cpp
@@ -2325,7 +2325,8 @@ void doc_iterator<IteratorTraits, FieldTraits, WandExtent>::prepare(
     skip_.Reader().Enable(term_state);
     skip_offs_ = term_state.doc_start + term_state.e_skip_start;
     docs_count_ = term_state.docs_count;
-  } else if (wand_index == WandContext::kDisable) {
+  } else if (term_state.docs_count != IteratorTraits::block_size() &&
+             wand_index == WandContext::kDisable) {
     skip_.Reader().SkipWandData(*this->doc_in_);
   }
 }


### PR DESCRIPTION
Non-wanderators should take into account case with doc_count == block_size