### PR TITLE
Fix missing stdint include

### DIFF
--- a/core/utils/thread_utils.hpp
+++ b/core/utils/thread_utils.hpp
@@ -24,6 +24,7 @@
 
 #include <mutex>
 #include <shared_mutex>
+#include <string>
 
 #include "shared.hpp"
 

--- a/external/fastText/src/args.cc
+++ b/external/fastText/src/args.cc
@@ -8,6 +8,7 @@
 
 #include "args.h"
 
+#include <cstdint>
 #include <stdlib.h>
 
 #include <iostream>

--- a/external/frozen/include/frozen/bits/pmh.h
+++ b/external/frozen/include/frozen/bits/pmh.h
@@ -28,6 +28,7 @@
 #include "frozen/bits/basic_types.h"
 
 #include <array>
+#include <cstdint>
 #include <limits>
 
 namespace frozen {

--- a/external/text/include/boost/text/utf.hpp
+++ b/external/text/include/boost/text/utf.hpp
@@ -8,6 +8,7 @@
 
 #include <boost/text/config.hpp>
 
+#include <cstdint>
 #include <type_traits>
 
 


### PR DESCRIPTION
Doesn't work without this patch with new libstdc++