### PR TITLE
Reduce burst trie memory usage

### DIFF
--- a/core/formats/formats_burst_trie.cpp
+++ b/core/formats/formats_burst_trie.cpp
@@ -347,6 +347,9 @@ class MonotonicBuffer {
     Release(std::exchange(head_, nullptr));
     resource_manager_.Decrease(std::exchange(blocks_memory_, 0));
 
+    // otherwise we always increasing size!
+    next_size_ = (next_size_ * 2) / 3;
+
     available_ = 0;
     current_ = nullptr;
   }

--- a/core/formats/formats_burst_trie.cpp
+++ b/core/formats/formats_burst_trie.cpp
@@ -278,7 +278,6 @@ struct block_t : private util::noncopyable {
     index.Visit([](prefixed_output& output) {  //
       output.~prefixed_output();
     });
-    index.tail_ = nullptr;
   }
 
   block_index_t index;  // fst index data

--- a/core/formats/formats_burst_trie.cpp
+++ b/core/formats/formats_burst_trie.cpp
@@ -378,7 +378,7 @@ class MonotonicBuffer {
 
   // TODO(MBkkt) Do we really want to measure this?
   IResourceManager& resource_manager_;
-  size_t blocks_memory_{0};
+  size_t blocks_memory_ = 0;
 
   size_t next_size_;
   Block* head_ = nullptr;

--- a/core/formats/formats_burst_trie.cpp
+++ b/core/formats/formats_burst_trie.cpp
@@ -1018,7 +1018,6 @@ class field_writer final : public irs::field_writer {
   void Push(bytes_view term);
 
   absl::flat_hash_map<irs::type_info::type_id, size_t> feature_map_;
-
   MonotonicBuffer<block_t::prefixed_output> output_buffer_;
   std::vector<entry, ManagedTypedAllocator<entry>> blocks_;
   memory_output suffix_;  // term suffix column

--- a/core/formats/formats_burst_trie.cpp
+++ b/core/formats/formats_burst_trie.cpp
@@ -345,7 +345,7 @@ class MonotonicBuffer {
     }
 
     Release(std::exchange(head_, nullptr));
-    resource_manager_.Decrease(blocks_memory_);
+    resource_manager_.Decrease(std::exchange(blocks_memory_, 0));
 
     available_ = 0;
     current_ = nullptr;

--- a/core/formats/formats_burst_trie.cpp
+++ b/core/formats/formats_burst_trie.cpp
@@ -346,7 +346,7 @@ class MonotonicBuffer {
 
     // otherwise we always increasing size!
     // TODO(MBkkt) we could compute current size, but it's
-    next_size_ = (next_size_ * 2) / 3;
+    next_size_ = (next_size_ * 2 + 2) / 3;
 
     available_ = 0;
     current_ = nullptr;

--- a/core/formats/formats_burst_trie.cpp
+++ b/core/formats/formats_burst_trie.cpp
@@ -293,8 +293,7 @@ class MonotonicBuffer {
     (alignof(T) * alignof(void*)) / std::gcd(alignof(T), alignof(void*));
 
   struct alignas(kAlign) Block {
-    Block* next = nullptr;
-    size_t size = 0;
+    Block* prev = nullptr;
   };
 
   static_assert(std::is_trivially_destructible_v<Block>);
@@ -328,7 +327,7 @@ class MonotonicBuffer {
       return;
     }
 
-    Release(std::exchange(head_->next, nullptr));
+    Release(std::exchange(head_->prev, nullptr));
     // TODO(MBkkt) Don't be lazy, call Decrease eager
     // resource_manager_.Decrease(blocks_memory_ - size of head block);
 
@@ -357,7 +356,7 @@ class MonotonicBuffer {
  private:
   void Release(Block* it) noexcept {
     while (it != nullptr) {
-      operator delete(std::exchange(it, it->next), std::align_val_t{kAlign});
+      operator delete(std::exchange(it, it->prev), std::align_val_t{kAlign});
     }
   }
 

--- a/core/formats/formats_burst_trie.cpp
+++ b/core/formats/formats_burst_trie.cpp
@@ -1018,14 +1018,14 @@ class field_writer final : public irs::field_writer {
 #ifdef IRS_COUNTER_MONOTONIC_MEMORY
   struct CounterManager : IResourceManager {
     bool Increase(size_t size) noexcept final {
-      fprintf(stderr, "increase: %p counter %lu on %lu\n", this, counter_,
+      fprintf(stderr, "\nincrease: %p counter %lu on %lu\n", this, counter_,
               size);
       counter_ += size;
       return true;
     }
 
     void Decrease(size_t size) noexcept final {
-      fprintf(stderr, "decrease: %p counter %lu on %lu\n", this, counter_,
+      fprintf(stderr, "\ndecrease: %p counter %lu on %lu\n", this, counter_,
               size);
       counter_ -= size;
     }

--- a/core/formats/formats_burst_trie.cpp
+++ b/core/formats/formats_burst_trie.cpp
@@ -360,6 +360,8 @@ class MonotonicBuffer {
 
   void AllocateMemory() {
     const auto size = sizeof(Block) + next_size_ * sizeof(T);
+    // TODO(MBkkt) round up size via nallocx,
+    // in theory new could return available size, but it's only proposal :(
     resource_manager_.Increase(size);
     blocks_memory_ += size;
     auto* p =

--- a/core/resource_manager.hpp
+++ b/core/resource_manager.hpp
@@ -23,15 +23,6 @@
 #pragma once
 
 #include "shared.hpp"
-
-#if (defined(__clang__) || defined(_MSC_VER) || defined(__GNUC__))
-#include <version>
-#endif
-
-#ifdef __cpp_lib_memory_resource
-#include <memory_resource>
-#endif
-
 #include "utils/managed_allocator.hpp"
 
 namespace irs {

--- a/core/resource_manager.hpp
+++ b/core/resource_manager.hpp
@@ -91,13 +91,4 @@ struct ManagedTypedAllocator
   using Base::Base;
 };
 
-#ifdef __cpp_lib_polymorphic_allocator
-template<typename T>
-struct ManagedTypedPmrAllocator
-  : ManagedAllocator<std::pmr::polymorphic_allocator<T>, IResourceManager> {
-  using ManagedAllocator<std::pmr::polymorphic_allocator<T>,
-                         IResourceManager>::ManagedAllocator;
-};
-#endif
-
 }  // namespace irs


### PR DESCRIPTION
Main improvements are
* clear monotonic buffer after field end
* release monotonic buffer after writes end

but always keep next block size, also

* sizeof prefixed_output 96 instead of 104 (node in list)
  because single linked list instead of double linked, so it single pointer in the Node instead of two
* sizeof entry(block_index_t) 88(8) instead of 120(40)
  because list just a single tail pointer instead of head, tail, size and alloc