### PR TITLE
Implement wand-like optimization for boolean query

### DIFF
--- a/core/analysis/token_attributes.hpp
+++ b/core/analysis/token_attributes.hpp
@@ -162,26 +162,4 @@ class attribute_provider_change final : public attribute {
   mutable callback_f callback_{&noop};
 };
 
-// min score set by document consumers
-// *_max set by document producers
-struct score_threshold final : public attribute {
-  // DO NOT CHANGE NAME
-  static constexpr std::string_view type_name() noexcept {
-    return "iresearch::score_threshold";
-  }
-
-  score_t min;
-  // For disjunction/conjunction it's just sum of sub-iterators max score
-  // For iterator without score it depends on count of documents in iterator
-  // For wanderator it's max score for whole skip-list
-  // TODO(MBkkt) tail_max better here and not affect correctness
-  //  but to support it we need to know max value in the tail blocks.
-  //  Open question: how do it without read next blocks?
-  score_t list_max{};
-  const score_t* leaf_max{};
-#ifdef IRESEARCH_TEST                   // Used for tests
-  std::span<const score_t> levels_max;  // levels_max.back() == *leaf_max
-#endif
-};
-
 }  // namespace irs

--- a/core/formats/formats.hpp
+++ b/core/formats/formats.hpp
@@ -63,7 +63,7 @@ using DocMapView = std::span<const doc_id_t>;
 using callback_f = std::function<bool(doc_iterator&)>;
 
 using ScoreFunctionFactory =
-  std::function<ScoreFunction(const attribute_provider&, const Scorer&)>;
+  std::function<ScoreFunction(const attribute_provider&)>;
 
 struct WanderatorOptions {
   ScoreFunctionFactory factory;

--- a/core/formats/formats_10.cpp
+++ b/core/formats/formats_10.cpp
@@ -25,7 +25,6 @@
 #include <limits>
 
 extern "C" {
-#include <avxbitpacking.h>
 #include <simdbitpacking.h>
 }
 
@@ -1131,7 +1130,7 @@ struct position_impl;
 template<typename IteratorTraits, typename FieldTraits>
 struct position_impl<IteratorTraits, FieldTraits, true, true>
   : public position_impl<IteratorTraits, FieldTraits, false, false> {
-  typedef position_impl<IteratorTraits, FieldTraits, false, false> base;
+  using base = position_impl<IteratorTraits, FieldTraits, false, false>;
 
   irs::attribute* attribute(irs::type_info::type_id type) noexcept {
     if (irs::type<payload>::id() == type) {
@@ -1265,7 +1264,7 @@ struct position_impl<IteratorTraits, FieldTraits, true, true>
 template<typename IteratorTraits, typename FieldTraits>
 struct position_impl<IteratorTraits, FieldTraits, false, true>
   : public position_impl<IteratorTraits, FieldTraits, false, false> {
-  typedef position_impl<IteratorTraits, FieldTraits, false, false> base;
+  using base = position_impl<IteratorTraits, FieldTraits, false, false>;
 
   irs::attribute* attribute(irs::type_info::type_id type) noexcept {
     return irs::type<payload>::id() == type ? &pay_ : nullptr;
@@ -1386,7 +1385,7 @@ struct position_impl<IteratorTraits, FieldTraits, false, true>
 template<typename IteratorTraits, typename FieldTraits>
 struct position_impl<IteratorTraits, FieldTraits, true, false>
   : public position_impl<IteratorTraits, FieldTraits, false, false> {
-  typedef position_impl<IteratorTraits, FieldTraits, false, false> base;
+  using base = position_impl<IteratorTraits, FieldTraits, false, false>;
 
   irs::attribute* attribute(irs::type_info::type_id type) noexcept {
     return irs::type<offset>::id() == type ? &offs_ : nullptr;
@@ -1588,7 +1587,7 @@ struct position_impl<IteratorTraits, FieldTraits, false, false> {
 template<typename IteratorTraits, typename FieldTraits,
          bool Position = IteratorTraits::position()>
 class position final : public irs::position,
-                       protected position_impl<IteratorTraits, FieldTraits> {
+                       private position_impl<IteratorTraits, FieldTraits> {
  public:
   using impl = position_impl<IteratorTraits, FieldTraits>;
 
@@ -1813,39 +1812,42 @@ void doc_iterator_base<IteratorTraits, FieldTraits>::read_tail_block() {
 }
 
 template<typename IteratorTraits, typename FieldTraits>
-using Attributes = std::conditional_t<
-  IteratorTraits::frequency() && IteratorTraits::position(),
-  std::tuple<document, frequency, score_threshold, score, cost,
+using AttributesT = std::conditional_t<
+  IteratorTraits::position(),
+  std::tuple<document, frequency, score, cost,
              position<IteratorTraits, FieldTraits>>,
-  std::conditional_t<
-    IteratorTraits::frequency(),
-    std::tuple<document, frequency, score_threshold, score, cost>,
-    std::tuple<document, score_threshold, score, cost>>>;
+  std::conditional_t<IteratorTraits::frequency(),
+                     std::tuple<document, frequency, score, cost>,
+                     std::tuple<document, score, cost>>>;
 
 template<typename IteratorTraits, typename FieldTraits>
 class single_doc_iterator
   : public irs::doc_iterator,
-    private std::conditional_t<IteratorTraits::frequency() &&
-                                 IteratorTraits::position(),
+    private std::conditional_t<IteratorTraits::position(),
                                data_buffer<IteratorTraits>, empty> {
   static_assert((IteratorTraits::features() & FieldTraits::features()) ==
                 IteratorTraits::features());
 
-  using attributes = Attributes<IteratorTraits, FieldTraits>;
+  using Attributes = AttributesT<IteratorTraits, FieldTraits>;
+  using Position = position<IteratorTraits, FieldTraits>;
 
  public:
   single_doc_iterator() = default;
 
   void WandPrepare(const term_meta& meta, const index_input* pos_in,
                    const index_input* pay_in,
-                   const ScoreFunctionFactory& factory, const Scorer& scorer) {
+                   const ScoreFunctionFactory& factory) {
     prepare(meta, pos_in, pay_in);
-    auto func = factory(*this, scorer);
+    auto func = factory(*this);
+
     auto& doc = std::get<document>(attrs_);
     doc.value = next_;
-    auto& threshold = std::get<score_threshold>(attrs_);
-    func(&threshold.list_max);
-    threshold.leaf_max = &threshold.list_max;
+
+    auto& score = std::get<irs::score>(attrs_);
+    func(&score.max.leaf);
+    score.max.tail = score.max.leaf;
+    score = ScoreFunction::Constant(score.max.tail);
+
     doc.value = doc_limits::invalid();
   }
 
@@ -1853,6 +1855,7 @@ class single_doc_iterator
                [[maybe_unused]] const index_input* pos_in,
                [[maybe_unused]] const index_input* pay_in);
 
+ private:
   attribute* get_mutable(irs::type_info::type_id type) noexcept final {
     return irs::get_mutable(attrs_, type);
   }
@@ -1879,7 +1882,7 @@ class single_doc_iterator
 
     if constexpr (IteratorTraits::position()) {
       if (!doc_limits::eof(doc.value)) {
-        auto& pos = std::get<position<IteratorTraits, FieldTraits>>(attrs_);
+        auto& pos = std::get<Position>(attrs_);
         pos.notify(std::get<frequency>(attrs_).value);
         pos.clear();
       }
@@ -1888,9 +1891,8 @@ class single_doc_iterator
     return !doc_limits::eof(doc.value);
   }
 
- private:
   doc_id_t next_{doc_limits::eof()};
-  attributes attrs_;
+  Attributes attrs_;
 };
 
 template<typename IteratorTraits, typename FieldTraits>
@@ -1901,7 +1903,7 @@ void single_doc_iterator<IteratorTraits, FieldTraits>::prepare(
   // must be ensured by the caller
   IRS_ASSERT(meta.docs_count == 1);
 
-  auto& term_state = static_cast<const version10::term_meta&>(meta);
+  const auto& term_state = static_cast<const version10::term_meta&>(meta);
   next_ = doc_limits::min() + term_state.e_single_doc;
   std::get<cost>(attrs_).reset(1);  // estimate iterator
 
@@ -1931,23 +1933,20 @@ void single_doc_iterator<IteratorTraits, FieldTraits>::prepare(
         .tail_start = get_tail_start(),
         .tail_length = term_freq % IteratorTraits::block_size()};
 
-      std::get<position<IteratorTraits, FieldTraits>>(attrs_).prepare(state);
+      std::get<Position>(attrs_).prepare(state);
     }
   }
 }
 
-static constexpr size_t kDynamicValue = std::numeric_limits<byte_type>::max();
-static_assert(kMaxScorers < kDynamicValue);
+static_assert(kMaxScorers < WandContext::kDisable);
 
 template<byte_type Value>
 struct Extent {
-  Extent(byte_type) {}
-
   static constexpr byte_type GetExtent() noexcept { return Value; }
 };
 
 template<>
-struct Extent<kDynamicValue> {
+struct Extent<WandContext::kDisable> {
   Extent(byte_type value) noexcept : value{value} {}
 
   constexpr byte_type GetExtent() const noexcept { return value; }
@@ -1955,15 +1954,23 @@ struct Extent<kDynamicValue> {
   byte_type value;
 };
 
-template<typename Func>
+using DynamicExtent = Extent<WandContext::kDisable>;
+
+template<byte_type PossibleMin, typename Func>
 auto ResolveExtent(byte_type extent, Func&& func) {
-  switch (extent) {
-    case 0:
-      return std::forward<Func>(func)(Extent<0>{0});
-    case 1:
-      return std::forward<Func>(func)(Extent<1>{0});
-    default:
-      return std::forward<Func>(func)(Extent<kDynamicValue>{extent});
+  if constexpr (PossibleMin == WandContext::kDisable) {
+    return std::forward<Func>(func)(Extent<0>{});
+  } else {
+    switch (extent) {
+      case 1:
+        return std::forward<Func>(func)(Extent<1>{});
+      case 0:
+        if constexpr (PossibleMin <= 0) {
+          return std::forward<Func>(func)(Extent<0>{});
+        }
+      default:
+        return std::forward<Func>(func)(DynamicExtent{extent});
+    }
   }
 }
 
@@ -1989,47 +1996,39 @@ void CommonSkipWandData(WandExtent extent, index_input& in) {
   }
 }
 
-template<typename WandExtent, typename WandIndex>
-void CommonReadWandData(WandExtent wextent, WandIndex windex,
+template<typename WandExtent>
+void CommonReadWandData(WandExtent wextent, byte_type index,
                         const ScoreFunction& func, WandSource& ctx,
                         index_input& in, score_t& score) {
   const auto extent = wextent.GetExtent();
   IRS_ASSERT(extent);
+  IRS_ASSERT(index < extent);
   if (IRS_LIKELY(extent == 1)) {
-    auto size = in.read_byte();
+    const auto size = in.read_byte();
     ctx.Read(in, size);
     func(&score);
-  } else {
-    const auto [scorer_offset, size, block_offset] = [&]() {
-      const auto index = windex.GetExtent();
-      IRS_ASSERT(index < extent);
+    return;
+  }
 
-      byte_type i = 0;
+  byte_type i = 0;
+  uint64_t scorer_offset = 0;
+  for (; i < index; ++i) {
+    scorer_offset += in.read_byte();
+  }
+  const auto size = in.read_byte();
+  ++i;
+  uint64_t block_offset = 0;
+  for (; i < extent; ++i) {
+    block_offset += in.read_byte();
+  }
 
-      uint64_t offset_before = 0;
-      for (; i < index; ++i) {
-        offset_before += in.read_byte();
-      }
-
-      const auto size = in.read_byte();
-      ++i;
-
-      uint64_t offset_after = 0;
-      for (; i < extent; ++i) {
-        offset_after += in.read_byte();
-      }
-
-      return std::tuple{offset_before, size, offset_after};
-    }();
-
-    if (scorer_offset) {
-      in.skip(scorer_offset);
-    }
-    ctx.Read(in, size);
-    func(&score);
-    if (block_offset) {
-      in.skip(block_offset);
-    }
+  if (scorer_offset) {
+    in.skip(scorer_offset);
+  }
+  ctx.Read(in, size);
+  func(&score);
+  if (block_offset) {
+    in.skip(block_offset);
   }
 }
 
@@ -2038,7 +2037,8 @@ void CommonReadWandData(WandExtent wextent, WandIndex windex,
 // FieldTraits defines requested features.
 template<typename IteratorTraits, typename FieldTraits, typename WandExtent>
 class doc_iterator : public doc_iterator_base<IteratorTraits, FieldTraits> {
-  using attributes = Attributes<IteratorTraits, FieldTraits>;
+  using Attributes = AttributesT<IteratorTraits, FieldTraits>;
+  using Position = position<IteratorTraits, FieldTraits>;
 
  public:
   // hide 'ptr' defined in irs::doc_iterator
@@ -2060,9 +2060,9 @@ class doc_iterator : public doc_iterator_base<IteratorTraits, FieldTraits> {
     if (meta.docs_count > FieldTraits::block_size()) {
       return;
     }
-    auto& threshold = std::get<score_threshold>(attrs_);
     auto ctx = scorer.prepare_wand_source();
-    auto func = factory(*ctx, scorer);
+    auto func = factory(*ctx);
+
     auto old_offset = std::numeric_limits<size_t>::max();
     if (meta.docs_count == FieldTraits::block_size()) {
       old_offset = this->doc_in_->file_pointer();
@@ -2071,12 +2071,15 @@ class doc_iterator : public doc_iterator_base<IteratorTraits, FieldTraits> {
         FieldTraits::skip_block(*this->doc_in_);
       }
     }
+
+    auto& score = std::get<irs::score>(attrs_);
     skip_.Reader().ReadMaxScore(wand_index, func, *ctx, *this->doc_in_,
-                                threshold.list_max);
+                                score.max.tail);
+    score.max.leaf = score.max.tail;
+
     if (old_offset != std::numeric_limits<size_t>::max()) {
       this->doc_in_->seek(old_offset);
     }
-    threshold.leaf_max = &threshold.list_max;
   }
 
   void prepare(const term_meta& meta, const index_input* doc_in,
@@ -2084,6 +2087,7 @@ class doc_iterator : public doc_iterator_base<IteratorTraits, FieldTraits> {
                [[maybe_unused]] const index_input* pay_in,
                byte_type wand_index = WandContext::kDisable);
 
+ private:
   attribute* get_mutable(irs::type_info::type_id type) noexcept final {
     return irs::get_mutable(attrs_, type);
   }
@@ -2124,7 +2128,7 @@ class doc_iterator : public doc_iterator_base<IteratorTraits, FieldTraits> {
       freq.value = *this->freq_++;  // update frequency attribute
 
       if constexpr (IteratorTraits::position()) {
-        auto& pos = std::get<position<IteratorTraits, FieldTraits>>(attrs_);
+        auto& pos = std::get<Position>(attrs_);
         pos.notify(freq.value);
         pos.clear();
       }
@@ -2148,8 +2152,8 @@ class doc_iterator : public doc_iterator_base<IteratorTraits, FieldTraits> {
 
     void ReadMaxScore(byte_type index, const ScoreFunction& func,
                       WandSource& ctx, index_input& in, score_t& score) {
-      CommonReadWandData(static_cast<WandExtent>(*this),
-                         Extent<kDynamicValue>{index}, func, ctx, in, score);
+      CommonReadWandData(static_cast<WandExtent>(*this), index, func, ctx, in,
+                         score);
     }
 
     void Disable() noexcept {
@@ -2221,8 +2225,8 @@ class doc_iterator : public doc_iterator_base<IteratorTraits, FieldTraits> {
 
   uint64_t skip_offs_{};
   SkipReader<ReadSkip> skip_;
-  attributes attrs_;
-  doc_id_t docs_count_{};
+  Attributes attrs_;
+  uint32_t docs_count_{};
 };
 
 template<typename IteratorTraits, typename FieldTraits, typename WandExtent>
@@ -2302,7 +2306,7 @@ void doc_iterator<IteratorTraits, FieldTraits, WandExtent>::prepare(
       .tail_start = get_tail_start(),
       .tail_length = term_freq % IteratorTraits::block_size()};
 
-    std::get<position<IteratorTraits, FieldTraits>>(attrs_).prepare(state);
+    std::get<Position>(attrs_).prepare(state);
   }
 
   if (term_state.docs_count > IteratorTraits::block_size()) {
@@ -2357,7 +2361,7 @@ doc_id_t doc_iterator<IteratorTraits, FieldTraits, WandExtent>::seek(
     } else {
       IRS_ASSERT(IteratorTraits::frequency());
       auto& freq = std::get<frequency>(attrs_);
-      auto& pos = std::get<position<IteratorTraits, FieldTraits>>(attrs_);
+      auto& pos = std::get<Position>(attrs_);
       freq.value = *this->freq_++;
       notify += freq.value;
 
@@ -2370,7 +2374,7 @@ doc_id_t doc_iterator<IteratorTraits, FieldTraits, WandExtent>::seek(
   }
 
   if constexpr (IteratorTraits::position()) {
-    std::get<position<IteratorTraits, FieldTraits>>(attrs_).notify(notify);
+    std::get<Position>(attrs_).notify(notify);
   }
   while (doc_value < target) {
     next();
@@ -2397,7 +2401,7 @@ void doc_iterator<IteratorTraits, FieldTraits, WandExtent>::seek_to_block(
     this->doc_in_->seek(last.doc_ptr);
     std::get<document>(attrs_).value = last.doc;
     if constexpr (IteratorTraits::position()) {
-      auto& pos = std::get<position<IteratorTraits, FieldTraits>>(attrs_);
+      auto& pos = std::get<Position>(attrs_);
       pos.prepare(last);  // Notify positions
     }
 
@@ -2436,36 +2440,56 @@ void doc_iterator<IteratorTraits, FieldTraits, WandExtent>::seek_to_block(
 // WAND iterator over posting list.
 // IteratorTraits defines requested features.
 // FieldTraits defines requested features.
-template<typename IteratorTraits, typename FieldTraits, typename WandIndex,
-         typename WandExtent, bool Strict>
-class wanderator : public doc_iterator_base<IteratorTraits, FieldTraits> {
- private:
+template<typename IteratorTraits, typename FieldTraits, typename WandExtent,
+         bool Root>
+class wanderator : public doc_iterator_base<IteratorTraits, FieldTraits>,
+                   private score_ctx {
   static_assert(IteratorTraits::wand());
   static_assert(IteratorTraits::frequency());
-  using attributes = Attributes<IteratorTraits, FieldTraits>;
+
+  using Attributes = AttributesT<IteratorTraits, FieldTraits>;
+  using Position = position<IteratorTraits, FieldTraits>;
+
+  static void MinStrict(score_ctx* ctx, score_t arg) noexcept {
+    auto& self = static_cast<wanderator&>(*ctx);
+    self.skip_.Reader().threshold_ = arg;
+  }
+
+  static void MinWeak(score_ctx* ctx, score_t arg) noexcept {
+    MinStrict(ctx, std::nextafter(arg, 0.f));
+  }
 
  public:
   // Hide 'ptr' defined in irs::doc_iterator
   using ptr = memory::managed_ptr<wanderator>;
 
   wanderator(const ScoreFunctionFactory& factory, const Scorer& scorer,
-             WandIndex index, WandExtent extent)
+             WandExtent extent, byte_type index, bool weak)
     : skip_{IteratorTraits::block_size(), postings_writer_base::kSkipN,
             ReadSkip{factory, scorer, index, extent}},
-      scorer_{factory(*this, scorer)} {
+      scorer_{factory(*this)} {
+    IRS_ASSERT(Root || !weak);
     IRS_ASSERT(
       std::all_of(std::begin(this->buf_.docs), std::end(this->buf_.docs),
                   [](doc_id_t doc) { return doc == doc_limits::invalid(); }));
-    std::get<score>(attrs_).Reset(*absl::bit_cast<score_ctx*>(&score_),
-                                  [](score_ctx* ctx, score_t* res) noexcept {
-                                    *res = *absl::bit_cast<score_t*>(ctx);
-                                  });
+    std::get<irs::score>(attrs_).Reset(
+      *this,
+      [](score_ctx* ctx, score_t* res) noexcept {
+        auto& self = static_cast<wanderator&>(*ctx);
+        if constexpr (Root) {
+          *res = self.score_;
+        } else {
+          self.scorer_(res);
+        }
+      },
+      weak ? MinWeak : MinStrict);
   }
 
   void WandPrepare(const term_meta& meta, const index_input* doc_in,
                    [[maybe_unused]] const index_input* pos_in,
                    [[maybe_unused]] const index_input* pay_in);
 
+ private:
   attribute* get_mutable(irs::type_info::type_id type) noexcept final {
     return irs::get_mutable(attrs_, type);
   }
@@ -2478,7 +2502,6 @@ class wanderator : public doc_iterator_base<IteratorTraits, FieldTraits> {
 
   bool next() final { return !doc_limits::eof(seek(value() + 1)); }
 
- private:
   struct SkipScoreContext final : attribute_provider {
     frequency freq;
 
@@ -2493,21 +2516,36 @@ class wanderator : public doc_iterator_base<IteratorTraits, FieldTraits> {
   class ReadSkip {
    public:
     ReadSkip(const ScoreFunctionFactory& factory, const Scorer& scorer,
-             WandIndex index, WandExtent extent)
+             byte_type index, WandExtent extent)
       : ctx_{scorer.prepare_wand_source()},
-        func_{factory(*ctx_, scorer)},
+        func_{factory(*ctx_)},
         index_{index},
         extent_{extent} {
       IRS_ASSERT(extent_.GetExtent() > 0);
     }
 
-    void EnsureSorted() const noexcept;
+    void EnsureSorted() const noexcept {
+      IRS_ASSERT(std::is_sorted(
+        skip_levels_.begin(), skip_levels_.end(),
+        [](const auto& lhs, const auto& rhs) { return lhs.doc > rhs.doc; }));
+      IRS_ASSERT(std::is_sorted(skip_scores_.begin(), skip_scores_.end(),
+                                std::greater<>{}));
+    }
 
-    void ReadMaxScore(score_threshold& threshold, index_input& input);
+    void ReadMaxScore(irs::score& score, index_input& input) {
+      CommonReadWandData(extent_, index_, func_, *ctx_, input, score.max.tail);
+      score.max.leaf = score.max.tail;
+    }
     void Init(const version10::term_meta& state, size_t num_levels,
-              score_threshold& threshold);
-    bool IsLess(size_t level, doc_id_t target) const noexcept;
-    bool IsLessThanUpperBound(doc_id_t target) const noexcept;
+              irs::score& score);
+    bool IsLess(size_t level, doc_id_t target) const noexcept {
+      return skip_levels_[level].doc < target ||
+             skip_scores_[level] <= threshold_;
+    }
+    bool IsLessThanUpperBound(doc_id_t target) const noexcept {
+      return skip_levels_.back().doc < target ||
+             skip_scores_.back() <= threshold_;
+    }
     void MoveDown(size_t level) noexcept {
       auto& next = skip_levels_[level];
 
@@ -2515,20 +2553,22 @@ class wanderator : public doc_iterator_base<IteratorTraits, FieldTraits> {
       CopyState<IteratorTraits>(next, prev_skip_);
     }
     void Read(size_t level, index_input& in);
-    void ReadWandData(size_t level, index_input& in);
+    void ReadWandData(size_t level, index_input& in) {
+      CommonReadWandData(extent_, index_, func_, *ctx_, in,
+                         skip_scores_[level]);
+    }
     void Seal(size_t level);
     size_t AdjustLevel(size_t level) const noexcept;
     SkipState& State() noexcept { return prev_skip_; }
     SkipState& Next() noexcept { return skip_levels_.back(); }
 
-   private:
     WandSource::ptr ctx_;
     ScoreFunction func_;
     std::vector<SkipState> skip_levels_;
     std::vector<score_t> skip_scores_;
     SkipState prev_skip_;  // skip context used by skip reader
-    const score_t* threshold_min_{};
-    IRS_NO_UNIQUE_ADDRESS WandIndex index_;
+    score_t threshold_{};
+    byte_type index_;
     IRS_NO_UNIQUE_ADDRESS WandExtent extent_;
   };
 
@@ -2544,69 +2584,38 @@ class wanderator : public doc_iterator_base<IteratorTraits, FieldTraits> {
     if (skip_.Reader().IsLessThanUpperBound(target)) {
       // Ensured by prepare(...)
       IRS_ASSERT(skip_.NumLevels());
-      IRS_ASSERT(0 == skip_.Reader().State().doc_ptr);
+      // We could decide to make new skip before actual read block
+      // IRS_ASSERT(0 == skip_.Reader().State().doc_ptr);
 
       this->left_ = skip_.Seek(target);
-      // If this is the initial doc_id then
-      // set it to min() for proper delta value
-      const auto doc = skip_.Reader().State().doc;
-      std::get<document>(attrs_).value =
-        doc + doc_id_t{!doc_limits::valid(doc)};
+      auto& doc_value = std::get<document>(attrs_).value;
+      doc_value = skip_.Reader().State().doc;
+      IRS_ASSERT(doc_value < target);
+      std::get<score>(attrs_).max.leaf = skip_.Reader().skip_scores_.back();
       // Will trigger refill in "next"
       this->begin_ = std::end(this->buf_.docs);
     }
   }
 
-  static bool ScoreLess(score_t lhs, score_t rhs) noexcept {
-    if constexpr (Strict) {
-      // For strict comparison we can skip equal scores
-      return lhs <= rhs;
-    } else {
-      return lhs < rhs;
-    }
-  }
-
   SkipReader<ReadSkip> skip_;
-  attributes attrs_;
+  Attributes attrs_;
   ScoreFunction scorer_;  // FIXME(gnusi): can we use only one ScoreFunction?
-  score_t score_;
+  score_t score_{};
 };
 
-template<typename IteratorTraits, typename FieldTraits, typename WandIndex,
-         typename WandExtent, bool Strict>
-void wanderator<IteratorTraits, FieldTraits, WandIndex, WandExtent,
-                Strict>::ReadSkip::EnsureSorted() const noexcept {
-  IRS_ASSERT(std::is_sorted(
-    skip_levels_.begin(), skip_levels_.end(),
-    [](const auto& lhs, const auto& rhs) { return lhs.doc > rhs.doc; }));
-  IRS_ASSERT(std::is_sorted(skip_scores_.begin(), skip_scores_.end(),
-                            [](auto lhs, auto rhs) { return lhs > rhs; }));
-}
-
-template<typename IteratorTraits, typename FieldTraits, typename WandIndex,
-         typename WandExtent, bool Strict>
-void wanderator<IteratorTraits, FieldTraits, WandIndex, WandExtent,
-                Strict>::ReadSkip::ReadMaxScore(score_threshold& threshold,
-                                                index_input& in) {
-  CommonReadWandData(extent_, index_, func_, *ctx_, in, threshold.list_max);
-  threshold.leaf_max = &threshold.list_max;
-  threshold_min_ = &threshold.min;
-}
-
-template<typename IteratorTraits, typename FieldTraits, typename WandIndex,
-         typename WandExtent, bool Strict>
-void wanderator<IteratorTraits, FieldTraits, WandIndex, WandExtent,
-                Strict>::ReadSkip::Init(const version10::term_meta& term_state,
-                                        size_t num_levels,
-                                        score_threshold& threshold) {
+template<typename IteratorTraits, typename FieldTraits, typename WandExtent,
+         bool Root>
+void wanderator<IteratorTraits, FieldTraits, WandExtent, Root>::ReadSkip::Init(
+  const version10::term_meta& term_state, size_t num_levels,
+  irs::score& score) {
   // Don't use wanderator for short posting lists, must be ensured by the caller
   IRS_ASSERT(term_state.docs_count > IteratorTraits::block_size());
 
   skip_levels_.resize(num_levels);
   skip_scores_.resize(num_levels);
-  threshold.leaf_max = &skip_scores_.back();
+  score.max.leaf = skip_scores_.back();
 #ifdef IRESEARCH_TEST
-  threshold.levels_max = std::span{skip_scores_};
+  score.max.levels = std::span{skip_scores_};
 #endif
 
   // Since we store pointer deltas, add postings offset
@@ -2614,35 +2623,10 @@ void wanderator<IteratorTraits, FieldTraits, WandIndex, WandExtent,
   CopyState<IteratorTraits>(top, term_state);
 }
 
-template<typename IteratorTraits, typename FieldTraits, typename WandIndex,
-         typename WandExtent, bool Strict>
-bool wanderator<IteratorTraits, FieldTraits, WandIndex, WandExtent,
-                Strict>::ReadSkip::IsLessThanUpperBound(doc_id_t target)
-  const noexcept {
-  return skip_levels_.back().doc < target ||
-         ScoreLess(skip_scores_.back(), *threshold_min_);
-}
-
-template<typename IteratorTraits, typename FieldTraits, typename WandIndex,
-         typename WandExtent, bool Strict>
-bool wanderator<IteratorTraits, FieldTraits, WandIndex, WandExtent,
-                Strict>::ReadSkip::IsLess(size_t level,
-                                          doc_id_t target) const noexcept {
-  return skip_levels_[level].doc < target ||
-         ScoreLess(skip_scores_[level], *threshold_min_);
-}
-
-template<typename IteratorTraits, typename FieldTraits, typename WandIndex,
-         typename WandExtent, bool Strict>
-void wanderator<IteratorTraits, FieldTraits, WandIndex, WandExtent,
-                Strict>::ReadSkip::ReadWandData(size_t level, index_input& in) {
-  CommonReadWandData(extent_, index_, func_, *ctx_, in, skip_scores_[level]);
-}
-
-template<typename IteratorTraits, typename FieldTraits, typename WandIndex,
-         typename WandExtent, bool Strict>
-void wanderator<IteratorTraits, FieldTraits, WandIndex, WandExtent,
-                Strict>::ReadSkip::Read(size_t level, index_input& in) {
+template<typename IteratorTraits, typename FieldTraits, typename WandExtent,
+         bool Root>
+void wanderator<IteratorTraits, FieldTraits, WandExtent, Root>::ReadSkip::Read(
+  size_t level, index_input& in) {
   auto& last = prev_skip_;
   auto& next = skip_levels_[level];
 
@@ -2653,10 +2637,10 @@ void wanderator<IteratorTraits, FieldTraits, WandIndex, WandExtent,
   ReadWandData(level, in);
 }
 
-template<typename IteratorTraits, typename FieldTraits, typename WandIndex,
-         typename WandExtent, bool Strict>
-size_t wanderator<IteratorTraits, FieldTraits, WandIndex, WandExtent,
-                  Strict>::ReadSkip::AdjustLevel(size_t level) const noexcept {
+template<typename IteratorTraits, typename FieldTraits, typename WandExtent,
+         bool Root>
+size_t wanderator<IteratorTraits, FieldTraits, WandExtent,
+                  Root>::ReadSkip::AdjustLevel(size_t level) const noexcept {
   while (level && skip_levels_[level].doc >= skip_levels_[level - 1].doc) {
     IRS_ASSERT(skip_levels_[level - 1].doc != doc_limits::eof());
     --level;
@@ -2664,10 +2648,10 @@ size_t wanderator<IteratorTraits, FieldTraits, WandIndex, WandExtent,
   return level;
 }
 
-template<typename IteratorTraits, typename FieldTraits, typename WandIndex,
-         typename WandExtent, bool Strict>
-void wanderator<IteratorTraits, FieldTraits, WandIndex, WandExtent,
-                Strict>::ReadSkip::Seal(size_t level) {
+template<typename IteratorTraits, typename FieldTraits, typename WandExtent,
+         bool Root>
+void wanderator<IteratorTraits, FieldTraits, WandExtent, Root>::ReadSkip::Seal(
+  size_t level) {
   auto& last = prev_skip_;
   auto& next = skip_levels_[level];
 
@@ -2679,12 +2663,12 @@ void wanderator<IteratorTraits, FieldTraits, WandIndex, WandExtent,
   skip_scores_[level] = std::numeric_limits<score_t>::max();
 }
 
-template<typename IteratorTraits, typename FieldTraits, typename WandIndex,
-         typename WandExtent, bool Strict>
-void wanderator<IteratorTraits, FieldTraits, WandIndex, WandExtent, Strict>::
-  WandPrepare(const term_meta& meta, const index_input* doc_in,
-              [[maybe_unused]] const index_input* pos_in,
-              [[maybe_unused]] const index_input* pay_in) {
+template<typename IteratorTraits, typename FieldTraits, typename WandExtent,
+         bool Root>
+void wanderator<IteratorTraits, FieldTraits, WandExtent, Root>::WandPrepare(
+  const term_meta& meta, const index_input* doc_in,
+  [[maybe_unused]] const index_input* pos_in,
+  [[maybe_unused]] const index_input* pay_in) {
   // Don't use wanderator for short posting lists, must be ensured by the caller
   IRS_ASSERT(meta.docs_count > IteratorTraits::block_size());
   IRS_ASSERT(this->begin_ == std::end(this->buf_.docs));
@@ -2733,7 +2717,7 @@ void wanderator<IteratorTraits, FieldTraits, WandIndex, WandExtent, Strict>::
       .tail_start = get_tail_start(),
       .tail_length = term_freq % IteratorTraits::block_size()};
 
-    std::get<position<IteratorTraits, FieldTraits>>(attrs_).prepare(state);
+    std::get<Position>(attrs_).prepare(state);
   }
 
   auto skip_in = this->doc_in_->dup();
@@ -2746,15 +2730,15 @@ void wanderator<IteratorTraits, FieldTraits, WandIndex, WandExtent, Strict>::
 
   skip_in->seek(term_state.doc_start + term_state.e_skip_start);
 
-  auto& threshold = std::get<score_threshold>(attrs_);
-  skip_.Reader().ReadMaxScore(threshold, *skip_in);
+  auto& score = std::get<irs::score>(attrs_);
+  skip_.Reader().ReadMaxScore(score, *skip_in);
 
   skip_.Prepare(std::move(skip_in), term_state.docs_count);
 
   // Initialize skip levels
   if (const auto num_levels = skip_.NumLevels(); IRS_LIKELY(
         num_levels > 0 && num_levels <= postings_writer_base::kMaxSkipLevels)) {
-    skip_.Reader().Init(term_state, num_levels, threshold);
+    skip_.Reader().Init(term_state, num_levels, score);
   } else {
     IRS_ASSERT(false);
     throw index_error{absl::StrCat("Invalid number of skip levels ", num_levels,
@@ -2763,10 +2747,10 @@ void wanderator<IteratorTraits, FieldTraits, WandIndex, WandExtent, Strict>::
   }
 }
 
-template<typename IteratorTraits, typename FieldTraits, typename WandIndex,
-         typename WandExtent, bool Strict>
-doc_id_t wanderator<IteratorTraits, FieldTraits, WandIndex, WandExtent,
-                    Strict>::seek(doc_id_t target) {
+template<typename IteratorTraits, typename FieldTraits, typename WandExtent,
+         bool Root>
+doc_id_t wanderator<IteratorTraits, FieldTraits, WandExtent, Root>::seek(
+  doc_id_t target) {
   auto& doc_value = std::get<document>(attrs_).value;
 
   if (IRS_UNLIKELY(target <= doc_value)) {
@@ -2784,17 +2768,18 @@ doc_id_t wanderator<IteratorTraits, FieldTraits, WandIndex, WandExtent,
       if (auto& state = skip_.Reader().State(); state.doc_ptr) {
         this->doc_in_->seek(state.doc_ptr);
         if constexpr (IteratorTraits::position()) {
-          auto& pos = std::get<position<IteratorTraits, FieldTraits>>(attrs_);
+          auto& pos = std::get<Position>(attrs_);
           pos.prepare(state);  // Notify positions
         }
         state.doc_ptr = 0;
       }
 
+      doc_value += !doc_limits::valid(doc_value);
       this->refill();
     }
 
-    const auto min_competitive_score = std::get<score_threshold>(attrs_).min;
     [[maybe_unused]] uint32_t notify{0};
+    [[maybe_unused]] const auto threshold = skip_.Reader().threshold_;
 
     while (this->begin_ != std::end(this->buf_.docs)) {
       doc_value += *this->begin_++;
@@ -2808,13 +2793,11 @@ doc_id_t wanderator<IteratorTraits, FieldTraits, WandIndex, WandExtent,
 
             auto& freq = std::get<frequency>(attrs_);
             freq.value = this->freq_[-1];
-
-            // FIXME(gnusi): can we use approximation before actual score
-            //               evaluation? e.g. frequency in case of tfidf
-            scorer_(&score_);
-
-            if (ScoreLess(score_, min_competitive_score)) {
-              continue;
+            if constexpr (Root) {
+              scorer_(&score_);
+              if (score_ <= threshold) {
+                continue;
+              }
             }
           }
           return doc_value;
@@ -2825,15 +2808,13 @@ doc_id_t wanderator<IteratorTraits, FieldTraits, WandIndex, WandExtent,
         freq.value = *this->freq_++;
         notify += freq.value;
         if (doc_value >= target) {
-          // FIXME(gnusi): can we use approximation before actual score
-          //               evaluation? e.g. frequency in case of tfidf
-          scorer_(&score_);
-
-          if (ScoreLess(score_, min_competitive_score)) {
-            continue;
+          if constexpr (Root) {
+            scorer_(&score_);
+            if (score_ <= threshold) {
+              continue;
+            }
           }
-
-          auto& pos = std::get<position<IteratorTraits, FieldTraits>>(attrs_);
+          auto& pos = std::get<Position>(attrs_);
           pos.notify(notify);
           pos.clear();
           return doc_value;
@@ -2842,7 +2823,7 @@ doc_id_t wanderator<IteratorTraits, FieldTraits, WandIndex, WandExtent,
     }
 
     if constexpr (IteratorTraits::position()) {
-      std::get<position<IteratorTraits, FieldTraits>>(attrs_).notify(notify);
+      std::get<Position>(attrs_).notify(notify);
     }
 
     target = doc_value + 1;
@@ -3531,7 +3512,7 @@ class postings_reader final : public postings_reader_base {
           it->prepare(meta, pos_in_.get(), pay_in_.get());
           return it;
         }
-        return ResolveExtent(
+        return ResolveExtent<(FieldTraits::wand() ? 0 : WandContext::kDisable)>(
           wand_count,
           [&]<typename Extent>(Extent&& extent) -> irs::doc_iterator::ptr {
             auto it = memory::make_managed<
@@ -3571,6 +3552,7 @@ class postings_reader final : public postings_reader_base {
         scorers_.size() <= ctx.index) {
       return {};
     }
+    IRS_ASSERT(info.count != 0);
     const auto& scorer = *scorers_[ctx.index];
     const auto scorer_features = scorer.index_features();
     // TODO(MBkkt) Should we also check against required_features?
@@ -3586,11 +3568,10 @@ class postings_reader final : public postings_reader_base {
         if (meta.docs_count == 1) {
           auto it = memory::make_managed<
             single_doc_iterator<IteratorTraits, FieldTraits>>();
-          it->WandPrepare(meta, pos_in_.get(), pay_in_.get(), options.factory,
-                          scorer);
+          it->WandPrepare(meta, pos_in_.get(), pay_in_.get(), options.factory);
           return it;
         }
-        return ResolveExtent(
+        return ResolveExtent<1>(
           info.count,
           [&]<typename WandExtent>(
             WandExtent extent) -> irs::doc_iterator::ptr {
@@ -3599,14 +3580,11 @@ class postings_reader final : public postings_reader_base {
               // No need to use wanderator for short lists
               if (meta.docs_count > FormatTraits::block_size()) {
                 return ResolveBool(
-                  ctx.strict,
-                  [&]<bool Strict>(std::integral_constant<bool, Strict>)
-                    -> irs::doc_iterator::ptr {
-                    auto it = memory::make_managed<
-                      ::wanderator<IteratorTraits, FieldTraits,
-                                   Extent<kDynamicValue>, WandExtent, Strict>>(
-                      options.factory, scorer,
-                      Extent<kDynamicValue>{info.mapped_index}, extent);
+                  ctx.Root(), [&]<bool Root>() -> irs::doc_iterator::ptr {
+                    auto it = memory::make_managed<::wanderator<
+                      IteratorTraits, FieldTraits, WandExtent, Root>>(
+                      options.factory, scorer, extent, info.mapped_index,
+                      ctx.Weak());
 
                     it->WandPrepare(meta, doc_in_.get(), pos_in_.get(),
                                     pay_in_.get());
@@ -3616,8 +3594,7 @@ class postings_reader final : public postings_reader_base {
               }
             }
             auto it = memory::make_managed<
-              doc_iterator<IteratorTraits, FieldTraits, WandExtent>>(
-              std::forward<WandExtent>(extent));
+              doc_iterator<IteratorTraits, FieldTraits, WandExtent>>(extent);
             it->WandPrepare(meta, doc_in_.get(), pos_in_.get(), pay_in_.get(),
                             options.factory, scorer, info.mapped_index);
             return it;
@@ -3808,7 +3785,7 @@ size_t postings_reader<FormatTraits>::bit_union(
       IRS_ASSERT(!doc_in->eof());
       if (FormatTraits::wand() &&
           term_state.docs_count < FormatTraits::block_size()) {
-        CommonSkipWandData(Extent<kDynamicValue>{wand_count}, *doc_in);
+        CommonSkipWandData(DynamicExtent{wand_count}, *doc_in);
       }
       IRS_ASSERT(!doc_in->eof());
 

--- a/core/formats/formats_10.cpp
+++ b/core/formats/formats_10.cpp
@@ -2474,7 +2474,7 @@ class wanderator : public doc_iterator_base<IteratorTraits, FieldTraits>,
       std::all_of(std::begin(this->buf_.docs), std::end(this->buf_.docs),
                   [](doc_id_t doc) { return doc == doc_limits::invalid(); }));
     std::get<irs::score>(attrs_).Reset(
-      *this, strict ? MinStrict : MinWeak,
+      *this,
       [](score_ctx* ctx, score_t* res) noexcept {
         auto& self = static_cast<wanderator&>(*ctx);
         if constexpr (Root) {
@@ -2482,7 +2482,8 @@ class wanderator : public doc_iterator_base<IteratorTraits, FieldTraits>,
         } else {
           self.scorer_(res);
         }
-      });
+      },
+      strict ? MinStrict : MinWeak);
   }
 
   void WandPrepare(const term_meta& meta, const index_input* doc_in,

--- a/core/formats/formats_10.cpp
+++ b/core/formats/formats_10.cpp
@@ -2590,7 +2590,6 @@ class wanderator : public doc_iterator_base<IteratorTraits, FieldTraits>,
       this->left_ = skip_.Seek(target);
       auto& doc_value = std::get<document>(attrs_).value;
       doc_value = skip_.Reader().State().doc;
-      IRS_ASSERT(doc_value < target);
       std::get<score>(attrs_).max.leaf = skip_.Reader().skip_scores_.back();
       // Will trigger refill in "next"
       this->begin_ = std::end(this->buf_.docs);

--- a/core/formats/formats_10.cpp
+++ b/core/formats/formats_10.cpp
@@ -2553,10 +2553,6 @@ class wanderator : public doc_iterator_base<IteratorTraits, FieldTraits>,
       CopyState<IteratorTraits>(next, prev_skip_);
     }
     void Read(size_t level, index_input& in);
-    void ReadWandData(size_t level, index_input& in) {
-      CommonReadWandData(extent_, index_, func_, *ctx_, in,
-                         skip_scores_[level]);
-    }
     void Seal(size_t level);
     size_t AdjustLevel(size_t level) const noexcept;
     SkipState& State() noexcept { return prev_skip_; }
@@ -2628,12 +2624,23 @@ void wanderator<IteratorTraits, FieldTraits, WandExtent, Root>::ReadSkip::Read(
   size_t level, index_input& in) {
   auto& last = prev_skip_;
   auto& next = skip_levels_[level];
+  auto& score = skip_scores_[level];
 
   // Store previous step on the same level
   CopyState<IteratorTraits>(last, next);
 
   ReadState<FieldTraits>(next, in);
-  ReadWandData(level, in);
+  // if constexpr (Root) {
+  CommonReadWandData(extent_, index_, func_, *ctx_, in, score);
+  // } else {
+  //   auto& back = skip_scores_.back();
+  //   if (&score == &back || threshold_ > back) {
+  //     CommonReadWandData(extent_, index_, func_, *ctx_, in, score);
+  //   } else {
+  //     CommonSkipWandData(extent_, in);
+  //     score = std::numeric_limits<score_t>::max();
+  //   }
+  // }
 }
 
 template<typename IteratorTraits, typename FieldTraits, typename WandExtent,

--- a/core/formats/wand_writer.hpp
+++ b/core/formats/wand_writer.hpp
@@ -198,9 +198,6 @@ class FreqNormProducer {
   template<typename Output>
   static void Write(Entry entry, Output& out) {
     // TODO(MBkkt) Compute difference second time looks unnecessary.
-    // TODO(MBkkt) Saving freq == 1 and freq == norm looks unnecessary.
-    //  We can avoid it because we're storing size, but do we want it?
-    //  It could makes read slower.
     IRS_ASSERT(entry.freq >= 1);
     out.write_vint(entry.freq);
     if constexpr (kNorm) {

--- a/core/index/index_reader_options.hpp
+++ b/core/index/index_reader_options.hpp
@@ -47,6 +47,7 @@ inline constexpr size_t kMaxScorers = bits_required<uint64_t>();
 
 struct WandContext {
   static constexpr auto kDisable = std::numeric_limits<byte_type>::max();
+
   bool Enabled() const noexcept { return index != kDisable; }
 
   // Index of the wand data in the IndexWriter to use for optimization.

--- a/core/index/index_reader_options.hpp
+++ b/core/index/index_reader_options.hpp
@@ -46,20 +46,14 @@ using ScorersView = std::span<const Scorer* const>;
 inline constexpr size_t kMaxScorers = bits_required<uint64_t>();
 
 struct WandContext {
-  bool Weak() const noexcept { return type == Type::kWeakRoot; }
-  bool Root() const noexcept { return type != Type::kLeaf; }
-
   static constexpr auto kDisable = std::numeric_limits<byte_type>::max();
   bool Enabled() const noexcept { return index != kDisable; }
 
   // Index of the wand data in the IndexWriter to use for optimization.
   // Optimization is turned off by default.
   byte_type index{kDisable};
-  enum class Type : byte_type {
-    kWeakRoot = 0,
-    kRoot = 1,
-    kLeaf = 2,
-  } type{Type::kWeakRoot};
+  bool strict{false};
+  mutable bool root{true};
 };
 
 struct IndexReaderOptions {

--- a/core/index/index_reader_options.hpp
+++ b/core/index/index_reader_options.hpp
@@ -48,16 +48,20 @@ using ScorersView = std::span<const Scorer* const>;
 inline constexpr size_t kMaxScorers = bits_required<uint64_t>();
 
 struct WandContext {
-  static constexpr auto kDisable = std::numeric_limits<byte_type>::max();
+  bool Weak() const noexcept { return type == Type::kWeakRoot; }
+  bool Root() const noexcept { return type != Type::kLeaf; }
 
+  static constexpr auto kDisable = std::numeric_limits<byte_type>::max();
   bool Enabled() const noexcept { return index != kDisable; }
 
-  // Index of the scorer to use for optimization.
+  // Index of the wand data in the IndexWriter to use for optimization.
   // Optimization is turned off by default.
   byte_type index{kDisable};
-  bool strict{false};
-  // Use maxscore instead of wand in disjunction
-  bool maxscore{false};
+  enum class Type : byte_type {
+    kWeakRoot = 0,
+    kRoot = 1,
+    kLeaf = 2,
+  } type{Type::kWeakRoot};
 };
 
 struct IndexReaderOptions {

--- a/core/index/iterators.hpp
+++ b/core/index/iterators.hpp
@@ -29,6 +29,7 @@
 #include "utils/attributes.hpp"
 #include "utils/iterator.hpp"
 #include "utils/memory.hpp"
+#include "utils/type_limits.hpp"
 
 namespace irs {
 
@@ -53,12 +54,21 @@ struct doc_iterator : iterator<doc_id_t, attribute_provider> {
   // (for more information see class description)
   virtual doc_id_t seek(doc_id_t target) = 0;
 
-  // Position iterator at block with a specified target
-  // return last document in this block
-  // (for more information see class description)
+  // protected:
+  // For any doc_iterator we want to define block.
+  // It's two bounds: (min...max]:
+  // doc_iterator always positioned to the some block.
+  //
+  // doc_iterator before seek/next/shallow_seek(any valid target)
+  // positioned to the first block.
+  // You could know about it max, with call shallow_seek(doc_limits::invalid());
+  //
+  // shallow_seek could move iterator to the some next block.
+  // If target is not in the current block or
+  // min competitive score force moving to the next block.
   virtual doc_id_t shallow_seek(doc_id_t target) {
-    IRS_ASSERT(false);
-    return {};
+    seek(target);
+    return doc_limits::eof();
   }
 };
 

--- a/core/search/all_iterator.cpp
+++ b/core/search/all_iterator.cpp
@@ -27,15 +27,15 @@
 namespace irs {
 
 AllIterator::AllIterator(const SubReader& reader, const byte_type* query_stats,
-                         const Scorers& order, uint64_t docs_count, score_t boost)
+                         const Scorers& order, uint64_t docs_count,
+                         score_t boost)
   : max_doc_{doc_id_t(doc_limits::min() + docs_count - 1)} {
   std::get<cost>(attrs_).reset(max_doc_);
 
   if (!order.empty()) {
     auto& score = std::get<irs::score>(attrs_);
-    score =
-      CompileScore(order.buckets(), reader, irs::empty_term_reader(docs_count),
-                   query_stats, *this, boost);
+    CompileScore(score, order.buckets(), reader,
+                 irs::empty_term_reader(docs_count), query_stats, *this, boost);
   }
 }
 

--- a/core/search/bm25.cpp
+++ b/core/search/bm25.cpp
@@ -279,7 +279,7 @@ struct MakeScoreFunctionImpl<BM1Context> {
           *res = state.num;
         }
       },
-      std::forward<Args>(args)...);
+      ScoreFunction::DefaultMin, std::forward<Args>(args)...);
   }
 };
 
@@ -311,7 +311,7 @@ struct MakeScoreFunctionImpl<BM15Context> {
 
         *res = c0 - c0 / (1.f + tf / c1);
       },
-      std::forward<Args>(args)...);
+      ScoreFunction::DefaultMin, std::forward<Args>(args)...);
   }
 };
 
@@ -357,7 +357,7 @@ struct MakeScoreFunctionImpl<BM25Context<Norm>> {
           *res = c0 - c0 * c1 / (c1 + tf);
         }
       },
-      std::forward<Args>(args)...);
+      ScoreFunction::DefaultMin, std::forward<Args>(args)...);
   }
 };
 
@@ -418,7 +418,7 @@ ScoreFunction BM25::prepare_scorer(const ColumnProvider& segment,
 
   if (!freq) {
     if (!boost_as_score_ || 0.f == boost) {
-      return ScoreFunction::Invalid();
+      return ScoreFunction::Default(1);
     }
 
     // if there is no frequency then all the scores
@@ -454,7 +454,7 @@ ScoreFunction BM25::prepare_scorer(const ColumnProvider& segment,
 
   if (IRS_UNLIKELY(!doc)) {
     // We need 'document' attribute to be exposed.
-    return ScoreFunction::Invalid();
+    return ScoreFunction::Default(1);
   }
 
   if (auto it = features.find(irs::type<Norm2>::id()); it != features.end()) {

--- a/core/search/boolean_filter.cpp
+++ b/core/search/boolean_filter.cpp
@@ -52,12 +52,15 @@ irs::ScoreAdapters<irs::doc_iterator::ptr> MakeScoreAdapters(
   const size_t size = std::distance(begin, end);
   irs::ScoreAdapters<irs::doc_iterator::ptr> itrs;
   itrs.reserve(size);
-  auto sub_ctx = ctx;
   if (Conjunction || size > 1) {
-    sub_ctx.wand.type = irs::WandContext::Type::kLeaf;
+    ctx.wand.root = false;
+    // TODO(MBkkt) ctx.wand.strict = true;
+    // We couldn't do this for few reasons:
+    // 1. It's small chance that we will use just term iterator (or + eof)
+    // 2. I'm not sure about precision
   }
   do {
-    auto docs = (*begin)->execute(sub_ctx);
+    auto docs = (*begin)->execute(ctx);
     ++begin;
 
     // filter out empty iterators

--- a/core/search/boolean_filter.cpp
+++ b/core/search/boolean_filter.cpp
@@ -45,32 +45,53 @@ std::pair<const irs::filter*, bool> optimize_not(const irs::Not& node) {
   return std::make_pair(inner, neg);
 }
 
+template<bool Conjunction, typename It>
+irs::ScoreAdapters<irs::doc_iterator::ptr> MakeScoreAdapters(
+  const irs::ExecutionContext& ctx, It begin, It end) {
+  IRS_ASSERT(begin <= end);
+  const size_t size = std::distance(begin, end);
+  irs::ScoreAdapters<irs::doc_iterator::ptr> itrs;
+  itrs.reserve(size);
+  auto sub_ctx = ctx;
+  if (Conjunction || size > 1) {
+    sub_ctx.wand.type = irs::WandContext::Type::kLeaf;
+  }
+  do {
+    auto docs = (*begin)->execute(sub_ctx);
+    ++begin;
+
+    // filter out empty iterators
+    if (irs::doc_limits::eof(docs->value())) {
+      if constexpr (Conjunction) {
+        return {};
+      } else {
+        continue;
+      }
+    }
+
+    itrs.emplace_back(std::move(docs));
+  } while (begin != end);
+
+  return itrs;
+}
+
 // Returns disjunction iterator created from the specified queries
 template<typename QueryIterator, typename... Args>
 irs::doc_iterator::ptr make_disjunction(const irs::ExecutionContext& ctx,
                                         irs::ScoreMergeType merge_type,
                                         QueryIterator begin, QueryIterator end,
                                         Args&&... args) {
-  IRS_ASSERT(std::distance(begin, end) >= 0);
-  const size_t size = size_t(std::distance(begin, end));
-
+  IRS_ASSERT(begin <= end);
+  const size_t size = std::distance(begin, end);
   // check the size before the execution
   if (0 == size) {
     // empty or unreachable search criteria
     return irs::doc_iterator::empty();
   }
 
-  std::vector<irs::score_iterator_adapter<irs::doc_iterator::ptr>> itrs;
-  itrs.reserve(size);
-
-  for (; begin != end; ++begin) {
-    // execute query - get doc iterator
-    auto docs = (*begin)->execute(ctx);
-
-    // filter out empty iterators
-    if (!irs::doc_limits::eof(docs->value())) {
-      itrs.emplace_back(std::move(docs));
-    }
+  auto itrs = MakeScoreAdapters<false>(ctx, begin, end);
+  if (itrs.empty()) {
+    return irs::doc_iterator::empty();
   }
 
   return irs::ResoveMergeType(
@@ -79,8 +100,9 @@ irs::doc_iterator::ptr make_disjunction(const irs::ExecutionContext& ctx,
       using disjunction_t =
         irs::disjunction_iterator<irs::doc_iterator::ptr, A>;
 
-      return irs::MakeDisjunction<disjunction_t>(
-        std::move(itrs), std::move(aggregator), std::forward<Args>(args)...);
+      return irs::MakeDisjunction<disjunction_t>(ctx.wand, std::move(itrs),
+                                                 std::move(aggregator),
+                                                 std::forward<Args>(args)...);
     });
 }
 
@@ -90,9 +112,8 @@ irs::doc_iterator::ptr make_conjunction(const irs::ExecutionContext& ctx,
                                         irs::ScoreMergeType merge_type,
                                         QueryIterator begin, QueryIterator end,
                                         Args&&... args) {
-  IRS_ASSERT(std::distance(begin, end) >= 0);
+  IRS_ASSERT(begin <= end);
   const size_t size = std::distance(begin, end);
-
   // check size before the execution
   switch (size) {
     case 0:
@@ -101,27 +122,16 @@ irs::doc_iterator::ptr make_conjunction(const irs::ExecutionContext& ctx,
       return (*begin)->execute(ctx);
   }
 
-  std::vector<irs::score_iterator_adapter<irs::doc_iterator::ptr>> itrs;
-  itrs.reserve(size);
-
-  for (; begin != end; ++begin) {
-    auto docs = (*begin)->execute(ctx);
-
-    // filter out empty iterators
-    if (irs::doc_limits::eof(docs->value())) {
-      return irs::doc_iterator::empty();
-    }
-
-    itrs.emplace_back(std::move(docs));
+  auto itrs = MakeScoreAdapters<true>(ctx, begin, end);
+  if (itrs.empty()) {
+    return irs::doc_iterator::empty();
   }
 
   return irs::ResoveMergeType(
     merge_type, ctx.scorers.buckets().size(),
     [&]<typename A>(A&& aggregator) -> irs::doc_iterator::ptr {
-      using conjunction_t = irs::conjunction<irs::doc_iterator::ptr, A>;
-
-      return irs::MakeConjunction<conjunction_t>(
-        std::move(itrs), std::move(aggregator), std::forward<Args>(args)...);
+      return irs::MakeConjunction(ctx.wand, std::move(aggregator),
+                                  std::move(itrs), std::forward<Args>(args)...);
     });
 }
 
@@ -278,18 +288,10 @@ class MinMatchQuery : public BooleanQuery {
     // min_match_count <= size
     min_match_count = std::min(size, min_match_count);
 
-    std::vector<score_iterator_adapter<doc_iterator::ptr>> itrs(size);
-    auto it = std::begin(itrs);
-    for (; begin != end; ++begin) {
-      // execute query - get doc iterator
-      *it = (*begin)->execute(ctx);
-
-      // filter out empty iterators
-      if (IRS_LIKELY(*it && !doc_limits::eof(it->value()))) {
-        ++it;
-      }
+    auto itrs = MakeScoreAdapters<false>(ctx, begin, end);
+    if (itrs.empty()) {
+      return irs::doc_iterator::empty();
     }
-    itrs.erase(it, std::end(itrs));
 
     return ResoveMergeType(
       merge_type(), ctx.scorers.buckets().size(),
@@ -298,7 +300,7 @@ class MinMatchQuery : public BooleanQuery {
         using disjunction_t = min_match_iterator<doc_iterator::ptr, A>;
 
         return MakeWeakDisjunction<disjunction_t, A>(
-          std::move(itrs), min_match_count, std::move(aggregator));
+          ctx.wand, std::move(itrs), min_match_count, std::move(aggregator));
       });
   }
 

--- a/core/search/boost_scorer.cpp
+++ b/core/search/boost_scorer.cpp
@@ -57,7 +57,7 @@ ScoreFunction BoostScore::prepare_scorer(
       auto& state = *static_cast<volatile_boost_score_ctx*>(ctx);
       *res = state.volatile_boost->value * state.boost;
     },
-    volatile_boost, boost);
+    ScoreFunction::DefaultMin, volatile_boost, boost);
 }
 
 void BoostScore::init() { REGISTER_SCORER_JSON(BoostScore, make_json); }

--- a/core/search/column_existence_filter.cpp
+++ b/core/search/column_existence_filter.cpp
@@ -61,9 +61,9 @@ class column_existence_query : public irs::filter::prepared {
 
     if (!ord.empty()) {
       if (auto* score = irs::get_mutable<irs::score>(it.get()); score) {
-        *score =
-          CompileScore(ord.buckets(), segment, empty_term_reader(column.size()),
-                       stats_.c_str(), *it, boost());
+        CompileScore(*score, ord.buckets(), segment,
+                     empty_term_reader(column.size()), stats_.c_str(), *it,
+                     boost());
       }
     }
 

--- a/core/search/column_existence_filter.cpp
+++ b/core/search/column_existence_filter.cpp
@@ -117,9 +117,7 @@ class column_prefix_existence_query : public column_existence_query {
       [&]<typename A>(A&& aggregator) -> irs::doc_iterator::ptr {
         using disjunction_t =
           irs::disjunction_iterator<irs::doc_iterator::ptr, A>;
-        // TODO(MBkkt) wand support,
-        //  it looks like here we have just bunch of constant scored iterators
-        return irs::MakeDisjunction<disjunction_t>({}, std::move(itrs),
+        return irs::MakeDisjunction<disjunction_t>(ctx.wand, std::move(itrs),
                                                    std::move(aggregator));
       });
   }

--- a/core/search/column_existence_filter.cpp
+++ b/core/search/column_existence_filter.cpp
@@ -84,7 +84,7 @@ class column_prefix_existence_query : public column_existence_query {
   }
 
   irs::doc_iterator::ptr execute(const ExecutionContext& ctx) const final {
-    using adapter_t = irs::score_iterator_adapter<irs::doc_iterator::ptr>;
+    using adapter_t = irs::ScoreAdapter<irs::doc_iterator::ptr>;
 
     IRS_ASSERT(acceptor_);
 
@@ -117,8 +117,9 @@ class column_prefix_existence_query : public column_existence_query {
       [&]<typename A>(A&& aggregator) -> irs::doc_iterator::ptr {
         using disjunction_t =
           irs::disjunction_iterator<irs::doc_iterator::ptr, A>;
-
-        return irs::MakeDisjunction<disjunction_t>(std::move(itrs),
+        // TODO(MBkkt) wand support,
+        //  it looks like here we have just bunch of constant scored iterators
+        return irs::MakeDisjunction<disjunction_t>({}, std::move(itrs),
                                                    std::move(aggregator));
       });
   }

--- a/core/search/conjunction.hpp
+++ b/core/search/conjunction.hpp
@@ -138,10 +138,10 @@ struct ConjunctionBase : public doc_iterator,
         score = std::move(*scores_.front());
         break;
       case 2:
-        score.Reset(*this, min, score_2);
+        score.Reset(*this, score_2, min);
         break;
       default:
-        score.Reset(*this, min, score_n);
+        score.Reset(*this, score_n, min);
         break;
     }
   }

--- a/core/search/conjunction.hpp
+++ b/core/search/conjunction.hpp
@@ -142,10 +142,10 @@ struct ConjunctionBase : public doc_iterator,
         score = std::move(*scores_.front());
         break;
       case 2:
-        score.Reset(*this, score_2, min);
+        score.Reset(*this, min, score_2);
         break;
       default:
-        score.Reset(*this, score_n, min);
+        score.Reset(*this, min, score_n);
         break;
     }
   }

--- a/core/search/conjunction.hpp
+++ b/core/search/conjunction.hpp
@@ -76,7 +76,7 @@ using EmptyWrapper = T;
 
 struct SubScores {
   std::vector<irs::score*> scores;
-  score_t sum_score{};
+  score_t sum_score = 0.f;
 };
 
 // Conjunction of N iterators
@@ -348,7 +348,7 @@ class BlockConjunction : public ConjunctionBase<DocIterator, Merger> {
   // TODO(MBkkt) Maybe optimize for 2?
   static void MinN(BlockConjunction& self, score_t arg) noexcept {
     for (auto* score : self.scores_) {
-      auto others = self.sum_scores_ - score->max.tail;
+      const auto others = self.sum_scores_ - score->max.tail;
       if (arg <= others) {
         return;
       }
@@ -461,7 +461,7 @@ doc_iterator::ptr MakeConjunction(WandContext ctx, Merger&& merger,
     bool use_block = ctx.Enabled() && cost::extract(itrs.front(), cost::kMax) >
                                         kBlockConjunctionCostThreshold;
     for (auto& it : itrs) {
-      // FIXME(gnus): remove const cast
+      // FIXME(gnusi): remove const cast
       auto* score = const_cast<irs::score*>(it.score);
       IRS_ASSERT(score);  // ensured by ScoreAdapter
       if (score->IsDefault()) {

--- a/core/search/conjunction.hpp
+++ b/core/search/conjunction.hpp
@@ -396,14 +396,14 @@ class BlockConjunction : public ConjunctionBase<DocIterator, Merger> {
 
     auto max_leafs = doc_limits::eof();
     auto min_leafs = doc;
-    score_t max_leafs_score = 0.f;
+    score_t sum_leafs_score = 0.f;
 
     for (auto& it : this->itrs_) {
       auto max_leaf = it->shallow_seek(target);
       auto min_leaf = it.doc->value;
       IRS_ASSERT(min_leaf <= max_leaf);
       if (target < min_leaf) {
-        target = min_leaf + doc_limits::eof(leafs_doc_);
+        target = min_leaf;
       }
       if (max_leafs < min_leaf) {
         goto eof_check;
@@ -414,15 +414,15 @@ class BlockConjunction : public ConjunctionBase<DocIterator, Merger> {
       if (max_leafs > max_leaf) {
         max_leafs = max_leaf;
       }
-      IRS_ASSERT(min_leafs < max_leafs);
+      IRS_ASSERT(min_leafs <= max_leafs);
       if constexpr (HasScore_v<Merger>) {
-        merger(&max_leafs_score, &it.score->max.leaf);
+        merger(&sum_leafs_score, &it.score->max.leaf);
       }
     }
 
     leafs_doc_ = max_leafs;
     doc = min_leafs;
-    score().leaf = max_leafs_score;
+    score().leaf = sum_leafs_score;
     IRS_ASSERT(doc <= target);
     IRS_ASSERT(target <= leafs_doc_);
     goto score_check;

--- a/core/search/conjunction.hpp
+++ b/core/search/conjunction.hpp
@@ -448,6 +448,7 @@ doc_iterator::ptr MakeConjunction(WandContext ctx, Merger&& merger,
     // single sub-query
     return std::move(itrs.front());
   }
+
   // conjunction
   std::sort(
     itrs.begin(), itrs.end(), [](const auto& lhs, const auto& rhs) noexcept {

--- a/core/search/disjunction.hpp
+++ b/core/search/disjunction.hpp
@@ -264,11 +264,11 @@ class basic_disjunction : public compound_doc_iterator<Adapter>,
     std::get<cost>(attrs_).reset(std::forward<Estimation>(estimation));
 
     if constexpr (HasScore_v<Merger>) {
-      prepare_score();
+      prepare_score(false, false);
     }
   }
 
-  void prepare_score() {
+  void prepare_score(bool /*wand*/, bool /*strict*/) {
     IRS_ASSERT(Merger::size());
     IRS_ASSERT(lhs_.score && rhs_.score);  // must be ensure by the adapter
 
@@ -279,34 +279,28 @@ class basic_disjunction : public compound_doc_iterator<Adapter>,
 
     if (!lhs_score_empty && !rhs_score_empty) {
       // both sub-iterators have score
-      score.Reset(
-        *this,
-        [](score_ctx* ctx, score_t* res) noexcept {
-          auto& self = *static_cast<basic_disjunction*>(ctx);
-          auto& merger = static_cast<Merger&>(self);
-          self.score_iterator_impl(self.lhs_, res);
-          self.score_iterator_impl(self.rhs_, merger.temp());
-          merger(res, merger.temp());
-        },
-        ScoreFunction::DefaultMin);
+      score.Reset(*this, ScoreFunction::DefaultMin,
+                  [](score_ctx* ctx, score_t* res) noexcept {
+                    auto& self = *static_cast<basic_disjunction*>(ctx);
+                    auto& merger = static_cast<Merger&>(self);
+                    self.score_iterator_impl(self.lhs_, res);
+                    self.score_iterator_impl(self.rhs_, merger.temp());
+                    merger(res, merger.temp());
+                  });
     } else if (!lhs_score_empty) {
       // only left sub-iterator has score
-      score.Reset(
-        *this,
-        [](score_ctx* ctx, score_t* res) noexcept {
-          auto& self = *static_cast<basic_disjunction*>(ctx);
-          return self.score_iterator_impl(self.lhs_, res);
-        },
-        ScoreFunction::DefaultMin);
+      score.Reset(*this, ScoreFunction::DefaultMin,
+                  [](score_ctx* ctx, score_t* res) noexcept {
+                    auto& self = *static_cast<basic_disjunction*>(ctx);
+                    return self.score_iterator_impl(self.lhs_, res);
+                  });
     } else if (!rhs_score_empty) {
       // only right sub-iterator has score
-      score.Reset(
-        *this,
-        [](score_ctx* ctx, score_t* res) noexcept {
-          auto& self = *static_cast<basic_disjunction*>(ctx);
-          return self.score_iterator_impl(self.rhs_, res);
-        },
-        ScoreFunction::DefaultMin);
+      score.Reset(*this, ScoreFunction::DefaultMin,
+                  [](score_ctx* ctx, score_t* res) noexcept {
+                    auto& self = *static_cast<basic_disjunction*>(ctx);
+                    return self.score_iterator_impl(self.rhs_, res);
+                  });
     } else {
       IRS_ASSERT(score.IsDefault());
       score = ScoreFunction::Default(Merger::size());
@@ -525,29 +519,27 @@ class small_disjunction : public compound_doc_iterator<Adapter>,
 
     // prepare score
     if (scored_begin_ != end_) {
-      score.Reset(
-        *this,
-        [](irs::score_ctx* ctx, score_t* res) noexcept {
-          auto& self = *static_cast<small_disjunction*>(ctx);
-          auto& merger = static_cast<Merger&>(self);
-          const auto doc = std::get<document>(self.attrs_).value;
+      score.Reset(*this, ScoreFunction::DefaultMin,
+                  [](irs::score_ctx* ctx, score_t* res) noexcept {
+                    auto& self = *static_cast<small_disjunction*>(ctx);
+                    auto& merger = static_cast<Merger&>(self);
+                    const auto doc = std::get<document>(self.attrs_).value;
 
-          std::memset(res, 0, merger.byte_size());
-          for (auto begin = self.scored_begin_, end = self.end_; begin != end;
-               ++begin) {
-            auto value = begin->value();
+                    std::memset(res, 0, merger.byte_size());
+                    for (auto begin = self.scored_begin_, end = self.end_;
+                         begin != end; ++begin) {
+                      auto value = begin->value();
 
-            if (value < doc) {
-              value = (*begin)->seek(doc);
-            }
+                      if (value < doc) {
+                        value = (*begin)->seek(doc);
+                      }
 
-            if (value == doc) {
-              (*begin->score)(merger.temp());
-              merger(res, merger.temp());
-            }
-          }
-        },
-        ScoreFunction::DefaultMin);
+                      if (value == doc) {
+                        (*begin->score)(merger.temp());
+                        merger(res, merger.temp());
+                      }
+                    }
+                  });
     } else {
       IRS_ASSERT(score.IsDefault());
       score = ScoreFunction::Default(Merger::size());
@@ -741,38 +733,37 @@ class disjunction : public compound_doc_iterator<Adapter>,
 
     auto& score = std::get<irs::score>(attrs_);
 
-    score.Reset(
-      *this,
-      [](score_ctx* ctx, score_t* res) noexcept {
-        auto& self = *static_cast<disjunction*>(ctx);
-        IRS_ASSERT(!self.heap_.empty());
+    score.Reset(*this, ScoreFunction::DefaultMin,
+                [](score_ctx* ctx, score_t* res) noexcept {
+                  auto& self = *static_cast<disjunction*>(ctx);
+                  IRS_ASSERT(!self.heap_.empty());
 
-        const auto its = self.hitch_all_iterators();
+                  const auto its = self.hitch_all_iterators();
 
-        if (auto& score = *self.lead().score; !score.IsDefault()) {
-          score(res);
-        } else {
-          std::memset(res, 0, self.byte_size());
-        }
-        if (const auto doc = std::get<document>(self.attrs_).value;
-            self.top().value() == doc) {
-          irstd::heap::for_each_if(
-            its.first, its.second,
-            [&self, doc](const size_t it) noexcept {
-              IRS_ASSERT(it < self.itrs_.size());
-              return self.itrs_[it].value() == doc;
-            },
-            [&self, res](size_t it) {
-              IRS_ASSERT(it < self.itrs_.size());
-              if (auto& score = *self.itrs_[it].score; !score.IsDefault()) {
-                auto& merger = static_cast<Merger&>(self);
-                score(merger.temp());
-                merger(res, merger.temp());
-              }
-            });
-        }
-      },
-      ScoreFunction::DefaultMin);
+                  if (auto& score = *self.lead().score; !score.IsDefault()) {
+                    score(res);
+                  } else {
+                    std::memset(res, 0, self.byte_size());
+                  }
+                  if (const auto doc = std::get<document>(self.attrs_).value;
+                      self.top().value() == doc) {
+                    irstd::heap::for_each_if(
+                      its.first, its.second,
+                      [&self, doc](const size_t it) noexcept {
+                        IRS_ASSERT(it < self.itrs_.size());
+                        return self.itrs_[it].value() == doc;
+                      },
+                      [&self, res](size_t it) {
+                        IRS_ASSERT(it < self.itrs_.size());
+                        if (auto& score = *self.itrs_[it].score;
+                            !score.IsDefault()) {
+                          auto& merger = static_cast<Merger&>(self);
+                          score(merger.temp());
+                          merger(res, merger.temp());
+                        }
+                      });
+                  }
+                });
   }
 
   template<typename Iterator>
@@ -1154,14 +1145,11 @@ class block_disjunction : public doc_iterator,
         };
       }
 
-      score.Reset(
-        *this,
-        [](score_ctx* ctx, score_t* res) noexcept {
-          auto& self = static_cast<block_disjunction&>(*ctx);
-          std::memcpy(res, self.score_value_,
-                      static_cast<Merger&>(self).byte_size());
-        },
-        min);
+      score.Reset(*this, min, [](score_ctx* ctx, score_t* res) noexcept {
+        auto& self = static_cast<block_disjunction&>(*ctx);
+        std::memcpy(res, self.score_value_,
+                    static_cast<Merger&>(self).byte_size());
+      });
     }
 
     if (traits_type::kMinMatch && min_match_count > 1) {

--- a/core/search/disjunction.hpp
+++ b/core/search/disjunction.hpp
@@ -1122,19 +1122,20 @@ class block_disjunction : public doc_iterator,
           auto& self = static_cast<block_disjunction&>(*ctx);
           auto it = self.scores_.scores.begin();
           auto end = self.scores_.scores.end();
-          [[maybe_unused]] size_t min_match = 1;
-          score_t sum = (*it)->max.tail;
-          for (++it; it != end;) {
+          [[maybe_unused]] size_t min_match = 0;
+          [[maybe_unused]] score_t sum = 0.f;
+          while (it != end) {
             auto next = end;
             if constexpr (traits_type::kMinMatch) {
-              sum += (*it)->max.tail;
               if (arg > sum) {  // TODO(MBkkt) strict wand: >=
                 ++min_match;
                 next = it + 1;
               }
+              sum += (*it)->max.tail;
             }
             const auto others = self.scores_.sum_score - (*it)->max.tail;
             if (arg > others) {
+              // For common usage `arg - others <= (*it)->max.tail` -- is true
               (*it)->Min(arg - others);
               next = it + 1;
             }

--- a/core/search/filter.hpp
+++ b/core/search/filter.hpp
@@ -39,6 +39,7 @@ struct ExecutionContext {
   const SubReader& segment;
   const Scorers& scorers;
   const attribute_provider* ctx{};
+  // If enabled, wand would use first scorer from scorers
   WandContext wand;
 };
 

--- a/core/search/min_match_disjunction.hpp
+++ b/core/search/min_match_disjunction.hpp
@@ -235,7 +235,7 @@ class min_match_disjunction : public doc_iterator,
     auto& score = std::get<irs::score>(attrs_);
 
     score.Reset(
-      *this,
+      *this, ScoreFunction::DefaultMin,
       [](score_ctx* ctx, score_t* res) noexcept {
         auto& self = *static_cast<min_match_disjunction*>(ctx);
         IRS_ASSERT(!self.heap_.empty());
@@ -252,8 +252,7 @@ class min_match_disjunction : public doc_iterator,
             merger(res, merger.temp());
           }
         });
-      },
-      ScoreFunction::DefaultMin);
+      });
   }
 
   // Push all valid iterators to lead.

--- a/core/search/min_match_disjunction.hpp
+++ b/core/search/min_match_disjunction.hpp
@@ -234,25 +234,23 @@ class min_match_disjunction : public doc_iterator,
 
     auto& score = std::get<irs::score>(attrs_);
 
-    score.Reset(
-      *this, ScoreFunction::DefaultMin,
-      [](score_ctx* ctx, score_t* res) noexcept {
-        auto& self = *static_cast<min_match_disjunction*>(ctx);
-        IRS_ASSERT(!self.heap_.empty());
+    score.Reset(*this, [](score_ctx* ctx, score_t* res) noexcept {
+      auto& self = *static_cast<min_match_disjunction*>(ctx);
+      IRS_ASSERT(!self.heap_.empty());
 
-        self.push_valid_to_lead();
+      self.push_valid_to_lead();
 
-        // score lead iterators
-        std::memset(res, 0, static_cast<Merger&>(self).byte_size());
-        std::for_each(self.lead(), self.heap_.end(), [&self, res](size_t it) {
-          IRS_ASSERT(it < self.itrs_.size());
-          if (auto& score = *self.itrs_[it].score; !score.IsDefault()) {
-            auto& merger = static_cast<Merger&>(self);
-            score(merger.temp());
-            merger(res, merger.temp());
-          }
-        });
+      // score lead iterators
+      std::memset(res, 0, static_cast<Merger&>(self).byte_size());
+      std::for_each(self.lead(), self.heap_.end(), [&self, res](size_t it) {
+        IRS_ASSERT(it < self.itrs_.size());
+        if (auto& score = *self.itrs_[it].score; !score.IsDefault()) {
+          auto& merger = static_cast<Merger&>(self);
+          score(merger.temp());
+          merger(res, merger.temp());
+        }
       });
+    });
   }
 
   // Push all valid iterators to lead.

--- a/core/search/multiterm_query.cpp
+++ b/core/search/multiterm_query.cpp
@@ -148,14 +148,11 @@ doc_iterator::ptr MultiTermQuery::execute(const ExecutionContext& ctx) const {
 
     if (!no_score) {
       auto* score = irs::get_mutable<irs::score>(docs.get());
-
-      if (score) {
-        IRS_ASSERT(entry.stat_offset < stats.size());
-        auto* stat = stats[entry.stat_offset].c_str();
-
-        *score = CompileScore(ord.buckets(), segment, *state->reader, stat,
-                              *docs, entry.boost * boost());
-      }
+      IRS_ASSERT(score);
+      IRS_ASSERT(entry.stat_offset < stats.size());
+      auto* stat = stats[entry.stat_offset].c_str();
+      CompileScore(*score, ord.buckets(), segment, *state->reader, stat, *docs,
+                   entry.boost * boost());
     }
 
     IRS_ASSERT(it != std::end(itrs));

--- a/core/search/multiterm_query.cpp
+++ b/core/search/multiterm_query.cpp
@@ -132,8 +132,8 @@ doc_iterator::ptr MultiTermQuery::execute(const ExecutionContext& ctx) const {
 
   const bool has_unscored_terms = !state->unscored_terms.empty();
 
-  std::vector<score_iterator_adapter<doc_iterator::ptr>> itrs(
-    state->scored_states.size() + size_t(has_unscored_terms));
+  ScoreAdapters<doc_iterator::ptr> itrs(state->scored_states.size() +
+                                        size_t(has_unscored_terms));
   auto it = std::begin(itrs);
 
   // add an iterator for each of the scored states
@@ -178,7 +178,7 @@ doc_iterator::ptr MultiTermQuery::execute(const ExecutionContext& ctx) const {
     [&]<typename A>(A&& aggregator) -> irs::doc_iterator::ptr {
       using disjunction_t = min_match_iterator<doc_iterator::ptr, A>;
 
-      return MakeWeakDisjunction<disjunction_t>(std::move(itrs), min_match_,
+      return MakeWeakDisjunction<disjunction_t>({}, std::move(itrs), min_match_,
                                                 std::move(aggregator),
                                                 state->estimation());
     });

--- a/core/search/nested_filter.cpp
+++ b/core/search/nested_filter.cpp
@@ -278,7 +278,8 @@ class AnyMatcher : public Merger, private score_ctx {
   ScoreFunction PrepareScore() {
     static_assert(HasScore_v<Merger>);
 
-    return {*this, [](score_ctx* ctx, score_t* res) noexcept {
+    return {*this,
+            [](score_ctx* ctx, score_t* res) noexcept {
               IRS_ASSERT(ctx);
               IRS_ASSERT(res);
               auto& self = static_cast<JoinType&>(*ctx);
@@ -294,7 +295,8 @@ class AnyMatcher : public Merger, private score_ctx {
                 child_score(merger.temp());
                 merger(res, merger.temp());
               }
-            }};
+            },
+            ScoreFunction::DefaultMin};
   }
 };
 
@@ -359,14 +361,16 @@ class PredMatcher : public Merger,
   ScoreFunction PrepareScore() noexcept {
     static_assert(HasScore_v<Merger>);
 
-    return {*this, [](score_ctx* ctx, score_t* res) noexcept {
+    return {*this,
+            [](score_ctx* ctx, score_t* res) noexcept {
               IRS_ASSERT(ctx);
               IRS_ASSERT(res);
               auto& self = static_cast<PredMatcher&>(*ctx);
               auto& merger = static_cast<Merger&>(self);
               auto& buf = static_cast<ScoreBuffer<Merger>&>(self);
               std::memcpy(res, buf.data(), merger.byte_size());
-            }};
+            },
+            ScoreFunction::DefaultMin};
   }
 
  private:
@@ -442,14 +446,16 @@ class RangeMatcher : public Merger,
   ScoreFunction PrepareScore() noexcept {
     static_assert(HasScore_v<Merger>);
 
-    return {*this, [](score_ctx* ctx, score_t* res) noexcept {
+    return {*this,
+            [](score_ctx* ctx, score_t* res) noexcept {
               IRS_ASSERT(ctx);
               IRS_ASSERT(res);
               auto& self = static_cast<RangeMatcher&>(*ctx);
               auto& merger = static_cast<Merger&>(self);
               auto& buf = static_cast<ScoreBuffer<Merger>&>(self);
               std::memcpy(res, buf.data(), merger.byte_size());
-            }};
+            },
+            ScoreFunction::DefaultMin};
   }
 
   const Match& range() const noexcept { return match_; }
@@ -524,7 +530,8 @@ class MinMatcher : public Merger,
   ScoreFunction PrepareScore() noexcept {
     static_assert(HasScore_v<Merger>);
 
-    return {*this, [](score_ctx* ctx, score_t* res) noexcept {
+    return {*this,
+            [](score_ctx* ctx, score_t* res) noexcept {
               IRS_ASSERT(ctx);
               IRS_ASSERT(res);
               auto& self = static_cast<JoinType&>(*ctx);
@@ -545,7 +552,8 @@ class MinMatcher : public Merger,
               }
 
               std::memcpy(res, buf.data(), merger.byte_size());
-            }};
+            },
+            ScoreFunction::DefaultMin};
   }
 
   Match range() const noexcept { return Match{min_}; }
@@ -639,6 +647,7 @@ doc_iterator::ptr ByNestedQuery::execute(const ExecutionContext& ctx) const {
   auto child = child_->execute({.segment = rdr,
                                 .scorers = GetOrder(match_, ord),
                                 .ctx = ctx.ctx,
+                                // TODO(MBkkt) wand for nested?
                                 .wand = {}});
 
   if (IRS_UNLIKELY(!child)) {

--- a/core/search/nested_filter.cpp
+++ b/core/search/nested_filter.cpp
@@ -278,8 +278,7 @@ class AnyMatcher : public Merger, private score_ctx {
   ScoreFunction PrepareScore() {
     static_assert(HasScore_v<Merger>);
 
-    return {*this,
-            [](score_ctx* ctx, score_t* res) noexcept {
+    return {*this, [](score_ctx* ctx, score_t* res) noexcept {
               IRS_ASSERT(ctx);
               IRS_ASSERT(res);
               auto& self = static_cast<JoinType&>(*ctx);
@@ -295,8 +294,7 @@ class AnyMatcher : public Merger, private score_ctx {
                 child_score(merger.temp());
                 merger(res, merger.temp());
               }
-            },
-            ScoreFunction::DefaultMin};
+            }};
   }
 };
 
@@ -361,16 +359,14 @@ class PredMatcher : public Merger,
   ScoreFunction PrepareScore() noexcept {
     static_assert(HasScore_v<Merger>);
 
-    return {*this,
-            [](score_ctx* ctx, score_t* res) noexcept {
+    return {*this, [](score_ctx* ctx, score_t* res) noexcept {
               IRS_ASSERT(ctx);
               IRS_ASSERT(res);
               auto& self = static_cast<PredMatcher&>(*ctx);
               auto& merger = static_cast<Merger&>(self);
               auto& buf = static_cast<ScoreBuffer<Merger>&>(self);
               std::memcpy(res, buf.data(), merger.byte_size());
-            },
-            ScoreFunction::DefaultMin};
+            }};
   }
 
  private:
@@ -446,16 +442,14 @@ class RangeMatcher : public Merger,
   ScoreFunction PrepareScore() noexcept {
     static_assert(HasScore_v<Merger>);
 
-    return {*this,
-            [](score_ctx* ctx, score_t* res) noexcept {
+    return {*this, [](score_ctx* ctx, score_t* res) noexcept {
               IRS_ASSERT(ctx);
               IRS_ASSERT(res);
               auto& self = static_cast<RangeMatcher&>(*ctx);
               auto& merger = static_cast<Merger&>(self);
               auto& buf = static_cast<ScoreBuffer<Merger>&>(self);
               std::memcpy(res, buf.data(), merger.byte_size());
-            },
-            ScoreFunction::DefaultMin};
+            }};
   }
 
   const Match& range() const noexcept { return match_; }
@@ -530,8 +524,7 @@ class MinMatcher : public Merger,
   ScoreFunction PrepareScore() noexcept {
     static_assert(HasScore_v<Merger>);
 
-    return {*this,
-            [](score_ctx* ctx, score_t* res) noexcept {
+    return {*this, [](score_ctx* ctx, score_t* res) noexcept {
               IRS_ASSERT(ctx);
               IRS_ASSERT(res);
               auto& self = static_cast<JoinType&>(*ctx);
@@ -552,8 +545,7 @@ class MinMatcher : public Merger,
               }
 
               std::memcpy(res, buf.data(), merger.byte_size());
-            },
-            ScoreFunction::DefaultMin};
+            }};
   }
 
   Match range() const noexcept { return Match{min_}; }

--- a/core/search/ngram_similarity_query.cpp
+++ b/core/search/ngram_similarity_query.cpp
@@ -442,8 +442,7 @@ class NGramSimilarityDocIterator : public doc_iterator, private score_ctx {
       irs::get_mutable<document>(&approx_);
 
     // FIXME find a better estimation
-    std::get<cost>(attrs_).reset(
-      [this]() noexcept { return cost::extract(approx_); });
+    std::get<attribute_ptr<cost>>(attrs_) = irs::get_mutable<cost>(&approx_);
   }
 
   NGramSimilarityDocIterator(NGramApprox::doc_iterators_t&& itrs,
@@ -497,7 +496,8 @@ class NGramSimilarityDocIterator : public doc_iterator, private score_ctx {
   }
 
  private:
-  using attributes = std::tuple<attribute_ptr<document>, cost, score>;
+  using attributes =
+    std::tuple<attribute_ptr<document>, attribute_ptr<cost>, score>;
 
   Checker checker_;
   NGramApprox approx_;

--- a/core/search/ngram_similarity_query.cpp
+++ b/core/search/ngram_similarity_query.cpp
@@ -455,7 +455,7 @@ class NGramSimilarityDocIterator : public doc_iterator, private score_ctx {
                                  min_match_count, !ord.empty()} {
     if (!ord.empty()) {
       auto& score = std::get<irs::score>(attrs_);
-      score = CompileScore(ord.buckets(), segment, field, stats, *this, boost);
+      CompileScore(score, ord.buckets(), segment, field, stats, *this, boost);
     }
   }
 

--- a/core/search/phrase_iterator.hpp
+++ b/core/search/phrase_iterator.hpp
@@ -576,7 +576,7 @@ class PhraseIterator : public doc_iterator {
     : PhraseIterator{std::move(itrs), std::move(pos)} {
     if (!ord.empty()) {
       auto& score = std::get<irs::score>(attrs_);
-      score = CompileScore(ord.buckets(), segment, field, stats, *this, boost);
+      CompileScore(score, ord.buckets(), segment, field, stats, *this, boost);
     }
   }
 

--- a/core/search/same_position_filter.cpp
+++ b/core/search/same_position_filter.cpp
@@ -161,11 +161,10 @@ class same_position_query : public filter::prepared {
 
       if (!no_score) {
         auto* score = irs::get_mutable<irs::score>(docs.get());
+        IRS_ASSERT(score);
 
-        if (score) {
-          *score = CompileScore(ord.buckets(), segment, *term_state.reader,
-                                term_stats->c_str(), *docs, boost());
-        }
+        CompileScore(*score, ord.buckets(), segment, *term_state.reader,
+                     term_stats->c_str(), *docs, boost());
       }
 
       // add iterator

--- a/core/search/same_position_filter.cpp
+++ b/core/search/same_position_filter.cpp
@@ -177,9 +177,8 @@ class same_position_query : public filter::prepared {
       irs::ScoreMergeType::kSum, ord.buckets().size(),
       [&]<typename A>(A&& aggregator) -> irs::doc_iterator::ptr {
         return MakeConjunction<same_position_iterator>(
-          // TODO(MBkkt)
-          WandContext{}, std::move(aggregator), std::move(itrs),
-          std::move(positions));
+          // TODO(MBkkt) Implement wand?
+          {}, std::move(aggregator), std::move(itrs), std::move(positions));
       });
   }
 

--- a/core/search/score.hpp
+++ b/core/search/score.hpp
@@ -71,12 +71,11 @@ ScoreFunctions PrepareScorers(std::span<const ScorerBucket> buckets,
 
 // Compiles a set of prepared scorers into a single score function.
 ScoreFunction CompileScorers(ScoreFunctions&& scorers);
-ScoreFunction CompileScorers(ScoreFunction&& score, ScoreFunctions&& scorers);
 
-template<typename... Args>
-ScoreFunction CompileScore(Args&&... args) {
-  return CompileScorers(PrepareScorers(std::forward<Args>(args)...));
-}
+void CompileScore(irs::score& score, std::span<const ScorerBucket> buckets,
+                  const ColumnProvider& segment, const term_reader& field,
+                  const byte_type* stats, const attribute_provider& doc,
+                  score_t boost);
 
 // Prepare empty collectors, i.e. call collect(...) on each of the
 // buckets without explicitly collecting field or term statistics,

--- a/core/search/score.hpp
+++ b/core/search/score.hpp
@@ -28,6 +28,8 @@
 namespace irs {
 
 // Represents a score related for the particular document
+// min score set by document consumers
+// max score set by document producers
 struct score : attribute, ScoreFunction {
   static const score kNoScore;
 
@@ -42,6 +44,21 @@ struct score : attribute, ScoreFunction {
   }
 
   using ScoreFunction::operator=;
+
+  // For disjunction/conjunction it's just sum of sub-iterators max score
+  // For iterator without score it depends on count of documents in iterator
+  // For wanderator it's max score for whole skip-list
+  // TODO(MBkkt) tail better here and not affect correctness
+  //  but to support it we need to know max value in the tail blocks.
+  //  Open question: how do it without read next blocks?
+  // TODO(MBkkt) At least when iterator exhausted, we could set it to zero.
+  struct UpperBounds {
+    score_t tail = std::numeric_limits<score_t>::max();
+    score_t leaf = std::numeric_limits<score_t>::max();
+#ifdef IRESEARCH_TEST
+    std::span<const score_t> levels;  // levels.back() == leaf
+#endif
+  } max;
 };
 
 using ScoreFunctions = SmallVector<ScoreFunction, 2>;
@@ -54,6 +71,7 @@ ScoreFunctions PrepareScorers(std::span<const ScorerBucket> buckets,
 
 // Compiles a set of prepared scorers into a single score function.
 ScoreFunction CompileScorers(ScoreFunctions&& scorers);
+ScoreFunction CompileScorers(ScoreFunction&& score, ScoreFunctions&& scorers);
 
 template<typename... Args>
 ScoreFunction CompileScore(Args&&... args) {

--- a/core/search/score_function.cpp
+++ b/core/search/score_function.cpp
@@ -51,7 +51,7 @@ ScoreFunction ScoreFunction::Constant(score_t value) noexcept {
   uintptr_t boost = 0;
   std::memcpy(&boost, &value, sizeof(score_t));
   static_assert(sizeof(score_ctx*) == sizeof(uintptr_t));
-  return {reinterpret_cast<score_ctx*>(boost), &Constant1, &Noop};
+  return {reinterpret_cast<score_ctx*>(boost), Constant1, DefaultMin, Noop};
 }
 
 ScoreFunction ScoreFunction::Constant(score_t value, uint32_t count) noexcept {
@@ -60,13 +60,9 @@ ScoreFunction ScoreFunction::Constant(score_t value, uint32_t count) noexcept {
   } else if (1 == count) {
     return Constant(value);
   } else {
-    return {absl::bit_cast<score_ctx*>(ConstantCtx{value, count}), &ConstantN,
-            &Noop};
+    return {absl::bit_cast<score_ctx*>(ConstantCtx{value, count}), ConstantN,
+            DefaultMin, Noop};
   }
-}
-
-bool ScoreFunction::IsConstant() const noexcept {
-  return IsDefault() || score_ == &Constant1 || score_ == &ConstantN;
 }
 
 }  // namespace irs

--- a/core/search/score_function.cpp
+++ b/core/search/score_function.cpp
@@ -65,4 +65,15 @@ ScoreFunction ScoreFunction::Constant(score_t value, uint32_t count) noexcept {
   }
 }
 
+score_t ScoreFunction::Max() const noexcept {
+  if (score_ == ScoreFunction::DefaultScore) {
+    return 0.f;
+  } else if (score_ == Constant1 || score_ == ConstantN) {
+    score_t score;
+    Score(&score);
+    return score;
+  }
+  return std::numeric_limits<score_t>::max();
+}
+
 }  // namespace irs

--- a/core/search/score_function.hpp
+++ b/core/search/score_function.hpp
@@ -95,7 +95,7 @@ class ScoreFunction : util::noncopyable {
   }
   ~ScoreFunction() noexcept { deleter_(ctx_); }
 
-  void Reset(score_ctx& ctx, min_f min, score_f score) noexcept {
+  void Reset(score_ctx& ctx, score_f score, min_f min = DefaultMin) noexcept {
     IRS_ASSERT(&ctx != ctx_ || deleter_ == Noop);
     deleter_(ctx_);
     ctx_ = &ctx;

--- a/core/search/score_function.hpp
+++ b/core/search/score_function.hpp
@@ -104,10 +104,7 @@ class ScoreFunction : util::noncopyable {
     deleter_ = Noop;
   }
 
-  bool IsDefault() const noexcept {
-    IRS_ASSERT(score_ != DefaultScore || min_ == DefaultMin);
-    return score_ == DefaultScore;
-  }
+  bool IsDefault() const noexcept { return score_ == DefaultScore; }
 
   IRS_FORCE_INLINE void Score(score_t* res) const noexcept {
     IRS_ASSERT(score_ != nullptr);
@@ -118,6 +115,8 @@ class ScoreFunction : util::noncopyable {
     IRS_ASSERT(min_ != nullptr);
     min_(ctx_, arg);
   }
+
+  score_t Max() const noexcept;
 
   // TODO(MBkkt) Remove it, use Score
   IRS_FORCE_INLINE void operator()(score_t* res) const noexcept { Score(res); }

--- a/core/search/score_function.hpp
+++ b/core/search/score_function.hpp
@@ -95,7 +95,7 @@ class ScoreFunction : util::noncopyable {
   }
   ~ScoreFunction() noexcept { deleter_(ctx_); }
 
-  void Reset(score_ctx& ctx, score_f score, min_f min) noexcept {
+  void Reset(score_ctx& ctx, min_f min, score_f score) noexcept {
     IRS_ASSERT(&ctx != ctx_ || deleter_ == Noop);
     deleter_(ctx_);
     ctx_ = &ctx;

--- a/core/search/score_function.hpp
+++ b/core/search/score_function.hpp
@@ -77,7 +77,7 @@ class ScoreFunction : util::noncopyable {
   }
 
   ScoreFunction() noexcept = default;
-  ScoreFunction(score_ctx& ctx, score_f score, min_f min) noexcept
+  ScoreFunction(score_ctx& ctx, score_f score, min_f min = DefaultMin) noexcept
     : ScoreFunction{&ctx, score, min, Noop} {}
   ScoreFunction(ScoreFunction&& rhs) noexcept
     : ScoreFunction{std::exchange(rhs.ctx_, nullptr),

--- a/core/search/term_query.cpp
+++ b/core/search/term_query.cpp
@@ -68,15 +68,8 @@ doc_iterator::ptr TermQuery::execute(const ExecutionContext& ctx) const {
   if (!ord_buckets.empty()) {
     auto* score = irs::get_mutable<irs::score>(docs.get());
     IRS_ASSERT(score);
-    if (score->IsDefault()) {
-      *score = CompileScore(ord_buckets, rdr, *state->reader, stats_.c_str(),
-                            *docs, boost());
-    } else if (ord_buckets.size() > 1) {
-      *score = CompileScorers(
-        std::move(*score),
-        PrepareScorers(ord_buckets.subspan(1), rdr, *state->reader,
-                       stats_.c_str(), *docs, boost()));
-    }
+    CompileScore(*score, ord_buckets, rdr, *state->reader, stats_.c_str(),
+                 *docs, boost());
   }
 
   return docs;

--- a/core/search/tfidf.cpp
+++ b/core/search/tfidf.cpp
@@ -256,7 +256,7 @@ struct MakeScoreFunctionImpl<TFIDFContext<Norm>> {
           *res = tfidf(state.freq.value, idf) * state.norm();
         }
       },
-      std::forward<Args>(args)...);
+      ScoreFunction::DefaultMin, std::forward<Args>(args)...);
   }
 };
 
@@ -292,7 +292,7 @@ ScoreFunction TFIDF::prepare_scorer(const ColumnProvider& segment,
 
   if (!freq) {
     if (!boost_as_score_ || 0.f == boost) {
-      return ScoreFunction::Invalid();
+      return ScoreFunction::Default(1);
     }
 
     // if there is no frequency then all the
@@ -322,7 +322,7 @@ ScoreFunction TFIDF::prepare_scorer(const ColumnProvider& segment,
 
     if (IRS_UNLIKELY(!doc)) {
       // we need 'document' attribute to be exposed
-      return ScoreFunction::Invalid();
+      return ScoreFunction::Default(1);
     }
 
     if (auto it = features.find(irs::type<Norm2>::id()); it != features.end()) {

--- a/core/utils/misc.hpp
+++ b/core/utils/misc.hpp
@@ -119,9 +119,9 @@ Visitor(T...) -> Visitor<std::decay_t<T>...>;
 template<typename Func>
 auto ResolveBool(bool value, Func&& func) {
   if (value) {
-    return std::forward<Func>(func)(std::true_type{});
+    return std::forward<Func>(func).template operator()<true>();
   } else {
-    return std::forward<Func>(func)(std::false_type{});
+    return std::forward<Func>(func).template operator()<false>();
   }
 }
 

--- a/tests/formats/formats_15_tests.cpp
+++ b/tests/formats/formats_15_tests.cpp
@@ -415,8 +415,7 @@ irs::doc_iterator::ptr Format15TestCase::GetWanderator(
   }
   if (iterator_has_freq) {
     ctx.index = 0;
-    ctx.type = strict ? irs::WandContext::Type::kRoot
-                      : irs::WandContext::Type::kWeakRoot;
+    ctx.strict = strict;
     info.mapped_index = 0;
   }
 

--- a/tests/formats/formats_15_tests.cpp
+++ b/tests/formats/formats_15_tests.cpp
@@ -56,8 +56,7 @@ struct FreqScorer : irs::ScorerBase<void> {
       reinterpret_cast<irs::score_ctx&>(const_cast<irs::frequency&>(*freq)),
       [](irs::score_ctx* ctx, irs::score_t* res) noexcept {
         *res = reinterpret_cast<irs::frequency*>(ctx)->value;
-      },
-      irs::ScoreFunction::DefaultMin};
+      }};
   }
 
   irs::WandWriter::ptr prepare_wand_writer(size_t max_levels) const {

--- a/tests/index/assert_format.cpp
+++ b/tests/index/assert_format.cpp
@@ -740,9 +740,8 @@ void assert_docs(const irs::term_iterator& expected_term,
         return irs::ScoreFunction::Default(1);
       }};
 
-    return actual_terms.wanderator(
-      *actual_cookie, requested_features, options,
-      {.index = 0, .type = irs::WandContext::Type::kWeakRoot});
+    return actual_terms.wanderator(*actual_cookie, requested_features, options,
+                                   {.index = 0, .strict = false});
   });
 
   // FIXME(gnusi): check bit_union

--- a/tests/index/assert_format.cpp
+++ b/tests/index/assert_format.cpp
@@ -741,12 +741,13 @@ void assert_docs(const irs::term_iterator& expected_term,
   assert_docs(expected_term.postings(requested_features), [&]() {
     // FIXME(gnusi)
     const irs::WanderatorOptions options{
-      .factory = [](const irs::attribute_provider&, const irs::Scorer& score) {
+      .factory = [](const irs::attribute_provider&) {
         return irs::ScoreFunction::Default(1);
       }};
 
-    return actual_terms.wanderator(*actual_cookie, requested_features, options,
-                                   {.index = 0, .strict = false});
+    return actual_terms.wanderator(
+      *actual_cookie, requested_features, options,
+      {.index = 0, .type = irs::WandContext::Type::kWeakRoot});
   });
 
   // FIXME(gnusi): check bit_union

--- a/tests/search/all_filter_tests.cpp
+++ b/tests/search/all_filter_tests.cpp
@@ -136,7 +136,7 @@ TEST_P(all_filter_test_case, all_order) {
                               const irs::feature_map_t&, const irs::byte_type*,
                               const irs::attribute_provider&,
                               irs::score_t) -> irs::ScoreFunction {
-      return irs::ScoreFunction::Invalid();
+      return irs::ScoreFunction::Default(1);
     };
     sort.prepare_term_collector_ = []() -> irs::TermCollector::ptr {
       return nullptr;

--- a/tests/search/boolean_filter_tests.cpp
+++ b/tests/search/boolean_filter_tests.cpp
@@ -126,13 +126,12 @@ class basic_doc_iterator : public irs::doc_iterator, irs::score_ctx {
         irs::PrepareScorers(ord.buckets(), irs::SubReader::empty(),
                             irs::empty_term_reader{0}, stats_, *this, boost);
 
-      score_.Reset(*this, irs::ScoreFunction::DefaultMin,
-                   [](irs::score_ctx* ctx, irs::score_t* res) noexcept {
-                     const auto& self = *static_cast<basic_doc_iterator*>(ctx);
-                     for (auto& scorer : self.scorers_) {
-                       scorer(res++);
-                     }
-                   });
+      score_.Reset(*this, [](irs::score_ctx* ctx, irs::score_t* res) noexcept {
+        const auto& self = *static_cast<basic_doc_iterator*>(ctx);
+        for (auto& scorer : self.scorers_) {
+          scorer(res++);
+        }
+      });
 
       attrs_[irs::type<irs::score>::id()] = &score_;
     }

--- a/tests/search/boolean_filter_tests.cpp
+++ b/tests/search/boolean_filter_tests.cpp
@@ -126,15 +126,13 @@ class basic_doc_iterator : public irs::doc_iterator, irs::score_ctx {
         irs::PrepareScorers(ord.buckets(), irs::SubReader::empty(),
                             irs::empty_term_reader{0}, stats_, *this, boost);
 
-      score_.Reset(
-        *this,
-        [](irs::score_ctx* ctx, irs::score_t* res) noexcept {
-          const auto& self = *static_cast<basic_doc_iterator*>(ctx);
-          for (auto& scorer : self.scorers_) {
-            scorer(res++);
-          }
-        },
-        irs::ScoreFunction::DefaultMin);
+      score_.Reset(*this, irs::ScoreFunction::DefaultMin,
+                   [](irs::score_ctx* ctx, irs::score_t* res) noexcept {
+                     const auto& self = *static_cast<basic_doc_iterator*>(ctx);
+                     for (auto& scorer : self.scorers_) {
+                       scorer(res++);
+                     }
+                   });
 
       attrs_[irs::type<irs::score>::id()] = &score_;
     }

--- a/tests/search/filter_test_case_base.hpp
+++ b/tests/search/filter_test_case_base.hpp
@@ -66,7 +66,7 @@ struct boost : public irs::ScorerBase<boost, void> {
 
         *res = state.boost_;
       },
-      boost);
+      irs::ScoreFunction::DefaultMin, boost);
   }
 };
 
@@ -189,7 +189,8 @@ struct custom_sort : public irs::ScorerBase<custom_sort, void> {
             irs::get<irs::document>(state.document_attrs_)->value, res);
         }
       },
-      *this, segment_reader, term_reader, filter_node_attrs, document_attrs);
+      irs::ScoreFunction::DefaultMin, *this, segment_reader, term_reader,
+      filter_node_attrs, document_attrs);
   }
 
   irs::TermCollector::ptr prepare_term_collector() const final {
@@ -295,7 +296,7 @@ struct frequency_sort : public irs::ScorerBase<frequency_sort, stats_t> {
           *res = std::numeric_limits<irs::score_t>::infinity();
         }
       },
-      docs_count, doc);
+      irs::ScoreFunction::DefaultMin, docs_count, doc);
   }
 
   irs::TermCollector::ptr prepare_term_collector() const final {

--- a/tests/search/nested_filter_test.cpp
+++ b/tests/search/nested_filter_test.cpp
@@ -129,7 +129,7 @@ struct DocIdScorer : irs::ScorerBase<void> {
         const auto& state = *static_cast<ScorerContext*>(ctx);
         *res = state.doc->value;
       },
-      doc);
+      irs::ScoreFunction::DefaultMin, doc);
   }
 };
 

--- a/tests/search/ngram_similarity_filter_tests.cpp
+++ b/tests/search/ngram_similarity_filter_tests.cpp
@@ -964,7 +964,7 @@ TEST_P(ngram_similarity_filter_test_case, missed_last_scored_test) {
         freq.filter_boost->push_back(freq.boost_from_filter->value);
         *res = {};
       },
-      &frequency, freq, &filter_boost, boost);
+      irs::ScoreFunction::DefaultMin, &frequency, freq, &filter_boost, boost);
   };
   std::vector<size_t> expectedFrequency{1, 1, 2, 1, 1, 1, 1};
   std::vector<irs::score_t> expected_filter_boost{
@@ -1036,7 +1036,7 @@ TEST_P(ngram_similarity_filter_test_case, missed_frequency_test) {
         freq.filter_boost->push_back(freq.boost_from_filter->value);
         *res = {};
       },
-      &frequency, freq, &filter_boost, boost);
+      irs::ScoreFunction::DefaultMin, &frequency, freq, &filter_boost, boost);
   };
   std::vector<size_t> expected_frequency{1, 1, 2, 1, 1, 1, 1};
   std::vector<irs::score_t> expected_filter_boost{

--- a/tests/search/sort_tests.cpp
+++ b/tests/search/sort_tests.cpp
@@ -955,7 +955,7 @@ TEST(ScoreFunctionTest, reset) {
     auto score_func =
       +[](irs::score_ctx*, irs::score_t* res) noexcept { *res = 42; };
 
-    func.Reset(ctx, irs::ScoreFunction::DefaultMin, score_func);
+    func.Reset(ctx, score_func);
 
     ASSERT_EQ(score_func, func.Func());
     ASSERT_EQ(&ctx, func.Ctx());
@@ -963,7 +963,7 @@ TEST(ScoreFunctionTest, reset) {
     func(&tmp);
     ASSERT_EQ(42, tmp);
 
-    func.Reset(ctx, irs::ScoreFunction::DefaultMin, score_func);
+    func.Reset(ctx, score_func);
     ASSERT_EQ(score_func, func.Func());
     ASSERT_EQ(&ctx, func.Ctx());
     tmp = 1;

--- a/tests/search/sort_tests.cpp
+++ b/tests/search/sort_tests.cpp
@@ -69,9 +69,9 @@ class aligned_scorer final
     const irs::attribute_provider& /*doc_attrs*/,
     irs::score_t /*boost*/) const final {
     if (empty_scorer_) {
-      return irs::ScoreFunction::Invalid();
+      return irs::ScoreFunction::Default(1);
     }
-    return irs::ScoreFunction::Empty();
+    return irs::ScoreFunction::Default(0);
   }
 
   irs::IndexFeatures index_features() const final { return index_features_; }
@@ -211,12 +211,9 @@ TEST(sort_tests, prepare_order) {
       prepared.buckets(), irs::SubReader::empty(), irs::empty_term_reader(0),
       stats_buf.c_str(), EMPTY_ATTRIBUTE_PROVIDER, irs::kNoBoost);
     ASSERT_TRUE(3 == scorers.size());
-    ASSERT_NE(nullptr, scorers[0]);
-    ASSERT_NE(&irs::ScoreFunction::DefaultScore, scorers[0]);
-    ASSERT_NE(nullptr, scorers[1]);
-    ASSERT_EQ(&irs::ScoreFunction::DefaultScore, scorers[1]);
-    ASSERT_NE(nullptr, scorers[2]);
-    ASSERT_EQ(&irs::ScoreFunction::DefaultScore, scorers[2]);
+    ASSERT_TRUE(scorers[0].IsDefault());
+    ASSERT_TRUE(scorers[1].IsDefault());
+    ASSERT_TRUE(scorers[2].IsDefault());
 
     irs::score score;
     ASSERT_TRUE(score.Func() == &irs::ScoreFunction::DefaultScore);
@@ -227,7 +224,8 @@ TEST(sort_tests, prepare_order) {
 
     irs::bstring expected(prepared.score_size(), 0);
     std::fill_n(expected.data(), sizeof(irs::score_t), 1);
-    ASSERT_EQ(expected, score_buf);
+    EXPECT_EQ(irs::ViewCast<char>(irs::bytes_view{expected}),
+              irs::ViewCast<char>(irs::bytes_view{score_buf}));
   }
 
   {
@@ -267,12 +265,9 @@ TEST(sort_tests, prepare_order) {
       prepared.buckets(), irs::SubReader::empty(), irs::empty_term_reader(0),
       stats_buf.c_str(), EMPTY_ATTRIBUTE_PROVIDER, irs::kNoBoost);
     ASSERT_TRUE(3 == scorers.size());
-    ASSERT_NE(nullptr, scorers[0]);
-    ASSERT_EQ(&irs::ScoreFunction::DefaultScore, scorers[0]);
-    ASSERT_NE(nullptr, scorers[1]);
-    ASSERT_NE(&irs::ScoreFunction::DefaultScore, scorers[1]);
-    ASSERT_NE(nullptr, scorers[2]);
-    ASSERT_EQ(&irs::ScoreFunction::DefaultScore, scorers[2]);
+    ASSERT_TRUE(scorers[0].IsDefault());
+    ASSERT_TRUE(scorers[1].IsDefault());
+    ASSERT_TRUE(scorers[2].IsDefault());
 
     irs::score score;
     ASSERT_TRUE(score.Func() == &irs::ScoreFunction::DefaultScore);
@@ -284,7 +279,8 @@ TEST(sort_tests, prepare_order) {
     irs::bstring expected(prepared.score_size(), 0);
     std::fill_n(expected.data() + sizeof(irs::score_t), sizeof(irs::score_t),
                 1);
-    ASSERT_EQ(expected, score_buf);
+    EXPECT_EQ(irs::ViewCast<char>(irs::bytes_view{expected}),
+              irs::ViewCast<char>(irs::bytes_view{score_buf}));
   }
 
   {
@@ -323,12 +319,9 @@ TEST(sort_tests, prepare_order) {
       prepared.buckets(), irs::SubReader::empty(), irs::empty_term_reader(0),
       stats_buf.c_str(), EMPTY_ATTRIBUTE_PROVIDER, irs::kNoBoost);
     ASSERT_TRUE(3 == scorers.size());
-    ASSERT_NE(nullptr, scorers[0]);
-    ASSERT_EQ(&irs::ScoreFunction::DefaultScore, scorers[0]);
-    ASSERT_NE(nullptr, scorers[1]);
-    ASSERT_EQ(&irs::ScoreFunction::DefaultScore, scorers[1]);
-    ASSERT_NE(nullptr, scorers[2]);
-    ASSERT_EQ(&irs::ScoreFunction::DefaultScore, scorers[2]);
+    ASSERT_TRUE(scorers[0].IsDefault());
+    ASSERT_TRUE(scorers[1].IsDefault());
+    ASSERT_TRUE(scorers[2].IsDefault());
 
     irs::score score;
     ASSERT_TRUE(score.Func() == &irs::ScoreFunction::DefaultScore);
@@ -337,7 +330,8 @@ TEST(sort_tests, prepare_order) {
 
     score(reinterpret_cast<irs::score_t*>(score_buf.data()));
     irs::bstring expected(prepared.score_size(), 0);
-    ASSERT_EQ(expected, score_buf);
+    EXPECT_EQ(irs::ViewCast<char>(irs::bytes_view{expected}),
+              irs::ViewCast<char>(irs::bytes_view{score_buf}));
   }
 
   {
@@ -377,9 +371,7 @@ TEST(sort_tests, prepare_order) {
       stats_buf.c_str(), EMPTY_ATTRIBUTE_PROVIDER, irs::kNoBoost);
     ASSERT_TRUE(2 == scorers.size());
     auto& front = scorers.front();
-    ASSERT_NE(nullptr, front);
     auto& back = scorers.back();
-    ASSERT_NE(nullptr, back);
 
     irs::score score;
     ASSERT_TRUE(score.Func() == &irs::ScoreFunction::DefaultScore);
@@ -428,9 +420,6 @@ TEST(sort_tests, prepare_order) {
       prepared.buckets(), irs::SubReader::empty(), irs::empty_term_reader(0),
       stats_buf.c_str(), EMPTY_ATTRIBUTE_PROVIDER, irs::kNoBoost);
     ASSERT_TRUE(3 == scorers.size());
-    ASSERT_NE(nullptr, scorers[0]);
-    ASSERT_NE(nullptr, scorers[1]);
-    ASSERT_NE(nullptr, scorers[2]);
 
     irs::score score;
     ASSERT_TRUE(score.Func() == &irs::ScoreFunction::DefaultScore);
@@ -477,14 +466,11 @@ TEST(sort_tests, prepare_order) {
       prepared.buckets(), irs::SubReader::empty(), irs::empty_term_reader(0),
       stats_buf.c_str(), EMPTY_ATTRIBUTE_PROVIDER, irs::kNoBoost);
     ASSERT_TRUE(3 == scorers.size());
-    ASSERT_NE(nullptr, scorers[0]);
-    ASSERT_NE(nullptr, scorers[1]);
-    ASSERT_NE(nullptr, scorers[2]);
 
     irs::score score;
-    ASSERT_TRUE(score == &irs::ScoreFunction::DefaultScore);
+    ASSERT_TRUE(score.Func() == &irs::ScoreFunction::DefaultScore);
     score = irs::CompileScorers(std::move(scorers));
-    ASSERT_FALSE(score == &irs::ScoreFunction::DefaultScore);
+    ASSERT_FALSE(score.Func() == &irs::ScoreFunction::DefaultScore);
 
     score(reinterpret_cast<irs::score_t*>(score_buf.data()));
   }
@@ -798,17 +784,11 @@ TEST(sort_tests, prepare_order) {
 
     irs::score score;
     ASSERT_TRUE(score.Ctx() == nullptr);
-    ASSERT_TRUE(score.Func() == &irs::ScoreFunction::DefaultScore);
+    ASSERT_TRUE(score.IsDefault());
     score = irs::CompileScorers(std::move(scorers));
     ASSERT_FALSE(score.Ctx() == nullptr);
-    ASSERT_FALSE(score.Func() == &irs::ScoreFunction::DefaultScore);
+    ASSERT_FALSE(score.IsDefault());
   }
-}
-
-TEST(ScoreFunctionTest, Invalid) {
-  auto func = irs::ScoreFunction::Invalid();
-  ASSERT_FALSE(func);
-  ASSERT_FALSE(func.IsDefault());
 }
 
 TEST(ScoreFunctionTest, Noop) {
@@ -816,7 +796,7 @@ TEST(ScoreFunctionTest, Noop) {
 
   {
     auto func = irs::ScoreFunction::Default(0);
-    ASSERT_TRUE(func);
+    ASSERT_TRUE(func.IsDefault());
     ASSERT_TRUE(func.Ctx() == nullptr);
     func(&value);
     ASSERT_EQ(42.f, value);
@@ -824,7 +804,7 @@ TEST(ScoreFunctionTest, Noop) {
 
   {
     auto func = irs::ScoreFunction::Constant(0.f, 0);
-    ASSERT_TRUE(func);
+    ASSERT_TRUE(func.IsDefault());
     ASSERT_TRUE(func.Ctx() == nullptr);
     func(&value);
     ASSERT_EQ(42.f, value);
@@ -835,7 +815,7 @@ TEST(ScoreFunctionTest, Default) {
   std::array<irs::score_t, 7> values;
   std::fill_n(std::begin(values), values.size(), 42.f);
   auto func = irs::ScoreFunction::Default(values.size());
-  ASSERT_TRUE(func);
+  ASSERT_TRUE(func.IsDefault());
   ASSERT_FALSE(func.Ctx() == nullptr);
   func(values.data());
   ASSERT_TRUE(std::all_of(std::begin(values), std::end(values),
@@ -848,7 +828,7 @@ TEST(ScoreFunctionTest, Constant) {
 
   {
     auto func = irs::ScoreFunction::Constant(43.f, values.size());
-    ASSERT_TRUE(func);
+    ASSERT_FALSE(func.IsDefault());
     ASSERT_FALSE(func.Ctx() == nullptr);
     func(values.data());
     ASSERT_TRUE(std::all_of(std::begin(values), std::end(values),
@@ -857,7 +837,7 @@ TEST(ScoreFunctionTest, Constant) {
 
   {
     auto func = irs::ScoreFunction::Constant(42.f, 1);
-    ASSERT_TRUE(func);
+    ASSERT_FALSE(func.IsDefault());
     ASSERT_FALSE(func.Ctx() == nullptr);
     func(values.data());
     ASSERT_EQ(42.f, values.front());
@@ -867,7 +847,7 @@ TEST(ScoreFunctionTest, Constant) {
 
   {
     auto func = irs::ScoreFunction::Constant(43.f);
-    ASSERT_TRUE(func);
+    ASSERT_FALSE(func.IsDefault());
     ASSERT_FALSE(func.Ctx() == nullptr);
     func(values.data());
     ASSERT_TRUE(std::all_of(std::begin(values), std::end(values),
@@ -883,7 +863,6 @@ TEST(ScoreFunctionTest, construct) {
 
   {
     irs::ScoreFunction func;
-    ASSERT_TRUE(func);
     ASSERT_NE(nullptr, func.Func());
     ASSERT_EQ(nullptr, func.Ctx());
     irs::score_t tmp{1};
@@ -897,8 +876,7 @@ TEST(ScoreFunctionTest, construct) {
     auto score_func =
       +[](irs::score_ctx*, irs::score_t* res) noexcept { *res = 42; };
 
-    irs::ScoreFunction func(ctx, score_func);
-    ASSERT_TRUE(func);
+    irs::ScoreFunction func(ctx, score_func, irs::ScoreFunction::DefaultMin);
     ASSERT_EQ(score_func, func.Func());
     ASSERT_EQ(&ctx, func.Ctx());
     irs::score_t tmp{1};
@@ -912,8 +890,7 @@ TEST(ScoreFunctionTest, construct) {
     auto score_func =
       +[](irs::score_ctx*, irs::score_t* res) noexcept { *res = 42; };
 
-    irs::ScoreFunction func(ctx, score_func);
-    ASSERT_TRUE(func);
+    irs::ScoreFunction func(ctx, score_func, irs::ScoreFunction::DefaultMin);
     ASSERT_EQ(score_func, func.Func());
     ASSERT_EQ(&ctx, func.Ctx());
     irs::score_t tmp{1};
@@ -928,8 +905,8 @@ TEST(ScoreFunctionTest, construct) {
       *res = 42;
     };
 
-    auto func = irs::ScoreFunction::Make<Ctx>(score_func);
-    ASSERT_TRUE(func);
+    auto func =
+      irs::ScoreFunction::Make<Ctx>(score_func, irs::ScoreFunction::DefaultMin);
     ASSERT_EQ(score_func, func.Func());
     ASSERT_NE(nullptr, func.Ctx());
     irs::score_t tmp;
@@ -945,8 +922,8 @@ TEST(ScoreFunctionTest, construct) {
       *res = 42;
     };
 
-    auto func = irs::ScoreFunction::Make<Ctx>(score_func);
-    ASSERT_TRUE(func);
+    auto func =
+      irs::ScoreFunction::Make<Ctx>(score_func, irs::ScoreFunction::DefaultMin);
     ASSERT_EQ(score_func, func.Func());
     ASSERT_NE(nullptr, func.Ctx());
     irs::score_t tmp;
@@ -964,7 +941,6 @@ TEST(ScoreFunctionTest, reset) {
 
   irs::ScoreFunction func;
 
-  ASSERT_TRUE(func);
   ASSERT_NE(nullptr, func.Func());
   ASSERT_EQ(nullptr, func.Ctx());
   {
@@ -979,17 +955,15 @@ TEST(ScoreFunctionTest, reset) {
     auto score_func =
       +[](irs::score_ctx*, irs::score_t* res) noexcept { *res = 42; };
 
-    func.Reset(ctx, score_func);
+    func.Reset(ctx, score_func, irs::ScoreFunction::DefaultMin);
 
-    ASSERT_TRUE(func);
     ASSERT_EQ(score_func, func.Func());
     ASSERT_EQ(&ctx, func.Ctx());
     irs::score_t tmp{1};
     func(&tmp);
     ASSERT_EQ(42, tmp);
 
-    func.Reset(ctx, score_func);
-    ASSERT_TRUE(func);
+    func.Reset(ctx, score_func, irs::ScoreFunction::DefaultMin);
     ASSERT_EQ(score_func, func.Func());
     ASSERT_EQ(&ctx, func.Ctx());
     tmp = 1;
@@ -1004,8 +978,8 @@ TEST(ScoreFunctionTest, reset) {
       *res = 42;
     };
 
-    func = irs::ScoreFunction::Make<Ctx>(score_func);
-    ASSERT_TRUE(func);
+    func =
+      irs::ScoreFunction::Make<Ctx>(score_func, irs::ScoreFunction::DefaultMin);
     ASSERT_EQ(score_func, func.Func());
     ASSERT_NE(nullptr, func.Ctx());
     irs::score_t tmp;
@@ -1021,20 +995,14 @@ TEST(ScoreFunctionTest, reset) {
       *res = 43;
     };
 
-    func = irs::ScoreFunction::Make<Ctx>(score_func);
-    ASSERT_TRUE(func);
+    func =
+      irs::ScoreFunction::Make<Ctx>(score_func, irs::ScoreFunction::DefaultMin);
     ASSERT_EQ(score_func, func.Func());
     ASSERT_NE(nullptr, func.Ctx());
     irs::score_t tmp;
     func(&tmp);
     ASSERT_EQ(43, static_cast<const Ctx*>(func.Ctx())->buf[0]);
     ASSERT_EQ(43, tmp);
-  }
-
-  {
-    Ctx ctx;
-    func.Reset(ctx, nullptr);
-    ASSERT_FALSE(func);
   }
 }
 
@@ -1051,20 +1019,17 @@ TEST(ScoreFunctionTest, move) {
       +[](irs::score_ctx*, irs::score_t* res) noexcept { *res = 42; };
 
     float_t tmp{1};
-    irs::ScoreFunction func(ctx, score_func);
-    ASSERT_TRUE(func);
+    irs::ScoreFunction func(ctx, score_func, irs::ScoreFunction::DefaultMin);
     ASSERT_EQ(&ctx, func.Ctx());
     ASSERT_EQ(score_func, func.Func());
     func(&tmp);
     ASSERT_EQ(42, tmp);
     irs::ScoreFunction moved(std::move(func));
-    ASSERT_TRUE(moved);
     ASSERT_EQ(&ctx, moved.Ctx());
     ASSERT_EQ(score_func, moved.Func());
     tmp = 1;
     moved(&tmp);
     ASSERT_EQ(42, tmp);
-    ASSERT_TRUE(func);
     ASSERT_EQ(nullptr, func.Ctx());
     ASSERT_NE(score_func, func.Func());
     tmp = 1;
@@ -1081,25 +1046,21 @@ TEST(ScoreFunctionTest, move) {
     float_t tmp{1};
 
     irs::ScoreFunction moved;
-    ASSERT_TRUE(moved);
     ASSERT_EQ(nullptr, moved.Ctx());
     ASSERT_NE(score_func, moved.Func());
     moved(&tmp);
     ASSERT_EQ(1, tmp);
-    irs::ScoreFunction func(ctx, score_func);
-    ASSERT_TRUE(func);
+    irs::ScoreFunction func(ctx, score_func, irs::ScoreFunction::DefaultMin);
     ASSERT_EQ(&ctx, func.Ctx());
     ASSERT_EQ(score_func, func.Func());
     func(&tmp);
     ASSERT_EQ(42, tmp);
     moved = std::move(func);
-    ASSERT_TRUE(moved);
     ASSERT_EQ(&ctx, moved.Ctx());
     ASSERT_EQ(score_func, moved.Func());
     tmp = 1;
     moved(&tmp);
     ASSERT_EQ(42, tmp);
-    ASSERT_TRUE(func);
     ASSERT_EQ(nullptr, func.Ctx());
     ASSERT_NE(score_func, func.Func());
     tmp = 1;
@@ -1118,15 +1079,17 @@ TEST(ScoreFunctionTest, equality) {
   auto score_func1 = [](irs::score_ctx*, irs::score_t*) noexcept {};
 
   irs::ScoreFunction func0;
-  irs::ScoreFunction func1(ctx0, score_func0);
-  irs::ScoreFunction func2(ctx1, score_func1);
-  irs::ScoreFunction func3(ctx0, score_func1);
-  irs::ScoreFunction func4(ctx1, score_func0);
+  irs::ScoreFunction func1(ctx0, score_func0, irs::ScoreFunction::DefaultMin);
+  irs::ScoreFunction func2(ctx1, score_func1, irs::ScoreFunction::DefaultMin);
+  irs::ScoreFunction func3(ctx0, score_func1, irs::ScoreFunction::DefaultMin);
+  irs::ScoreFunction func4(ctx1, score_func0, irs::ScoreFunction::DefaultMin);
 
   ASSERT_EQ(func0, irs::ScoreFunction());
   ASSERT_NE(func0, func1);
   ASSERT_NE(func2, func3);
   ASSERT_NE(func2, func4);
-  ASSERT_EQ(func1, irs::ScoreFunction(ctx0, score_func0));
-  ASSERT_EQ(func2, irs::ScoreFunction(ctx1, score_func1));
+  ASSERT_EQ(func1, irs::ScoreFunction(ctx0, score_func0,
+                                      irs::ScoreFunction::DefaultMin));
+  ASSERT_EQ(func2, irs::ScoreFunction(ctx1, score_func1,
+                                      irs::ScoreFunction::DefaultMin));
 }

--- a/tests/search/sort_tests.cpp
+++ b/tests/search/sort_tests.cpp
@@ -876,7 +876,7 @@ TEST(ScoreFunctionTest, construct) {
     auto score_func =
       +[](irs::score_ctx*, irs::score_t* res) noexcept { *res = 42; };
 
-    irs::ScoreFunction func(ctx, score_func, irs::ScoreFunction::DefaultMin);
+    irs::ScoreFunction func(ctx, score_func);
     ASSERT_EQ(score_func, func.Func());
     ASSERT_EQ(&ctx, func.Ctx());
     irs::score_t tmp{1};
@@ -890,7 +890,7 @@ TEST(ScoreFunctionTest, construct) {
     auto score_func =
       +[](irs::score_ctx*, irs::score_t* res) noexcept { *res = 42; };
 
-    irs::ScoreFunction func(ctx, score_func, irs::ScoreFunction::DefaultMin);
+    irs::ScoreFunction func(ctx, score_func);
     ASSERT_EQ(score_func, func.Func());
     ASSERT_EQ(&ctx, func.Ctx());
     irs::score_t tmp{1};
@@ -1019,7 +1019,7 @@ TEST(ScoreFunctionTest, move) {
       +[](irs::score_ctx*, irs::score_t* res) noexcept { *res = 42; };
 
     float_t tmp{1};
-    irs::ScoreFunction func(ctx, score_func, irs::ScoreFunction::DefaultMin);
+    irs::ScoreFunction func(ctx, score_func);
     ASSERT_EQ(&ctx, func.Ctx());
     ASSERT_EQ(score_func, func.Func());
     func(&tmp);
@@ -1050,7 +1050,7 @@ TEST(ScoreFunctionTest, move) {
     ASSERT_NE(score_func, moved.Func());
     moved(&tmp);
     ASSERT_EQ(1, tmp);
-    irs::ScoreFunction func(ctx, score_func, irs::ScoreFunction::DefaultMin);
+    irs::ScoreFunction func(ctx, score_func);
     ASSERT_EQ(&ctx, func.Ctx());
     ASSERT_EQ(score_func, func.Func());
     func(&tmp);
@@ -1079,17 +1079,15 @@ TEST(ScoreFunctionTest, equality) {
   auto score_func1 = [](irs::score_ctx*, irs::score_t*) noexcept {};
 
   irs::ScoreFunction func0;
-  irs::ScoreFunction func1(ctx0, score_func0, irs::ScoreFunction::DefaultMin);
-  irs::ScoreFunction func2(ctx1, score_func1, irs::ScoreFunction::DefaultMin);
-  irs::ScoreFunction func3(ctx0, score_func1, irs::ScoreFunction::DefaultMin);
-  irs::ScoreFunction func4(ctx1, score_func0, irs::ScoreFunction::DefaultMin);
+  irs::ScoreFunction func1(ctx0, score_func0);
+  irs::ScoreFunction func2(ctx1, score_func1);
+  irs::ScoreFunction func3(ctx0, score_func1);
+  irs::ScoreFunction func4(ctx1, score_func0);
 
   ASSERT_EQ(func0, irs::ScoreFunction());
   ASSERT_NE(func0, func1);
   ASSERT_NE(func2, func3);
   ASSERT_NE(func2, func4);
-  ASSERT_EQ(func1, irs::ScoreFunction(ctx0, score_func0,
-                                      irs::ScoreFunction::DefaultMin));
-  ASSERT_EQ(func2, irs::ScoreFunction(ctx1, score_func1,
-                                      irs::ScoreFunction::DefaultMin));
+  ASSERT_EQ(func1, irs::ScoreFunction(ctx0, score_func0));
+  ASSERT_EQ(func2, irs::ScoreFunction(ctx1, score_func1));
 }

--- a/tests/search/sort_tests.cpp
+++ b/tests/search/sort_tests.cpp
@@ -955,7 +955,7 @@ TEST(ScoreFunctionTest, reset) {
     auto score_func =
       +[](irs::score_ctx*, irs::score_t* res) noexcept { *res = 42; };
 
-    func.Reset(ctx, score_func, irs::ScoreFunction::DefaultMin);
+    func.Reset(ctx, irs::ScoreFunction::DefaultMin, score_func);
 
     ASSERT_EQ(score_func, func.Func());
     ASSERT_EQ(&ctx, func.Ctx());
@@ -963,7 +963,7 @@ TEST(ScoreFunctionTest, reset) {
     func(&tmp);
     ASSERT_EQ(42, tmp);
 
-    func.Reset(ctx, score_func, irs::ScoreFunction::DefaultMin);
+    func.Reset(ctx, irs::ScoreFunction::DefaultMin, score_func);
     ASSERT_EQ(score_func, func.Func());
     ASSERT_EQ(&ctx, func.Ctx());
     tmp = 1;

--- a/tests/search/sort_tests.cpp
+++ b/tests/search/sort_tests.cpp
@@ -167,9 +167,9 @@ TEST(sort_tests, prepare_order) {
 
     irs::score score;
     ASSERT_TRUE(score.Func() == &irs::ScoreFunction::DefaultScore);
-    score = irs::CompileScore(prepared.buckets(), irs::SubReader::empty(),
-                              irs::empty_term_reader(0), stats_buf.c_str(),
-                              EMPTY_ATTRIBUTE_PROVIDER, irs::kNoBoost);
+    irs::CompileScore(score, prepared.buckets(), irs::SubReader::empty(),
+                      irs::empty_term_reader(0), stats_buf.c_str(),
+                      EMPTY_ATTRIBUTE_PROVIDER, irs::kNoBoost);
     ASSERT_NE(score.Func(), &irs::ScoreFunction::DefaultScore);
   }
 

--- a/tests/search/terms_filter_test.cpp
+++ b/tests/search/terms_filter_test.cpp
@@ -506,7 +506,7 @@ TEST_P(terms_filter_test_case, min_match) {
           auto* state = static_cast<ScoreCtx*>(ctx);
           *res = static_cast<irs::score_t>(state->doc->value) * state->boost;
         },
-        doc, boost);
+        irs::ScoreFunction::DefaultMin, doc, boost);
     };
 
     const auto filter =

--- a/tests/search/top_terms_collector_test.cpp
+++ b/tests/search/top_terms_collector_test.cpp
@@ -120,7 +120,7 @@ struct sort : irs::Scorer {
     const irs::byte_type* /*stats*/,
     const irs::attribute_provider& /*doc_attrs*/,
     irs::score_t /*boost*/) const final {
-    return irs::ScoreFunction::Invalid();
+    return irs::ScoreFunction::Default(1);
   }
 
   std::pair<size_t, size_t> stats_size() const final { return {0, 0}; }

--- a/tests/search/wand_test.cpp
+++ b/tests/search/wand_test.cpp
@@ -127,7 +127,6 @@ std::vector<Doc> WandTestCase::Collect(const irs::DirectoryReader& index,
 
   const irs::WandContext mode{.index = wand_idx};
 
-  irs::score_threshold tmp;
   std::vector<ScoredDoc> sorted;
   sorted.reserve(limit);
 
@@ -138,20 +137,18 @@ std::vector<Doc> WandTestCase::Collect(const irs::DirectoryReader& index,
 
     const auto* doc = irs::get<irs::document>(*docs);
     EXPECT_NE(nullptr, doc);
-    const auto* score = irs::get<irs::score>(*docs);
+    auto* score = irs::get_mutable<irs::score>(docs.get());
     EXPECT_NE(nullptr, score);
-    auto* threshold = irs::get_mutable<irs::score_threshold>(docs.get());
     if (wand_idx != irs::WandContext::kDisable && can_use_wand) {
-      EXPECT_NE(nullptr, threshold->leaf_max);
+      EXPECT_NE(std::numeric_limits<irs::score_t>::max(), score->max.tail);
     } else {
-      EXPECT_EQ(nullptr, threshold->leaf_max);
-      threshold = &tmp;
+      EXPECT_EQ(std::numeric_limits<irs::score_t>::max(), score->max.tail);
     }
 
     if (!left) {
       EXPECT_TRUE(!sorted.empty());
       EXPECT_TRUE(std::is_heap(std::begin(sorted), std::end(sorted)));
-      threshold->min = sorted.front().score;
+      score->Min(sorted.front().score);
     }
 
     for (float_t score_value; docs->next();) {
@@ -162,7 +159,7 @@ std::vector<Doc> WandTestCase::Collect(const irs::DirectoryReader& index,
 
         if (0 == --left) {
           std::make_heap(std::begin(sorted), std::end(sorted));
-          threshold->min = sorted.front().score;
+          score->Min(sorted.front().score);
         }
       } else if (sorted.front().score < score_value) {
         std::pop_heap(std::begin(sorted), std::end(sorted));
@@ -174,7 +171,7 @@ std::vector<Doc> WandTestCase::Collect(const irs::DirectoryReader& index,
 
         std::push_heap(std::begin(sorted), std::end(sorted));
 
-        threshold->min = sorted.front().score;
+        score->Min(sorted.front().score);
       }
     }
 

--- a/utils/index-put.cpp
+++ b/utils/index-put.cpp
@@ -377,10 +377,9 @@ int put(const std::string& path, const std::string& dir_type,
     auto it = WAND_TYPES.find(wand_type);
     if (it != WAND_TYPES.end()) {
       scorer = it->second;
-    }
     scr = irs::scorers::get(
       scorer.name, irs::type<irs::text_format::json>::get(), scorer.arg);
-
+    }
     if (!scr) {
       std::cerr << "Unable to instatiate wand from wand type: " << wand_type
                 << std::endl;

--- a/utils/index-search.cpp
+++ b/utils/index-search.cpp
@@ -485,10 +485,7 @@ int search(std::string_view path, std::string_view dir_type,
       return {};
     }
 
-    return {.index = 0,
-            .type = mode == ExecutionMode::kStrictTop
-                      ? irs::WandContext::Type::kRoot
-                      : irs::WandContext::Type::kWeakRoot};
+    return {.index = 0, .strict = mode == ExecutionMode::kStrictTop};
   }();
 
   auto arg_format_itr = kTextFormats.find(scorer_arg_format);

--- a/utils/index-search.cpp
+++ b/utils/index-search.cpp
@@ -547,7 +547,7 @@ int search(std::string_view path, std::string_view dir_type,
             << SCORED_TERMS_LIMIT << "=" << scored_terms_limit << '\n'
             << SCORER << "=" << scorer << '\n'
             << SCORER_ARG_FMT << "=" << scorer_arg_format << '\n'
-            << SCORER_ARG << "=" << scorer_arg << '\n';
+            << SCORER_ARG << "=" << scorer_arg << std::endl;
 
   SCOPED_TIMER("Total Time");
 
@@ -564,9 +564,10 @@ int search(std::string_view path, std::string_view dir_type,
     reader = irs::DirectoryReader(*dir, codec, options);
   }
 
-  std::cout << "Index stats:\n"
-            << "docs=" << reader->docs_count()
-            << "\nlive-docs=" << reader->live_docs_count() << '\n';
+  std::cout << "Index stats:"
+            << "\nsegments=" << reader->size()
+            << "\ndocs=" << reader->docs_count()
+            << "\nlive-docs=" << reader->live_docs_count() << std::endl;
 
   {
     SCOPED_TIMER("Order build time");


### PR DESCRIPTION
Also:
* Compute score single time
* Make wand score compatible work
* Add wand optimization for conjunction, disjunction and min_match

master:
```
Index read time calls:1, time: 50293 us, avg call: 50293 us
Order build time calls:1, time: 1 us, avg call: 1 us
Query building (AndHighHigh) time calls:1000, time: 27679 us, avg call: 27.679 us
Query building (AndHighLow) time calls:1000, time: 20964 us, avg call: 20.964 us
Query building (AndHighMed) time calls:1000, time: 28698 us, avg call: 28.698 us
Query building (HighTerm) time calls:282, time: 1560 us, avg call: 5.53191 us
Query building (LowTerm) time calls:1000, time: 8037 us, avg call: 8.037 us
Query building (MedTerm) time calls:1000, time: 6794 us, avg call: 6.794 us
Query building (MinMatch2High2Med) time calls:2, time: 320 us, avg call: 160 us
Query building (Or4High) time calls:2, time: 78 us, avg call: 39 us
Query building (Or6High4Med2Low) time calls:2, time: 203 us, avg call: 101.5 us
Query execution (AndHighHigh) time calls:1000, time: 84034036 us, avg call: 84034 us
Query execution (AndHighLow) time calls:1000, time: 1891038 us, avg call: 1891.04 us
Query execution (AndHighMed) time calls:1000, time: 29832592 us, avg call: 29832.6 us
Query execution (HighTerm) time calls:282, time: 55568 us, avg call: 197.05 us
Query execution (LowTerm) time calls:1000, time: 240645 us, avg call: 240.645 us
Query execution (MedTerm) time calls:1000, time: 230304 us, avg call: 230.304 us
Query execution (MinMatch2High2Med) time calls:2, time: 1095620 us, avg call: 547810 us
Query execution (Or4High) time calls:2, time: 1831226 us, avg call: 915613 us
Query execution (Or6High4Med2Low) time calls:2, time: 3189758 us, avg call: 1.59488e+06 us
Total Time calls:1, time: 384756430 us, avg call: 3.84756e+08 us
```

this branch:
```
Index read time calls:1, time: 49971 us, avg call: 49971 us
Order build time calls:1, time: 1 us, avg call: 1 us
Query building (AndHighHigh) time calls:1000, time: 21830 us, avg call: 21.83 us
Query building (AndHighLow) time calls:1000, time: 20462 us, avg call: 20.462 us
Query building (AndHighMed) time calls:1000, time: 22017 us, avg call: 22.017 us
Query building (HighTerm) time calls:282, time: 1846 us, avg call: 6.5461 us
Query building (LowTerm) time calls:1000, time: 6599 us, avg call: 6.599 us
Query building (MedTerm) time calls:1000, time: 6743 us, avg call: 6.743 us
Query building (MinMatch2High2Med) time calls:2, time: 314 us, avg call: 157 us
Query building (Or4High) time calls:2, time: 99 us, avg call: 49.5 us
Query building (Or6High4Med2Low) time calls:2, time: 208 us, avg call: 104 us
Query execution (AndHighHigh) time calls:1000, time: 32042074 us, avg call: 32042.1 us
Query execution (AndHighLow) time calls:1000, time: 1538670 us, avg call: 1538.67 us
Query execution (AndHighMed) time calls:1000, time: 15533962 us, avg call: 15534 us
Query execution (HighTerm) time calls:282, time: 55386 us, avg call: 196.404 us
Query execution (LowTerm) time calls:1000, time: 228807 us, avg call: 228.807 us
Query execution (MedTerm) time calls:1000, time: 227585 us, avg call: 227.585 us
Query execution (MinMatch2High2Med) time calls:2, time: 809330 us, avg call: 404665 us
Query execution (Or4High) time calls:2, time: 1342383 us, avg call: 671192 us
Query execution (Or6High4Med2Low) time calls:2, time: 2340679 us, avg call: 1.17034e+06 us
Total Time calls:1, time: 316445536 us, avg call: 3.16446e+08 us
```