### PR TITLE
wand improvements

### DIFF
--- a/core/formats/formats.hpp
+++ b/core/formats/formats.hpp
@@ -207,7 +207,8 @@ struct postings_reader {
   // It's up to the caller to allocate enough space for a bitset.
   // This API is experimental.
   virtual size_t bit_union(IndexFeatures field_features,
-                           const term_provider_f& provider, size_t* set) = 0;
+                           const term_provider_f& provider, size_t* set,
+                           byte_type wand_count) = 0;
 };
 
 // Expected usage pattern of seek_term_iterator

--- a/core/formats/formats_10.cpp
+++ b/core/formats/formats_10.cpp
@@ -3793,9 +3793,10 @@ size_t postings_reader<FormatTraits>::bit_union(
 
     if (term_state.docs_count > 1) {
       doc_in->seek(term_state.doc_start);
+      IRS_ASSERT(!doc_in->eof());
       if (FormatTraits::wand() &&
           term_state.docs_count < FormatTraits::block_size()) {
-        CommonSkipWandData(Extent<kDynamicValue>{wand_count}, *doc_in_);
+        CommonSkipWandData(Extent<kDynamicValue>{wand_count}, *doc_in);
       }
       IRS_ASSERT(!doc_in->eof());
 

--- a/core/formats/formats_burst_trie.cpp
+++ b/core/formats/formats_burst_trie.cpp
@@ -3112,7 +3112,10 @@ class field_reader final : public irs::field_reader {
         return nullptr;
       };
 
-      return owner_->pr_->bit_union(meta().index_features, term_provider, set);
+      IRS_ASSERT(owner_ != nullptr);
+      IRS_ASSERT(owner_->pr_ != nullptr);
+      return owner_->pr_->bit_union(meta().index_features, term_provider, set,
+                                    WandCount());
     }
 
     seek_term_iterator::ptr iterator(

--- a/core/formats/skip_list.hpp
+++ b/core/formats/skip_list.hpp
@@ -62,7 +62,9 @@ class SkipWriter : util::noncopyable {
                const memory_allocator& alloc = memory_allocator::global());
 
   // Flushes all internal data into the specified output stream
-  void Flush(index_output& out);
+  uint32_t CountLevels() const;
+  void FlushLevels(uint32_t num_levels, index_output& out);
+  void Flush(index_output& out) { FlushLevels(CountLevels(), out); }
 
   // Resets skip writer internal state
   void Reset() noexcept {

--- a/core/formats/wand_writer.hpp
+++ b/core/formats/wand_writer.hpp
@@ -28,16 +28,18 @@
 #include "index/norm.hpp"
 #include "search/scorer.hpp"
 #include "store/memory_directory.hpp"
-
-#include <absl/container/inlined_vector.h>
+#include "utils/empty.hpp"
+#include "utils/small_vector.hpp"
 
 namespace irs {
 
-template<typename ValueProducer>
+template<typename Producer>
 class WandWriterImpl final : public WandWriter {
+  using EntryType = typename Producer::Entry;
+
  public:
   WandWriterImpl(const Scorer& scorer, size_t max_levels)
-    : score_levels_{max_levels + 1}, producer_{scorer} {
+    : levels_{max_levels + 1}, producer_{scorer} {
     IRS_ASSERT(max_levels != 0);
   }
 
@@ -47,238 +49,295 @@ class WandWriterImpl final : public WandWriter {
   }
 
   void Reset() noexcept final {
-    for (auto& level : score_levels_) {
-      level = {};
+    for (auto& entry : levels_) {
+      entry = {};
     }
   }
 
   void Update() noexcept final {
-    score_t score;
-    producer_.GetScore(&score);
-
-    Update(score_levels_.front(), score, [&] { return producer_.GetValue(); });
+    IRS_ASSERT(!levels_.empty());
+    producer_.Produce(levels_.front());
   }
 
   void Write(size_t level, memory_index_output& out) final {
-    IRS_ASSERT(level + 1 < score_levels_.size());
-    auto& score = score_levels_[level];
-    // Accumulate score on less granular level
-    Update(score_levels_[level + 1], score.score, [&] { return score.value; });
-
-    IRS_ASSERT(
-      std::is_sorted(score_levels_.begin(), score_levels_.begin() + level + 2));
-    ValueProducer::Write(score.value, out);
-    score.score = 0.f;
+    IRS_ASSERT(level + 1 < levels_.size());
+    auto& entry = levels_[level];
+    Producer::Produce(entry, levels_[level + 1]);
+    Producer::Write(entry, out);
+    entry = {};
   }
 
-  void WriteRoot(index_output& out) final {
-    IRS_ASSERT(!score_levels_.empty());
-    IRS_ASSERT(
-      score_levels_.back().score ==
-      std::max_element(score_levels_.begin(), score_levels_.end())->score);
-    ValueProducer::Write(score_levels_.back().value, out);
+  void WriteRoot(size_t level, index_output& out) final {
+    IRS_ASSERT(level < levels_.size());
+    auto& entry = levels_[level];
+    Producer::Write(entry, out);
   }
 
   byte_type Size(size_t level) const noexcept final {
-    IRS_ASSERT(level + 1 < score_levels_.size());
-    const auto& entry = score_levels_[level];
-    return ValueProducer::Size(entry.value);
+    IRS_ASSERT(level + 1 < levels_.size());
+    const auto& entry = levels_[level];
+    return Producer::Size(entry);
   }
 
-  byte_type SizeRoot() noexcept final {
-    IRS_ASSERT(!score_levels_.empty());
-    auto max = std::max_element(score_levels_.begin(), score_levels_.end());
-    score_levels_.back() = *max;
-    return ValueProducer::Size(score_levels_.back().value);
+  byte_type SizeRoot(size_t level) noexcept final {
+    IRS_ASSERT(level < levels_.size());
+    auto it = levels_.begin();
+    for (auto end = it + level; it != end;) {
+      const auto& from = *it;
+      Producer::Produce(from, *++it);
+    }
+    return Producer::Size(*it);
   }
 
  private:
-  using ValueType = typename ValueProducer::Value;
-
-  struct Entry {
-    score_t score{};
-    ValueType value;
-
-    friend bool operator<(const Entry& lhs, const Entry& rhs) noexcept {
-      return lhs.score < rhs.score;
-    }
-  };
-
-  template<typename Func>
-  void Update(Entry& lhs, score_t rhs_score, Func&& func) noexcept {
-    if (lhs.score < rhs_score) {
-      lhs.score = rhs_score;
-      lhs.value = func();
-    }
-  }
-
-  absl::InlinedVector<Entry, 9 + 1> score_levels_;
-  IRS_NO_UNIQUE_ADDRESS ValueProducer producer_;
+  // 9 -- current max skip list levels
+  // 1 -- for whole skip list level
+  irs::SmallVector<EntryType, 9 + 1> levels_;
+  IRS_NO_UNIQUE_ADDRESS Producer producer_;
 };
 
-class ValueProducerBase {
- public:
-  void GetScore(score_t* score) const noexcept { func_(score); }
+template<bool NeedScore>
+struct WandScorer {
+  explicit WandScorer(const Scorer& /*scorer*/) noexcept {}
 
-  explicit ValueProducerBase(const Scorer& scorer) : scorer_{&scorer} {
+  constexpr bool Prepare(const ColumnProvider& /*reader*/,
+                         const feature_map_t& /*features*/,
+                         const attribute_provider& /*attrs*/) noexcept {
+    return true;
+  }
+};
+
+template<>
+struct WandScorer<true> {
+  explicit WandScorer(const Scorer& scorer) : scorer_{scorer} {
+    // TODO(MBkkt) alignment could be incorrect here
     stats_.resize(scorer.stats_size().first);
     scorer.collect(stats_.data(), nullptr, nullptr);
   }
 
- protected:
   bool Prepare(const ColumnProvider& reader, const feature_map_t& features,
                const attribute_provider& attrs) {
     func_ =
-      scorer_->prepare_scorer(reader, features, stats_.data(), attrs, kNoBoost);
+      scorer_.prepare_scorer(reader, features, stats_.data(), attrs, kNoBoost);
     return static_cast<bool>(func_);
   }
 
+  score_t GetScore() const noexcept {
+    score_t score{};
+    func_(&score);
+    return score;
+  }
+
  private:
-  absl::InlinedVector<byte_type, 16> stats_;
+  const Scorer& scorer_;
   ScoreFunction func_;
-  const Scorer* scorer_;
+  irs::SmallVector<byte_type, 16> stats_;
 };
 
-class FreqNormProducer : public ValueProducerBase {
+enum WandTag : uint32_t {
+  // What will be written?
+  kWandTagFreq = 0U,
+  kWandTagNorm = 1U << 0U,
+  // How to Produce best Entry?
+  // Produce max freq
+  kWandTagMaxFreq = 1U << 1U,
+  // Produce max freq, min norm, but norm >= freq
+  kWandTagMinNorm = 1U << 2U,
+  // Produce max freq/norm
+  kWandTagDivNorm = 1U << 3U,
+  // Produce max score
+  kWandTagMaxScore = 1U << 4U,
+};
+
+template<uint32_t Tag>
+class FreqNormProducer {
+  static constexpr bool kMaxScore = (Tag & kWandTagMaxScore) != 0;
+  static constexpr bool kDivNorm = (Tag & kWandTagDivNorm) != 0;
+  static constexpr bool kMinNorm = (Tag & kWandTagMinNorm) != 0;
+  static constexpr bool kMaxFreq = kMinNorm || (Tag & kWandTagMaxFreq) != 0;
+
+  static constexpr bool kNorm =
+    kDivNorm || kMinNorm || (Tag & kWandTagNorm) != 0;
+
  public:
-  struct Value {
-    uint32_t freq{};
-    uint32_t delta_norm{};
+  struct Entry {
+    IRS_NO_UNIQUE_ADDRESS utils::Need<kMaxScore, score_t> score{0.f};
+    uint32_t freq{1};
+    IRS_NO_UNIQUE_ADDRESS utils::Need<kNorm, uint32_t> norm{
+      std::numeric_limits<uint32_t>::max()};
   };
 
+  static void Produce(const Entry& from, Entry& to) noexcept {
+    if constexpr (kMaxFreq) {
+      if (from.freq > to.freq) {
+        to.freq = from.freq;
+      }
+      if constexpr (kMinNorm) {
+        if (from.norm < to.norm) {
+          to.norm = from.norm;
+        }
+        if (to.norm < to.freq) {
+          to.norm = to.freq;
+        }
+      }
+    } else if constexpr (kDivNorm) {
+      if (static_cast<uint64_t>(from.freq) * to.norm >
+          static_cast<uint64_t>(to.freq) * from.norm) {
+        to.freq = from.freq;
+        to.norm = from.norm;
+      }
+    } else if constexpr (kMaxScore) {
+      if (from.score > to.score) {
+        to.score = from.score;
+        to.freq = from.freq;
+        to.norm = from.norm;
+      }
+    }
+  }
+
   template<typename Output>
-  static void Write(Value value, Output& out) {
-    out.write_vint(value.freq);
-    out.write_vint(value.delta_norm);
+  static void Write(Entry entry, Output& out) {
+    // TODO(MBkkt) Compute difference second time looks unnecessary.
+    // TODO(MBkkt) Saving freq == 1 and freq == norm looks unnecessary.
+    //  We can avoid it because we're storing size, but do we want it?
+    //  It could makes read slower.
+    IRS_ASSERT(entry.freq >= 1);
+    out.write_vint(entry.freq);
+    if constexpr (kNorm) {
+      IRS_ASSERT(entry.norm >= entry.freq);
+      if (entry.norm != entry.freq) {
+        out.write_vint(entry.norm - entry.freq);
+      }
+    }
   }
 
-  static size_t Size(Value value) noexcept {
-    return bytes_io<uint32_t>::vsize(value.freq) +
-           bytes_io<uint32_t>::vsize(value.delta_norm);
+  static size_t Size(Entry entry) noexcept {
+    IRS_ASSERT(entry.freq >= 1);
+    size_t size = bytes_io<uint32_t>::vsize(entry.freq);
+    if constexpr (kNorm) {
+      IRS_ASSERT(entry.norm >= entry.freq);
+      if (entry.norm != entry.freq) {
+        size += bytes_io<uint32_t>::vsize(entry.norm - entry.freq);
+      }
+    }
+    return size;
   }
 
-  explicit FreqNormProducer(const Scorer& scorer) : ValueProducerBase{scorer} {}
+  explicit FreqNormProducer(const Scorer& scorer) : scorer_{scorer} {}
 
   bool Prepare(const ColumnProvider& reader, const feature_map_t& features,
                const attribute_provider& attrs) {
     freq_ = irs::get<frequency>(attrs);
 
-    if (!freq_) {
+    if (IRS_UNLIKELY(freq_ == nullptr)) {
       return false;
     }
 
-    const auto* doc = irs::get<irs::document>(attrs);
+    if constexpr (kNorm) {
+      const auto* doc = irs::get<irs::document>(attrs);
 
-    if (IRS_UNLIKELY(!doc)) {
-      return false;
+      if (IRS_UNLIKELY(doc == nullptr)) {
+        return false;
+      }
+
+      const auto it = features.find(irs::type<Norm2>::id());
+
+      if (IRS_UNLIKELY(it == features.end() ||
+                       !field_limits::valid(it->second))) {
+        return false;
+      }
+
+      Norm2::Context ctx;
+      if (IRS_UNLIKELY(!ctx.Reset(reader, it->second, *doc))) {
+        return false;
+      }
+
+      norm_ = Norm2::MakeReader(std::move(ctx), [&](auto&& reader) {
+        return fu2::unique_function<uint32_t()>{std::move(reader)};
+      });
     }
 
-    const auto norm = features.find(irs::type<Norm2>::id());
-
-    if (norm == features.end() || !field_limits::valid(norm->second)) {
-      return false;
-    }
-
-    Norm2::Context ctx;
-    if (!ctx.Reset(reader, norm->second, *doc)) {
-      return false;
-    }
-
-    norm_ = Norm2::MakeReader(std::move(ctx), [&](auto&& reader) {
-      return fu2::unique_function<Norm2::ValueType()>{std::move(reader)};
-    });
-
-    return ValueProducerBase::Prepare(reader, features, attrs);
+    return scorer_.Prepare(reader, features, attrs);
   }
 
-  Value GetValue() const noexcept {
-    const auto freq = freq_->value;
-    const auto norm = norm_();
-    IRS_ASSERT(freq <= norm);
-    return {.freq = freq, .delta_norm = norm - freq};
+  void Produce(Entry& to) noexcept {
+    if constexpr (kMaxFreq) {
+      const auto freq = freq_->value;
+      if (freq > to.freq) {
+        to.freq = freq;
+      }
+      if constexpr (kMinNorm) {
+        const auto norm = norm_();
+        if (norm < to.norm) {
+          to.norm = norm;
+        }
+        if (to.norm < to.freq) {
+          to.norm = to.freq;
+        }
+      }
+    } else if constexpr (kDivNorm) {
+      const auto freq = freq_->value;
+      const auto norm = norm_();
+      if (static_cast<uint64_t>(freq) * to.norm >
+          static_cast<uint64_t>(to.freq) * norm) {
+        to.freq = freq;
+        to.norm = norm;
+      }
+    } else if constexpr (kMaxScore) {
+      const auto score = scorer_.GetScore();
+      if (score > to.score) {
+        to.score = score;
+        to.freq = freq_->value;
+        if constexpr (kNorm) {
+          to.norm = norm_();
+        }
+      }
+    }
   }
 
  private:
   const irs::frequency* freq_{};
-  mutable fu2::unique_function<uint32_t()> norm_;
+  IRS_NO_UNIQUE_ADDRESS utils::Need<kNorm, fu2::unique_function<uint32_t()>>
+    norm_{};
+  IRS_NO_UNIQUE_ADDRESS WandScorer<kMaxScore> scorer_;
 };
 
+template<uint32_t Tag>
+using FreqNormWriter = WandWriterImpl<FreqNormProducer<Tag>>;
+
+template<uint32_t Tag>
 class FreqNormSource final : public WandSource {
+  static constexpr bool kNorm = (Tag & kWandTagNorm) != 0;
+
  public:
   attribute* get_mutable(type_info::type_id type) final {
     if (irs::type<frequency>::id() == type) {
       return &freq_;
     }
-    if (irs::type<Norm2>::id() == type) {
-      return &norm_;
+    if constexpr (kNorm) {
+      if (irs::type<Norm2>::id() == type) {
+        return &norm_;
+      }
     }
     return nullptr;
   }
 
-  void Read(data_input& in) final {
+  void Read(data_input& in, size_t size) final {
     freq_.value = in.read_vint();
-    norm_.value = freq_.value + in.read_vint();
+    if constexpr (kNorm) {
+      // TODO(MBkkt) don't compute vsize here
+      const auto read = bytes_io<uint32_t>::vsize(freq_.value);
+      norm_.value = freq_.value;
+      IRS_ASSERT(read <= size);
+      if (read != size) {
+        norm_.value += in.read_vint();
+      }
+    }
   }
 
  private:
   frequency freq_;
-  Norm2 norm_;
+  IRS_NO_UNIQUE_ADDRESS utils::Need<kNorm, Norm2> norm_;
 };
-
-class FreqProducer : public ValueProducerBase {
- public:
-  struct Value {
-    uint32_t freq{};
-  };
-
-  template<typename Output>
-  static void Write(Value value, Output& out) {
-    out.write_vint(value.freq);
-  }
-
-  static size_t Size(Value value) noexcept {
-    return bytes_io<uint32_t>::vsize(value.freq);
-  }
-
-  explicit FreqProducer(const Scorer& scorer) : ValueProducerBase{scorer} {}
-
-  bool Prepare(const ColumnProvider& reader, const feature_map_t& features,
-               const attribute_provider& attrs) {
-    freq_ = irs::get<frequency>(attrs);
-
-    if (!freq_) {
-      return false;
-    }
-
-    return ValueProducerBase::Prepare(reader, features, attrs);
-  }
-
-  Value GetValue() const noexcept { return {.freq = freq_->value}; }
-
- private:
-  const frequency* freq_{};
-};
-
-class FreqSource final : public WandSource {
- public:
-  attribute* get_mutable(type_info::type_id type) final {
-    if (irs::type<frequency>::id() == type) {
-      return &freq_;
-    }
-    return nullptr;
-  }
-
-  void Read(data_input& in) final { freq_.value = in.read_vint(); }
-
- private:
-  frequency freq_;
-};
-
-template<bool HasNorms>
-using WandProducer =
-  std::conditional_t<HasNorms, FreqNormProducer, FreqProducer>;
-
-template<bool HasNorms>
-using WandAttributes = std::conditional_t<HasNorms, FreqNormSource, FreqSource>;
 
 }  // namespace irs

--- a/core/search/bm25.hpp
+++ b/core/search/bm25.hpp
@@ -94,6 +94,8 @@ class BM25 final : public irs::ScorerBase<BM25, BM25Stats> {
 
   TermCollector::ptr prepare_term_collector() const final;
 
+  WandType wand_type() const noexcept final;
+
   bool equals(const Scorer& other) const noexcept final;
 
   float_t k() const noexcept { return k_; }

--- a/core/search/scorer.hpp
+++ b/core/search/scorer.hpp
@@ -115,7 +115,7 @@ struct TermCollector {
 struct WandSource : attribute_provider {
   using ptr = std::unique_ptr<WandSource>;
 
-  virtual void Read(data_input& in) = 0;
+  virtual void Read(data_input& in, size_t size) = 0;
 };
 
 struct WandWriter {
@@ -135,10 +135,10 @@ struct WandWriter {
   virtual void Update() = 0;
 
   virtual void Write(size_t level, memory_index_output& out) = 0;
-  virtual void WriteRoot(index_output& out) = 0;
+  virtual void WriteRoot(size_t level, index_output& out) = 0;
 
   virtual byte_type Size(size_t level) const = 0;
-  virtual byte_type SizeRoot() = 0;
+  virtual byte_type SizeRoot(size_t level) = 0;
 };
 
 // Base class for all scorers.
@@ -195,6 +195,20 @@ struct Scorer {
   virtual WandWriter::ptr prepare_wand_writer(size_t max_levels) const = 0;
 
   virtual WandSource::ptr prepare_wand_source() const = 0;
+
+  enum class WandType : uint8_t {
+    kNone = 0,
+    kDivNorm = 1,
+    kMaxFreq = 2,
+    kMinNorm = 3,
+  };
+
+  virtual WandType wand_type() const noexcept { return WandType::kNone; }
+
+  // 0 -- not compatible
+  // x -- degree of compatibility
+  // 255 -- compatible, same types
+  static uint8_t compatible(WandType lhs, WandType rhs) noexcept;
 
   // Number of bytes (first) and alignment (first) required to store stats
   // Alignment must satisfy the following requirements:

--- a/core/search/scorer_impl.hpp
+++ b/core/search/scorer_impl.hpp
@@ -86,8 +86,6 @@ struct TermCollectorImpl final : TermCollector {
   void write(data_output& out) const final { out.write_vlong(docs_with_term); }
 };
 
-struct Empty final {};
-
 inline constexpr frequency kEmptyFreq;
 
 template<typename Ctx>

--- a/core/search/tfidf.hpp
+++ b/core/search/tfidf.hpp
@@ -67,6 +67,8 @@ class TFIDF final : public irs::ScorerBase<TFIDF, TFIDFStats> {
 
   WandSource::ptr prepare_wand_source() const final;
 
+  WandType wand_type() const noexcept final;
+
   bool equals(const Scorer& other) const noexcept final;
 
   bool normalize() const noexcept { return normalize_; }

--- a/core/utils/empty.hpp
+++ b/core/utils/empty.hpp
@@ -1,0 +1,39 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2023 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Valery Mironov
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <type_traits>
+
+#include "shared.hpp"
+
+namespace irs::utils {
+
+struct Empty final {
+  template<typename... Args>
+  Empty(Args&&... /*args*/) {}
+};
+
+template<bool Condition, typename T>
+using Need = std::conditional_t<Condition, T, Empty>;
+
+}  // namespace irs::utils

--- a/core/utils/fstext/fst_builder.hpp
+++ b/core/utils/fstext/fst_builder.hpp
@@ -136,6 +136,7 @@ class fst_builder : util::noncopyable {
       if (last_out != weight_t::One()) {
         auto prefix = fst::Plus(last_out, output);
         const auto suffix = fst::DivideLeft(last_out, prefix);
+        output = fst::DivideLeft(output, prefix);
 
         for (arc& a : s.arcs) {
           a.out = fst::Times(suffix, a.out);
@@ -145,8 +146,11 @@ class fst_builder : util::noncopyable {
           s.out = fst::Times(suffix, s.out);
         }
 
-        last_out = std::move(prefix);
-        output = fst::DivideLeft(output, last_out);
+        if constexpr (std::is_same_v<decltype(prefix), irs::bytes_view>) {
+          last_out.Resize(prefix.size());
+        } else {
+          last_out = std::move(prefix);
+        }
       }
     }
 

--- a/core/utils/fstext/fst_string_weight.hpp
+++ b/core/utils/fstext/fst_string_weight.hpp
@@ -62,9 +62,9 @@ struct StringLeftWeightTraits {
 template<typename Label>
 class StringLeftWeight : public StringLeftWeightTraits<Label> {
  public:
-  typedef StringLeftWeight<Label> ReverseWeight;
-  typedef std::basic_string<Label> str_t;
-  typedef typename str_t::const_iterator iterator;
+  using ReverseWeight = StringLeftWeight<Label>;
+  using str_t = std::basic_string<Label>;
+  using iterator = typename str_t::const_iterator;
 
   static const std::string& Type() {
     static const std::string type = "left_string";
@@ -516,6 +516,10 @@ inline irs::bytes_view DivideLeft(irs::bytes_view lhs,
 
 inline irs::bytes_view DivideLeft(const StringLeftWeight<irs::byte_type>& lhs,
                                   irs::bytes_view rhs) {
+  return DivideLeftImpl(lhs, rhs);
+}
+
+inline irs::bytes_view DivideLeft(irs::bytes_view lhs, irs::bytes_view rhs) {
   return DivideLeftImpl(lhs, rhs);
 }
 

--- a/tests/formats/formats_15_tests.cpp
+++ b/tests/formats/formats_15_tests.cpp
@@ -59,12 +59,12 @@ struct FreqScorer : irs::ScorerBase<void> {
   }
 
   irs::WandWriter::ptr prepare_wand_writer(size_t max_levels) const {
-    return std::make_unique<irs::WandWriterImpl<irs::FreqProducer>>(*this,
-                                                                    max_levels);
+    return std::make_unique<irs::FreqNormWriter<irs::kWandTagMaxScore>>(
+      *this, max_levels);
   }
 
   irs::WandSource::ptr prepare_wand_source() const {
-    return std::make_unique<irs::FreqSource>();
+    return std::make_unique<irs::FreqNormSource<irs::kWandTagFreq>>();
   }
 };
 

--- a/tests/index/doc_generator.cpp
+++ b/tests/index/doc_generator.cpp
@@ -758,7 +758,18 @@ void normalized_string_json_field_factory(
     doc.insert(std::make_shared<string_field>(
       name, data.str, irs::IndexFeatures::NONE,
       std::vector<irs::type_info::type_id>{irs::type<irs::Norm>::id()}));
-    ;
+  } else {
+    generic_json_field_factory(doc, name, data);
+  }
+}
+
+void norm2_string_json_field_factory(
+  tests::document& doc, const std::string& name,
+  const json_doc_generator::json_value& data) {
+  if (json_doc_generator::ValueType::STRING == data.vt) {
+    doc.insert(std::make_shared<string_field>(
+      name, data.str, irs::IndexFeatures::NONE,
+      std::vector<irs::type_info::type_id>{irs::type<irs::Norm2>::id()}));
   } else {
     generic_json_field_factory(doc, name, data);
   }

--- a/tests/index/doc_generator.hpp
+++ b/tests/index/doc_generator.hpp
@@ -746,6 +746,10 @@ void normalized_string_json_field_factory(
   tests::document& doc, const std::string& name,
   const json_doc_generator::json_value& data);
 
+void norm2_string_json_field_factory(
+  tests::document& doc, const std::string& name,
+  const json_doc_generator::json_value& data);
+
 template<typename Indexed>
 bool insert(irs::IndexWriter& writer, Indexed ibegin, Indexed iend) {
   auto ctx = writer.GetBatch();

--- a/tests/index/index_tests.hpp
+++ b/tests/index/index_tests.hpp
@@ -200,8 +200,9 @@ class index_test_base : public virtual test_param_base<index_test_context> {
     return irs::IndexWriter::Make(*dir_, codec_, mode, options);
   }
 
-  irs::DirectoryReader open_reader() const {
-    return irs::DirectoryReader{*dir_, codec_};
+  irs::DirectoryReader open_reader(
+    const irs::IndexReaderOptions& options = {}) const {
+    return irs::DirectoryReader{*dir_, codec_, options};
   }
 
   void AssertSnapshotEquality(const irs::IndexWriter& writer);

--- a/tests/resources/simple_single_column_multi_term_norm.json
+++ b/tests/resources/simple_single_column_multi_term_norm.json
@@ -1,0 +1,392 @@
+[
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a b"
+  },
+  {
+    "name": "a a a b b"
+  },
+  {
+    "name": "a b"
+  }
+]

--- a/tests/search/wand_test.cpp
+++ b/tests/search/wand_test.cpp
@@ -314,8 +314,12 @@ TEST_P(WandTestCase, TermFilterMultipleScorersDense) {
   Scorers scorers;
   scorers.PushBack<irs::TFIDF>(false);
   scorers.PushBack<irs::TFIDF>(true);
-  scorers.PushBack<irs::BM25>();
-  scorers.PushBack<irs::BM25>(irs::BM25::K(), 0);
+  const auto& bm25 = scorers.PushBack<irs::BM25>();
+  ASSERT_FALSE(bm25.IsBM15() || bm25.IsBM11());
+  const auto& bm15 = scorers.PushBack<irs::BM25>(irs::BM25::K(), 0.f);
+  ASSERT_TRUE(bm15.IsBM15());
+  const auto& bm11 = scorers.PushBack<irs::BM25>(irs::BM25::K(), 1.f);
+  ASSERT_TRUE(bm11.IsBM11());
 
   GenerateSegment(scorers, true);
   AssertTermFilter(scorers);
@@ -339,8 +343,12 @@ TEST_P(WandTestCase, TermFilterMultipleScorersSparse) {
   Scorers scorers;
   scorers.PushBack<irs::TFIDF>(false);
   scorers.PushBack<irs::TFIDF>(true);
-  scorers.PushBack<irs::BM25>();
-  scorers.PushBack<irs::BM25>(irs::BM25::K(), 0);
+  const auto& bm25 = scorers.PushBack<irs::BM25>();
+  ASSERT_FALSE(bm25.IsBM15() || bm25.IsBM11());
+  const auto& bm15 = scorers.PushBack<irs::BM25>(irs::BM25::K(), 0.f);
+  ASSERT_TRUE(bm15.IsBM15());
+  const auto& bm11 = scorers.PushBack<irs::BM25>(irs::BM25::K(), 1.f);
+  ASSERT_TRUE(bm11.IsBM11());
 
   GenerateSegment(scorers, false);
   AssertTermFilter(scorers);
@@ -380,8 +388,17 @@ TEST_P(WandTestCase, TermFilterBM25) {
 
 TEST_P(WandTestCase, TermFilterBM15) {
   Scorers scorers;
-  auto& scorer = scorers.PushBack<irs::BM25>(irs::BM25::K(), 0);
+  auto& scorer = scorers.PushBack<irs::BM25>(irs::BM25::K(), 0.f);
   ASSERT_TRUE(scorer.IsBM15());
+
+  GenerateSegment(scorers, true);
+  AssertTermFilter(scorers);
+}
+
+TEST_P(WandTestCase, TermFilterBM11) {
+  Scorers scorers;
+  auto& scorer = scorers.PushBack<irs::BM25>(irs::BM25::K(), 1.f);
+  ASSERT_TRUE(scorer.IsBM11());
 
   GenerateSegment(scorers, true);
   AssertTermFilter(scorers);

--- a/utils/index-search.cpp
+++ b/utils/index-search.cpp
@@ -510,6 +510,7 @@ int search(std::string_view path, std::string_view dir_type,
     }
     return 1;
   }
+  auto* score = scr.get();
 
   auto dir = create_directory(dir_type, path);
 
@@ -550,10 +551,14 @@ int search(std::string_view path, std::string_view dir_type,
   irs::DirectoryReader reader;
   irs::Scorers order;
   irs::async_utils::thread_pool thread_pool(search_threads);
+  irs::IndexReaderOptions options;
+  if (wand.Enabled()) {
+    options.scorers = {&score, 1};
+  }
 
   {
     SCOPED_TIMER("Index read time");
-    reader = irs::DirectoryReader(*dir, codec);
+    reader = irs::DirectoryReader(*dir, codec, options);
   }
 
   std::cout << "Index stats:\n"

--- a/utils/main.cpp
+++ b/utils/main.cpp
@@ -106,6 +106,9 @@ int main(int argc, char* argv[]) {
   irs::Finally output_stats = []() noexcept {
     irs::timer_utils::visit(
       [](const std::string& key, size_t count, size_t time_us) -> bool {
+        if (count == 0) {
+          return true;
+        }
         std::cout << key << " calls:" << count << ", time: " << time_us
                   << " us, avg call: " << time_us / double(count) << " us"
                   << std::endl;


### PR DESCRIPTION
* Don't compute real score for tfidf, bm15, bm11 on index stage
* Add valid for any BM25 less effective option for wand data producer: max tf, min norm
* Don't allow to write wand data for BM1 (constant score, just idf)

Also optimize fst builder: don't need to copy itself prefix