### PR TITLE
Speedup segmentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,14 @@ endif ()
 if (CMAKE_BUILD_TYPE MATCHES "Coverage")
   set(IRESEARCH_COVERAGE ON)
   set(CMAKE_BUILD_TYPE "Debug")
+elseif (CMAKE_BUILD_TYPE MATCHES "Profile")
+  set(CMAKE_BUILD_TYPE "Release")
+  add_compile_options(
+    -g 
+    -fno-omit-frame-pointer
+  # -fno-inline
+  # -fno-optimize-sibling-calls
+  )
 endif ()
 
 add_option_gprof(FALSE)

--- a/core/analysis/segmentation_token_stream.cpp
+++ b/core/analysis/segmentation_token_stream.cpp
@@ -328,11 +328,10 @@ bool segmentation_token_stream::next() {
     const auto begin = gr_begin.base();
     const auto end = gr_end.base();
 
-    const size_t length =
+    const auto length =
       static_cast<size_t>(std::distance(begin.base(), end.base()));
 
-    if (!length) {
-      // eof
+    if (length == 0) {  // eof
       return false;
     }
 
@@ -355,6 +354,7 @@ bool segmentation_token_stream::next() {
         term.value = {reinterpret_cast<const byte_type*>(&(*begin.base())),
                       length};
         break;
+        // TODO(MBkkt) do we need to call as_graphemes? Feels like no
       case options_t::case_convert_t::LOWER:
         term_buf_.clear();
         to_lower(as_graphemes(begin, end), from_utf32_back_inserter(term_buf_));

--- a/core/formats/columnstore.cpp
+++ b/core/formats/columnstore.cpp
@@ -256,21 +256,22 @@ void read_compact(irs::index_input& in, irs::encryption::stream* cipher,
   }
 }
 
-struct column_ref_eq : value_ref_eq<column_meta*> {
-  using self_t::operator();
+struct ColumnMetaEq : ValueRefEq<column_meta*> {
+  using is_transparent = void;
+  using Self::operator();
 
-  bool operator()(const ref_t& lhs,
+  bool operator()(const Ref& lhs,
                   const hashed_string_view& rhs) const noexcept {
-    return lhs.second->name == rhs;
+    return lhs.ref->name == rhs;
   }
 
   bool operator()(const hashed_string_view& lhs,
-                  const ref_t& rhs) const noexcept {
+                  const Ref& rhs) const noexcept {
     return this->operator()(rhs, lhs);
   }
 };
 
-using name_to_column_map = flat_hash_set<column_ref_eq>;
+using name_to_column_map = flat_hash_set<ColumnMetaEq>;
 
 class meta_writer final {
  public:

--- a/core/index/field_data.cpp
+++ b/core/index/field_data.cpp
@@ -1054,9 +1054,9 @@ bool field_data::invert(token_stream& stream, doc_id_t id) {
       last_start_offs_ = start_offset;
     }
 
-    auto* posting = terms_.emplace(term->value);
+    auto* p = terms_.emplace(term->value);
 
-    if (posting == nullptr) {
+    if (p == nullptr) {
       IRS_LOG_WARN(absl::StrCat("skipping too long term of size: ",
                                 term->value.size(), " in field: ", meta_.name));
       IRS_LOG_TRACE(
@@ -1065,8 +1065,8 @@ bool field_data::invert(token_stream& stream, doc_id_t id) {
       continue;
     }
 
-    (this->*proc_table_[posting->doc == doc_limits::invalid()])(*posting, id,
-                                                                pay, offs);
+    (this->*proc_table_[!doc_limits::valid(p->doc)])(*p, id, pay, offs);
+    IRS_ASSERT(doc_limits::valid(p->doc));
 
     if (0 == ++stats_.len) {
       IRS_LOG_ERROR(absl::StrCat("too many tokens in field: ", meta_.name,

--- a/core/index/field_data.hpp
+++ b/core/index/field_data.hpp
@@ -198,21 +198,22 @@ class field_data : util::noncopyable {
 
 class fields_data : util::noncopyable {
  private:
-  struct field_ref_eq : value_ref_eq<field_data*> {
-    using self_t::operator();
+  struct FieldEq : ValueRefEq<field_data*> {
+    using is_transparent = void;
+    using Self::operator();
 
-    bool operator()(const ref_t& lhs,
+    bool operator()(const Ref& lhs,
                     const hashed_string_view& rhs) const noexcept {
-      return lhs.second->meta().name == rhs;
+      return lhs.ref->meta().name == rhs;
     }
 
     bool operator()(const hashed_string_view& lhs,
-                    const ref_t& rhs) const noexcept {
+                    const Ref& rhs) const noexcept {
       return this->operator()(rhs, lhs);
     }
   };
 
-  using fields_map = flat_hash_set<field_ref_eq>;
+  using fields_map = flat_hash_set<FieldEq>;
 
  public:
   using postings_ref_t = std::vector<const posting*>;

--- a/core/index/postings.cpp
+++ b/core/index/postings.cpp
@@ -34,12 +34,12 @@ namespace irs {
 
 void postings::get_sorted_postings(
   std::vector<const posting*>& postings) const {
-  postings.resize(map_.size());
+  IRS_ASSERT(terms_.size() == postings_.size());
 
-  auto begin = postings.begin();
-  for (auto& entry : map_) {
-    *begin = &postings_[entry.second];
-    ++begin;
+  postings.resize(postings_.size());
+
+  for (auto* p = postings.data(); const auto& posting : postings_) {
+    *p++ = &posting;
   }
 
   std::sort(postings.begin(), postings.end(),
@@ -48,20 +48,20 @@ void postings::get_sorted_postings(
             });
 }
 
-std::pair<posting*, bool> postings::emplace(bytes_view term) {
+posting* postings::emplace(bytes_view term) {
   REGISTER_TIMER_DETAILED();
   auto& parent = writer_.parent();
 
   // maximum number to bytes needed for storage of term length and data
-  const auto max_term_len = term.size();  // + vencode_size(term.size());
+  const auto term_size = term.size();  // + vencode_size(term.size());
 
-  if (writer_t::container::block_type::SIZE < max_term_len) {
+  if (writer_t::container::block_type::SIZE < term_size) {
     // TODO: maybe move big terms it to a separate storage
     // reject terms that do not fit in a block
-    return std::make_pair(nullptr, false);
+    return nullptr;
   }
 
-  const auto slice_end = writer_.pool_offset() + max_term_len;
+  const auto slice_end = writer_.pool_offset() + term_size;
   const auto next_block_start =
     writer_.pool_offset() < parent.value_count()
       ? writer_.position().block_offset() +
@@ -74,34 +74,31 @@ std::pair<posting*, bool> postings::emplace(bytes_view term) {
   }
 
   IRS_ASSERT(size() < doc_limits::eof());  // not larger then the static flag
-  IRS_ASSERT(map_.size() == postings_.size());
+  IRS_ASSERT(terms_.size() == postings_.size());
 
   const hashed_bytes_view hashed_term{term};
 
   bool is_new = false;
-  const auto it = map_.lazy_emplace(
-    hashed_term, [&is_new, hash = hashed_term.hash(),
-                  id = map_.size()](const map_t::constructor& ctor) {
+  const auto it = terms_.lazy_emplace(
+    hashed_term, [&, size = terms_.size()](const auto& ctor) {
+      ctor(size, hashed_term.hash());
       is_new = true;
-      ctor(hash, id);
     });
-
-  if (is_new) {
-    // for new terms also write out their value
-    try {
-      writer_.write(term.data(), term.size());
-      postings_.emplace_back();
-    } catch (...) {
-      // we leave some garbage in block pool
-      map_.erase(it);
-      throw;
-    }
-
-    postings_.back().term = {(writer_.position() - term.size()).buffer(),
-                             term.size()};
+  if (IRS_LIKELY(!is_new)) {
+    return &postings_[it->ref];
   }
-
-  return {&postings_[it->second], is_new};
+  // for new terms also write out their value
+  try {
+    auto* start = writer_.position().buffer();
+    writer_.write(term.data(), term_size);
+    IRS_ASSERT(start == (writer_.position() - term_size).buffer());
+    auto& posting = postings_.emplace_back(start, term_size);
+    return &posting;
+  } catch (...) {
+    // we leave some garbage in block pool
+    terms_.erase(it);
+    throw;
+  }
 }
 
 }  // namespace irs

--- a/core/index/postings.cpp
+++ b/core/index/postings.cpp
@@ -92,8 +92,7 @@ posting* postings::emplace(bytes_view term) {
     auto* start = writer_.position().buffer();
     writer_.write(term.data(), term_size);
     IRS_ASSERT(start == (writer_.position() - term_size).buffer());
-    auto& posting = postings_.emplace_back(start, term_size);
-    return &posting;
+    return &postings_.emplace_back(start, term_size);
   } catch (...) {
     // we leave some garbage in block pool
     terms_.erase(it);

--- a/core/utils/hash_set_utils.hpp
+++ b/core/utils/hash_set_utils.hpp
@@ -28,22 +28,20 @@
 
 namespace irs {
 
-////////////////////////////////////////////////////////////////////////////////
-/// @brief first - hash value, second - reference
-////////////////////////////////////////////////////////////////////////////////
 template<typename T>
-using value_ref_t = std::pair<size_t, T>;
+struct ValueRef {
+  explicit ValueRef(T ref, size_t hash) : ref{ref}, hash{hash} {}
 
-////////////////////////////////////////////////////////////////////////////////
-/// @struct transparent hash for value_ref_t
-////////////////////////////////////////////////////////////////////////////////
-class value_ref_hash {
- public:
+  T ref;
+  size_t hash;
+};
+
+struct ValueRefHash {
   using is_transparent = void;
 
   template<typename T>
-  size_t operator()(const value_ref_t<T>& value) const noexcept {
-    return value.first;
+  size_t operator()(const ValueRef<T>& value) const noexcept {
+    return value.hash;
   }
 
   template<typename Char>
@@ -53,19 +51,13 @@ class value_ref_hash {
   }
 };
 
-////////////////////////////////////////////////////////////////////////////////
-/// @struct transparent equality comparator for value_ref_t
-////////////////////////////////////////////////////////////////////////////////
 template<typename T>
-struct value_ref_eq {
-  using is_transparent = void;
+struct ValueRefEq {
+  using Self = ValueRefEq<T>;
+  using Ref = ValueRef<T>;
 
-  using self_t = value_ref_eq<T>;
-  using ref_t = value_ref_t<T>;
-  using value_t = typename ref_t::second_type;
-
-  bool operator()(const ref_t& lhs, const ref_t& rhs) const noexcept {
-    return lhs.second == rhs.second;
+  bool operator()(const Ref& lhs, const Ref& rhs) const noexcept {
+    return lhs.ref == rhs.ref;
   }
 };
 
@@ -74,7 +66,6 @@ struct value_ref_eq {
 ///        rehash may still happen even if enough space was allocated
 ////////////////////////////////////////////////////////////////////////////////
 template<typename Eq>
-using flat_hash_set =
-  absl::flat_hash_set<typename Eq::ref_t, value_ref_hash, Eq>;
+using flat_hash_set = absl::flat_hash_set<typename Eq::Ref, ValueRefHash, Eq>;
 
 }  // namespace irs

--- a/tests/index/postings_tests.cpp
+++ b/tests/index/postings_tests.cpp
@@ -55,12 +55,13 @@ void insert_find_core(const std::vector<std::string>& src) {
     const std::string& s = src[i];
     const bytes_view b = detail::to_bytes_view(s);
     auto res = bh.emplace(b);
-    ASSERT_NE(nullptr, res.first);
-    ASSERT_TRUE(res.second);
+    ASSERT_NE(nullptr, res);
+    ASSERT_FALSE(doc_limits::valid(res->doc));
+    res->doc = doc_limits::invalid() + 1;
 
     res = bh.emplace(b);
-    ASSERT_NE(nullptr, res.first);
-    ASSERT_FALSE(res.second);
+    ASSERT_NE(nullptr, res);
+    ASSERT_TRUE(doc_limits::valid(res->doc));
   }
   ASSERT_GT(memory.counter_, 0);
 
@@ -72,21 +73,21 @@ void insert_find_core(const std::vector<std::string>& src) {
     const std::string long_str(block_size - irs::bytes_io<size_t>::vsize(32767),
                                'c');
     auto res = bh.emplace(detail::to_bytes_view(long_str));
-    ASSERT_TRUE(res.second);
+    ASSERT_FALSE(doc_limits::valid(res->doc));
   }
 
   // insert long key
   {
     const std::string too_long_str(block_size, 'c');
     auto res = bh.emplace(detail::to_bytes_view(too_long_str));
-    ASSERT_TRUE(res.second);
+    ASSERT_FALSE(doc_limits::valid(res->doc));
   }
 
   // insert too long key
   {
     const std::string too_long_str(1 + block_size, 'c');
     auto res = bh.emplace(detail::to_bytes_view(too_long_str));
-    ASSERT_FALSE(res.second);
+    ASSERT_EQ(nullptr, res);
   }
   ASSERT_GT(memory.counter_, 0);
   pool.reset();


### PR DESCRIPTION
3 ideas:
1. We don't need to call `std::next(it) multiple time
2. We don't need next_next
3. We can simplify check if we rearrange enum