### PR TITLE
attempt to fix compile warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,8 +145,8 @@ if (MSVC)
     set(CMAKE_CXX_FLAGS "/Zc:static_assert- ${CMAKE_CXX_FLAGS}")
   endif ()
 else ()
-  # We want to force clang to use it
-  add_compile_options(-fsized-deallocation)
+  # We want to force clang/gcc to use it, but only for C++ files
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fsized-deallocation>)
 endif ()
 
 # fix strange issue with utf_8_to_32_iterator failing


### PR DESCRIPTION
the compile option `-fsized-deallocation` should only be used for C++ code, but not for C code. otherwise clang warns with the following message:
```
warning: command-line option ‘-fsized-deallocation’ is valid for C++/ObjC++ but not for C
```