### PR TITLE
[SEARCH-476] [APM-757] Fix fst builder

### DIFF
--- a/core/utils/fstext/fst_builder.hpp
+++ b/core/utils/fstext/fst_builder.hpp
@@ -134,7 +134,7 @@ class fst_builder : util::noncopyable {
       auto& last_out = p.arcs.back().out;
 
       if (last_out != weight_t::One()) {
-        auto prefix = fst::Plus(last_out, out);
+        auto prefix = fst::Plus(last_out, output);
         const auto suffix = fst::DivideLeft(last_out, prefix);
 
         for (arc& a : s.arcs) {

--- a/core/utils/fstext/fst_string_weight.hpp
+++ b/core/utils/fstext/fst_string_weight.hpp
@@ -428,71 +428,65 @@ inline std::istream& operator>>(std::istream& strm,
 // For binary strings that's impossible to use
 // Zero() or NoWeight() as they may interfere
 // with real values
-inline irs::bytes_view Plus(const StringLeftWeight<irs::byte_type>& lhs,
-                            const StringLeftWeight<irs::byte_type>& rhs) {
-  typedef irs::bytes_view Weight;
-
+inline irs::bytes_view PlusImpl(irs::bytes_view lhs, irs::bytes_view rhs) {
   const auto* plhs = &lhs;
   const auto* prhs = &rhs;
 
-  if (rhs.Size() > lhs.Size()) {
+  if (rhs.size() > lhs.size()) {
     // enusre that 'prhs' is shorter than 'plhs'
     // The behavior is undefined if the second range is shorter than the first
     // range. (http://en.cppreference.com/w/cpp/algorithm/mismatch)
     std::swap(plhs, prhs);
   }
 
-  IRS_ASSERT(prhs->Size() <= plhs->Size());
+  auto pair =
+    std::mismatch(prhs->data(), prhs->data() + prhs->size(), plhs->data());
+  return {prhs->data(), static_cast<size_t>(pair.first - prhs->data())};
+}
 
-  return Weight(
-    prhs->c_str(),
-    std::distance(prhs->c_str(),
-                  std::mismatch(prhs->c_str(), (prhs->c_str() + prhs->Size()),
-                                plhs->c_str())
-                    .first));
+inline irs::bytes_view Plus(const StringLeftWeight<irs::byte_type>& lhs,
+                            const StringLeftWeight<irs::byte_type>& rhs) {
+  return PlusImpl(lhs, rhs);
+}
+
+inline irs::bytes_view Plus(irs::bytes_view lhs,
+                            const StringLeftWeight<irs::byte_type>& rhs) {
+  return PlusImpl(lhs, rhs);
+}
+
+inline irs::bytes_view Plus(const StringLeftWeight<irs::byte_type>& lhs,
+                            irs::bytes_view rhs) {
+  return PlusImpl(lhs, rhs);
 }
 
 // For binary strings that's impossible to use
 // Zero() or NoWeight() as they may interfere
 // with real values
+inline StringLeftWeight<irs::byte_type> TimesImpl(irs::bytes_view lhs,
+                                                  irs::bytes_view rhs) {
+  using Weight = StringLeftWeight<irs::byte_type>;
+
+  Weight product;
+  product.Reserve(lhs.size() + rhs.size());
+  product.PushBack(lhs.begin(), lhs.end());
+  product.PushBack(rhs.begin(), rhs.end());
+  return product;
+}
+
 inline StringLeftWeight<irs::byte_type> Times(
   const StringLeftWeight<irs::byte_type>& lhs,
   const StringLeftWeight<irs::byte_type>& rhs) {
-  typedef StringLeftWeight<irs::byte_type> Weight;
-
-  Weight product;
-  product.Reserve(lhs.Size() + rhs.Size());
-  product.PushBack(lhs.begin(), lhs.end());
-  product.PushBack(rhs.begin(), rhs.end());
-  return product;
+  return TimesImpl(lhs, rhs);
 }
 
-// For binary strings that's impossible to use
-// Zero() or NoWeight() as they may interfere
-// with real values
 inline StringLeftWeight<irs::byte_type> Times(
   irs::bytes_view lhs, const StringLeftWeight<irs::byte_type>& rhs) {
-  typedef StringLeftWeight<irs::byte_type> Weight;
-
-  Weight product;
-  product.Reserve(lhs.size() + rhs.Size());
-  product.PushBack(lhs.begin(), lhs.end());
-  product.PushBack(rhs.begin(), rhs.end());
-  return product;
+  return TimesImpl(lhs, rhs);
 }
 
-// For binary strings that's impossible to use
-// Zero() or NoWeight() as they may interfere
-// with real values
 inline StringLeftWeight<irs::byte_type> Times(
   const StringLeftWeight<irs::byte_type>& lhs, irs::bytes_view rhs) {
-  typedef StringLeftWeight<irs::byte_type> Weight;
-
-  Weight product;
-  product.Reserve(lhs.Size() + rhs.size());
-  product.PushBack(lhs.begin(), lhs.end());
-  product.PushBack(rhs.begin(), rhs.end());
-  return product;
+  return TimesImpl(lhs, rhs);
 }
 
 // Left division in a left string semiring.

--- a/microbench/crc_benchmark.cpp
+++ b/microbench/crc_benchmark.cpp
@@ -36,7 +36,8 @@ void BM_Calculate2(benchmark::State& state) {
     benchmark::DoNotOptimize(data);
     irs::crc32c crc;
     crc.process_bytes(data.data(), data.size());
-    benchmark::DoNotOptimize(crc.checksum());
+    auto tmp = crc.checksum();
+    benchmark::DoNotOptimize(tmp);
   }
 }
 
@@ -62,7 +63,8 @@ void BM_Extend2(benchmark::State& state) {
     benchmark::DoNotOptimize(base);
     benchmark::DoNotOptimize(extension);
     base.process_bytes(extension.data(), extension.size());
-    benchmark::DoNotOptimize(base.checksum());
+    auto tmp = base.checksum();
+    benchmark::DoNotOptimize(tmp);
   }
 }
 

--- a/microbench/lower_bound_benchmark.cpp
+++ b/microbench/lower_bound_benchmark.cpp
@@ -35,7 +35,7 @@ void BM_lower_bound(benchmark::State& state) {
 
   for (auto _ : state) {
     for (auto v : nums) {
-      const auto it = std::upper_bound(nums.begin(), nums.end(), v);
+      auto it = std::upper_bound(nums.begin(), nums.end(), v);
       benchmark::DoNotOptimize(it);
     }
   }
@@ -49,7 +49,7 @@ void BM_linear_scan(benchmark::State& state) {
 
   for (auto _ : state) {
     for (auto v : nums) {
-      const auto it = std::find(nums.begin(), nums.end(), v);
+      auto it = std::find(nums.begin(), nums.end(), v);
       benchmark::DoNotOptimize(it);
     }
   }

--- a/microbench/segmentation_stream_benchmark.cpp
+++ b/microbench/segmentation_stream_benchmark.cpp
@@ -39,7 +39,7 @@ void BM_segmentation_analyzer(benchmark::State& state) {
   const std::string_view str = "QUICK BROWN FOX JUMPS OVER THE LAZY DOG";
   for (auto _ : state) {
     stream.reset(str);
-    while (const bool has_next = stream.next()) {
+    while (bool has_next = stream.next()) {
       benchmark::DoNotOptimize(has_next);
     }
   }

--- a/tests/utils/object_pool_tests.cpp
+++ b/tests/utils/object_pool_tests.cpp
@@ -1533,7 +1533,7 @@ TEST(concurrent_linked_list_test, concurrent_pop_push) {
   const size_t THREADS = 16;
 
   struct data {
-    std::atomic_flag visited = ATOMIC_FLAG_INIT;
+    std::atomic_flag visited{false};
     std::atomic<size_t> num_owners{};
     size_t value{};
   };

--- a/tests/utils/object_pool_tests.cpp
+++ b/tests/utils/object_pool_tests.cpp
@@ -1533,7 +1533,7 @@ TEST(concurrent_linked_list_test, concurrent_pop_push) {
   const size_t THREADS = 16;
 
   struct data {
-    std::atomic_flag visited{false};
+    std::atomic_flag visited = ATOMIC_FLAG_INIT;
     std::atomic<size_t> num_owners{};
     size_t value{};
   };


### PR DESCRIPTION
How does it work before?

When I looked to the failed assert it starts to looks obviously that we are doing it wrong
`DivideLeft("\x04\x03G?\x02\x05S?\x04\x05i?\x06\x05", "\x05");` 

From intuitive point of view we are trying to reduce initial output.
To do this we put part of it to the outputs of the common prefix (prev_key, curr_key).
To do this we need to cut common prefix of the current weight(output) and previous output and put suffix to the arcs.
Then make previous output prefix.
Then reduce current output to the written prefix.

I also checked reference paper and it also using CurrentOutput and other implementation of this algorithm

https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.24.3698&rep=rep1&type=pdf
![image](https://github.com/iresearch-toolkit/iresearch/assets/32071355/bf9961af-cf54-4d8d-9227-cd351ac1eb1c)
https://github.com/phiresky/tantivy-fst/blob/dynamic-loading/src/raw/build.rs#L400

