### PR TITLE
Make IndexWriter::Transaction default constructible and move assignable

### DIFF
--- a/tests/index/index_tests.cpp
+++ b/tests/index/index_tests.cpp
@@ -16931,7 +16931,10 @@ TEST_P(index_test_case_11, testExternalGenerationDifferentStart) {
   irs::IndexWriterOptions writer_options;
   auto writer = open_writer(irs::OM_CREATE, writer_options);
   {
-    auto trx = writer->GetBatch();
+    irs::IndexWriter::Transaction trx;
+    ASSERT_FALSE(trx.Valid());
+    trx = writer->GetBatch();
+    ASSERT_TRUE(trx.Valid());
     {
       auto doc = trx.Insert();
       doc.Insert<irs::Action::INDEX>(doc0->indexed.begin(),


### PR DESCRIPTION
Add IndexWriter::Transaction::FlushRequired

Needed for https://github.com/arangodb/arangodb/pull/19173