### PR TITLE
Fixes

### DIFF
--- a/core/analysis/analyzers.cpp
+++ b/core/analysis/analyzers.cpp
@@ -65,17 +65,14 @@ struct value {
 
 }  // namespace
 
-namespace std {
-
 template<>
-struct hash<::key> {
+struct std::hash<::key> {
   size_t operator()(const ::key& value) const noexcept {
     return irs::hash_combine(
       std::hash<irs::type_info::type_id>()(value.args_format.id()), value.type);
   }
 };
 
-}  // namespace std
 namespace irs::analysis {
 namespace {
 

--- a/core/analysis/pipeline_token_stream.hpp
+++ b/core/analysis/pipeline_token_stream.hpp
@@ -70,22 +70,15 @@ class pipeline_token_stream final : public TypedAnalyzer<pipeline_token_stream>,
   template<typename Visitor>
   bool visit_members(Visitor&& visitor) const {
     for (const auto& sub : pipeline_) {
-      if (sub.get_stream().type() ==
-          type()) {  // pipe inside pipe - forward visiting
-#if IRESEARCH_DEBUG
-        const auto& sub_pipe =
-          dynamic_cast<const pipeline_token_stream&>(sub.get_stream());
-#else
-        const auto& sub_pipe =
-          static_cast<const pipeline_token_stream&>(sub.get_stream());
-#endif
+      const auto& stream = sub.get_stream();
+      if (stream.type() == type()) {
+        // pipe inside pipe - forward visiting
+        const auto& sub_pipe = DownCast<pipeline_token_stream>(stream);
         if (!sub_pipe.visit_members(visitor)) {
           return false;
         }
-      } else {
-        if (!visitor(sub.get_stream())) {
-          return false;
-        }
+      } else if (!visitor(sub.get_stream())) {
+        return false;
       }
     }
     return true;

--- a/core/search/all_docs_provider.cpp
+++ b/core/search/all_docs_provider.cpp
@@ -26,7 +26,7 @@
 
 namespace irs {
 
-FilterWithBoost::Ptr AllDocsProvider::Default(score_t boost) {
+AllDocsProvider::Ptr AllDocsProvider::Default(score_t boost) {
   auto filter = std::make_unique<all>();
   filter->boost(boost);
   return filter;

--- a/core/search/all_docs_provider.cpp
+++ b/core/search/all_docs_provider.cpp
@@ -26,7 +26,7 @@
 
 namespace irs {
 
-filter::ptr AllDocsProvider::Default(score_t boost) {
+FilterWithBoost::Ptr AllDocsProvider::Default(score_t boost) {
   auto filter = std::make_unique<all>();
   filter->boost(boost);
   return filter;

--- a/core/search/all_docs_provider.hpp
+++ b/core/search/all_docs_provider.hpp
@@ -28,11 +28,11 @@ namespace irs {
 
 class AllDocsProvider {
  public:
-  using ProviderFunc = std::function<filter::ptr(score_t)>;
+  using ProviderFunc = std::function<FilterWithBoost::Ptr(score_t)>;
 
-  static filter::ptr Default(score_t boost);
+  static FilterWithBoost::Ptr Default(score_t boost);
 
-  filter::ptr MakeAllDocsFilter(score_t boost) const {
+  FilterWithBoost::Ptr MakeAllDocsFilter(score_t boost) const {
     return all_docs_(boost);
   }
 

--- a/core/search/all_docs_provider.hpp
+++ b/core/search/all_docs_provider.hpp
@@ -28,13 +28,12 @@ namespace irs {
 
 class AllDocsProvider {
  public:
-  using ProviderFunc = std::function<FilterWithBoost::Ptr(score_t)>;
+  using Ptr = std::unique_ptr<FilterWithBoost>;
+  using ProviderFunc = std::function<Ptr(score_t)>;
 
-  static FilterWithBoost::Ptr Default(score_t boost);
+  static Ptr Default(score_t boost);
 
-  FilterWithBoost::Ptr MakeAllDocsFilter(score_t boost) const {
-    return all_docs_(boost);
-  }
+  Ptr MakeAllDocsFilter(score_t boost) const { return all_docs_(boost); }
 
   void SetProvider(ProviderFunc&& provider) {
     all_docs_ = provider ? std::move(provider) : ProviderFunc{&Default};

--- a/core/search/all_filter.cpp
+++ b/core/search/all_filter.cpp
@@ -30,21 +30,24 @@ namespace irs {
 class all_query : public filter::prepared {
  public:
   explicit all_query(bstring&& stats, score_t boost)
-    : filter::prepared(boost), stats_(std::move(stats)) {}
+    : stats_{std::move(stats)}, boost_{boost} {}
 
   doc_iterator::ptr execute(const ExecutionContext& ctx) const final {
     auto& rdr = ctx.segment;
 
     return memory::make_managed<AllIterator>(rdr, stats_.c_str(), ctx.scorers,
-                                             rdr.docs_count(), boost());
+                                             rdr.docs_count(), boost_);
   }
 
   void visit(const SubReader&, PreparedStateVisitor&, score_t) const final {
     // No terms to visit
   }
 
+  score_t boost() const noexcept final { return boost_; }
+
  private:
   bstring stats_;
+  score_t boost_;
 };
 
 filter::prepared::ptr all::prepare(const PrepareContext& ctx) const {

--- a/core/search/all_filter.hpp
+++ b/core/search/all_filter.hpp
@@ -29,7 +29,7 @@ namespace irs {
 // Filter returning all documents
 class all : public FilterWithBoost {
  public:
-  filter::prepared::ptr prepare(const PrepareContext& ctx) const final;
+  prepared::ptr prepare(const PrepareContext& ctx) const final;
 
   irs::type_info::type_id type() const noexcept final {
     return irs::type<all>::id();

--- a/core/search/all_filter.hpp
+++ b/core/search/all_filter.hpp
@@ -27,7 +27,7 @@
 namespace irs {
 
 // Filter returning all documents
-class all : public filter {
+class all : public FilterWithBoost {
  public:
   filter::prepared::ptr prepare(const PrepareContext& ctx) const final;
 

--- a/core/search/boolean_filter.cpp
+++ b/core/search/boolean_filter.cpp
@@ -75,8 +75,8 @@ filter::prepared::ptr boolean_filter::prepare(const PrepareContext& ctx) const {
   std::vector<const filter*> incl;
   std::vector<const filter*> excl;
 
-  FilterWithBoost::Ptr all_docs_zero_boost;
-  FilterWithBoost::Ptr all_docs_no_boost;
+  AllDocsProvider::Ptr all_docs_zero_boost;
+  AllDocsProvider::Ptr all_docs_no_boost;
 
   group_filters(all_docs_zero_boost, incl, excl);
 
@@ -89,7 +89,7 @@ filter::prepared::ptr boolean_filter::prepare(const PrepareContext& ctx) const {
   return PrepareBoolean(incl, excl, ctx);
 }
 
-void boolean_filter::group_filters(FilterWithBoost::Ptr& all_docs_zero_boost,
+void boolean_filter::group_filters(AllDocsProvider::Ptr& all_docs_zero_boost,
                                    std::vector<const filter*>& incl,
                                    std::vector<const filter*>& excl) const {
   incl.reserve(size() / 2);
@@ -98,7 +98,7 @@ void boolean_filter::group_filters(FilterWithBoost::Ptr& all_docs_zero_boost,
   const filter* empty_filter = nullptr;
   const auto is_or = type() == irs::type<Or>::id();
   for (const auto& filter : *this) {
-    if (irs::type<irs::empty>::id() == filter->type()) {
+    if (irs::type<Empty>::id() == filter->type()) {
       empty_filter = filter.get();
       continue;
     }
@@ -143,7 +143,7 @@ filter::prepared::ptr And::PrepareBoolean(std::vector<const filter*>& incl,
   // optimization step
   //  if include group empty itself or has 'empty' -> this whole conjunction is
   //  empty
-  if (incl.empty() || incl.back()->type() == irs::type<irs::empty>::id()) {
+  if (incl.empty() || incl.back()->type() == irs::type<Empty>::id()) {
     return prepared::empty();
   }
 
@@ -228,7 +228,7 @@ filter::prepared::ptr Or::PrepareBoolean(std::vector<const filter*>& incl,
     return MakeAllDocsFilter(kNoBoost)->prepare(sub_ctx);
   }
 
-  if (!incl.empty() && incl.back()->type() == irs::type<irs::empty>::id()) {
+  if (!incl.empty() && incl.back()->type() == irs::type<Empty>::id()) {
     incl.pop_back();
   }
 

--- a/core/search/boolean_filter.cpp
+++ b/core/search/boolean_filter.cpp
@@ -22,8 +22,6 @@
 
 #include "boolean_filter.hpp"
 
-#include <boost/container_hash/hash.hpp>
-
 #include "conjunction.hpp"
 #include "disjunction.hpp"
 #include "exclusion.hpp"
@@ -49,17 +47,6 @@ std::pair<const irs::filter*, bool> optimize_not(const irs::Not& node) {
 }  // namespace
 
 namespace irs {
-
-size_t boolean_filter::hash() const noexcept {
-  size_t seed = 0;
-
-  ::boost::hash_combine(seed, filter::hash());
-  std::for_each(
-    filters_.begin(), filters_.end(),
-    [&seed](const filter::ptr& f) { ::boost::hash_combine(seed, *f); });
-
-  return seed;
-}
 
 bool boolean_filter::equals(const filter& rhs) const noexcept {
   if (!filter::equals(rhs)) {
@@ -351,15 +338,6 @@ filter::prepared::ptr Not::prepare(const PrepareContext& ctx) const {
 
   // negation has been optimized out
   return res.first->prepare(sub_ctx);
-}
-
-size_t Not::hash() const noexcept {
-  size_t seed = 0;
-  ::boost::hash_combine(seed, filter::hash());
-  if (filter_) {
-    ::boost::hash_combine<const irs::filter&>(seed, *filter_);
-  }
-  return seed;
 }
 
 bool Not::equals(const irs::filter& rhs) const noexcept {

--- a/core/search/boolean_filter.cpp
+++ b/core/search/boolean_filter.cpp
@@ -29,35 +29,29 @@
 #include "prepared_state_visitor.hpp"
 #include "search/boolean_query.hpp"
 
+namespace irs {
 namespace {
 
-// first - pointer to the innermost not "not" node
-// second - collapsed negation mark
-std::pair<const irs::filter*, bool> optimize_not(const irs::Not& node) {
+std::pair<const filter*, bool> optimize_not(const Not& node) {
   bool neg = true;
-  const irs::filter* inner = node.filter();
-  while (inner && inner->type() == irs::type<irs::Not>::id()) {
+  const auto* inner = node.filter();
+  while (inner != nullptr && inner->type() == type<Not>::id()) {
     neg = !neg;
-    inner = static_cast<const irs::Not*>(inner)->filter();
+    inner = DownCast<Not>(inner)->filter();
   }
 
-  return std::make_pair(inner, neg);
+  return std::pair{inner, neg};
 }
 
 }  // namespace
-
-namespace irs {
-
 bool boolean_filter::equals(const filter& rhs) const noexcept {
   if (!filter::equals(rhs)) {
     return false;
   }
   const auto& typed_rhs = DownCast<boolean_filter>(rhs);
-  return filters_.size() == typed_rhs.size() &&
-         std::equal(begin(), end(), typed_rhs.begin(),
-                    [](const filter::ptr& lhs, const filter::ptr& rhs) {
-                      return *lhs == *rhs;
-                    });
+  return std::equal(
+    begin(), end(), typed_rhs.begin(), typed_rhs.end(),
+    [](const auto& lhs, const auto& rhs) { return *lhs == *rhs; });
 }
 
 filter::prepared::ptr boolean_filter::prepare(const PrepareContext& ctx) const {
@@ -81,8 +75,8 @@ filter::prepared::ptr boolean_filter::prepare(const PrepareContext& ctx) const {
   std::vector<const filter*> incl;
   std::vector<const filter*> excl;
 
-  irs::filter::ptr all_docs_zero_boost;
-  irs::filter::ptr all_docs_no_boost;
+  FilterWithBoost::Ptr all_docs_zero_boost;
+  FilterWithBoost::Ptr all_docs_no_boost;
 
   group_filters(all_docs_zero_boost, incl, excl);
 
@@ -95,21 +89,21 @@ filter::prepared::ptr boolean_filter::prepare(const PrepareContext& ctx) const {
   return PrepareBoolean(incl, excl, ctx);
 }
 
-void boolean_filter::group_filters(filter::ptr& all_docs_zero_boost,
+void boolean_filter::group_filters(FilterWithBoost::Ptr& all_docs_zero_boost,
                                    std::vector<const filter*>& incl,
                                    std::vector<const filter*>& excl) const {
   incl.reserve(size() / 2);
   excl.reserve(incl.capacity());
 
-  const irs::filter* empty_filter{nullptr};
+  const filter* empty_filter = nullptr;
   const auto is_or = type() == irs::type<Or>::id();
-  for (auto begin = this->begin(), end = this->end(); begin != end; ++begin) {
-    if (irs::type<irs::empty>::id() == (*begin)->type()) {
-      empty_filter = begin->get();
+  for (const auto& filter : *this) {
+    if (irs::type<irs::empty>::id() == filter->type()) {
+      empty_filter = filter.get();
       continue;
     }
-    if (irs::type<Not>::id() == (*begin)->type()) {
-      const auto res = optimize_not(DownCast<Not>(**begin));
+    if (irs::type<Not>::id() == filter->type()) {
+      const auto res = optimize_not(DownCast<Not>(*filter));
 
       if (!res.first) {
         continue;
@@ -117,7 +111,7 @@ void boolean_filter::group_filters(filter::ptr& all_docs_zero_boost,
 
       if (res.second) {
         if (!all_docs_zero_boost) {
-          all_docs_zero_boost = MakeAllDocsFilter(0.f);
+          all_docs_zero_boost = MakeAllDocsFilter(0.F);
         }
 
         if (*all_docs_zero_boost == *res.first) {
@@ -135,7 +129,7 @@ void boolean_filter::group_filters(filter::ptr& all_docs_zero_boost,
         incl.push_back(res.first);
       }
     } else {
-      incl.push_back(begin->get());
+      incl.push_back(filter.get());
     }
   }
   if (empty_filter != nullptr) {
@@ -167,7 +161,7 @@ filter::prepared::ptr And::PrepareBoolean(std::vector<const filter*>& incl,
   for (auto filter : incl) {
     if (*filter == *cumulative_all) {
       all_count++;
-      all_boost += filter->boost();
+      all_boost += DownCast<FilterWithBoost>(*filter).boost();
     }
   }
   if (all_count != 0) {
@@ -191,7 +185,7 @@ filter::prepared::ptr And::PrepareBoolean(std::vector<const filter*>& incl,
       // resulting boost will be: new_boost * OR_BOOST * LEFT_BOOST. If we
       // substitute new_boost back we will get ( boost * OR_BOOST * ALL_BOOST +
       // boost * OR_BOOST * LEFT_BOOST) - original non-optimized boost value
-      auto left_boost = (*incl.begin())->boost();
+      auto left_boost = (*incl.begin())->BoostImpl();
       if (boost() != 0 && left_boost != 0 && !sub_ctx.scorers.empty()) {
         sub_ctx.boost = (sub_ctx.boost * boost() * all_boost +
                          sub_ctx.boost * boost() * left_boost) /
@@ -257,7 +251,7 @@ filter::prepared::ptr Or::PrepareBoolean(std::vector<const filter*>& incl,
   for (auto filter : incl) {
     if (*filter == *cumulative_all) {
       all_count++;
-      all_boost += filter->boost();
+      all_boost += DownCast<FilterWithBoost>(*filter).boost();
       incl_all = filter;
     }
   }

--- a/core/search/boolean_filter.hpp
+++ b/core/search/boolean_filter.hpp
@@ -67,7 +67,7 @@ class boolean_filter : public FilterWithBoost, public AllDocsProvider {
                                        const PrepareContext& ctx) const = 0;
 
  private:
-  void group_filters(FilterWithBoost::Ptr& all_docs_zero_boost,
+  void group_filters(AllDocsProvider::Ptr& all_docs_zero_boost,
                      std::vector<const filter*>& incl,
                      std::vector<const filter*>& excl) const;
 
@@ -114,7 +114,7 @@ class Or final : public boolean_filter {
 };
 
 // Represents negation
-class Not : public FilterWithBoost, public AllDocsProvider {
+class Not : public FilterWithType<Not>, public AllDocsProvider {
  public:
   const filter* filter() const { return filter_.get(); }
 
@@ -134,10 +134,6 @@ class Not : public FilterWithBoost, public AllDocsProvider {
   bool empty() const { return nullptr == filter_; }
 
   prepared::ptr prepare(const PrepareContext& ctx) const final;
-
-  type_info::type_id type() const noexcept final {
-    return irs::type<Not>::id();
-  }
 
  protected:
   bool equals(const irs::filter& rhs) const noexcept final;

--- a/core/search/boolean_filter.hpp
+++ b/core/search/boolean_filter.hpp
@@ -55,8 +55,6 @@ class boolean_filter : public filter, public AllDocsProvider {
     return *filters_.emplace_back(std::move(filter));
   }
 
-  size_t hash() const noexcept final;
-
   void clear() { filters_.clear(); }
   bool empty() const { return filters_.empty(); }
   size_t size() const { return filters_.size(); }
@@ -143,8 +141,6 @@ class Not : public filter, public AllDocsProvider {
   bool empty() const { return nullptr == filter_; }
 
   filter::prepared::ptr prepare(const PrepareContext& ctx) const final;
-
-  size_t hash() const noexcept final;
 
   type_info::type_id type() const noexcept final {
     return irs::type<Not>::id();

--- a/core/search/boolean_query.hpp
+++ b/core/search/boolean_query.hpp
@@ -40,6 +40,8 @@ class BooleanQuery : public filter::prepared {
   void visit(const irs::SubReader& segment, irs::PreparedStateVisitor& visitor,
              score_t boost) const final;
 
+  score_t boost() const noexcept final { return boost_; }
+
   void prepare(const PrepareContext& ctx, ScoreMergeType merge_type,
                queries_t queries, size_t exclude_start);
 
@@ -65,8 +67,9 @@ class BooleanQuery : public filter::prepared {
   // excl_..queries.end() - excluded queries
   queries_t queries_;
   // index of the first excluded query
-  size_t excl_{0};
-  ScoreMergeType merge_type_{ScoreMergeType::kSum};
+  size_t excl_ = 0;
+  ScoreMergeType merge_type_ = ScoreMergeType::kSum;
+  score_t boost_ = kNoBoost;
 };
 
 // Represent a set of queries joint by "And"

--- a/core/search/column_existence_filter.hpp
+++ b/core/search/column_existence_filter.hpp
@@ -45,9 +45,9 @@ struct by_column_existence_options {
 
 // User-side column existence filter
 class by_column_existence final
-  : public filter_base<by_column_existence_options> {
+  : public FilterWithField<by_column_existence_options> {
  public:
-  filter::prepared::ptr prepare(const PrepareContext& ctx) const final;
+  prepared::ptr prepare(const PrepareContext& ctx) const final;
 };
 
 }  // namespace irs

--- a/core/search/column_existence_filter.hpp
+++ b/core/search/column_existence_filter.hpp
@@ -41,8 +41,6 @@ struct by_column_existence_options {
   bool operator==(const by_column_existence_options& rhs) const noexcept {
     return acceptor == rhs.acceptor;
   }
-
-  size_t hash() const noexcept { return std::hash<ColumnAcceptor>()(acceptor); }
 };
 
 // User-side column existence filter

--- a/core/search/filter.cpp
+++ b/core/search/filter.cpp
@@ -46,11 +46,11 @@ EmptyQuery kEmptyQuery;
 }  // namespace
 
 filter::prepared::ptr filter::prepared::empty() {
-  return memory::to_managed<filter::prepared>(kEmptyQuery);
+  return memory::to_managed<prepared>(kEmptyQuery);
 }
 
-filter::prepared::ptr empty::prepare(const PrepareContext& /*ctx*/) const {
-  return memory::to_managed<filter::prepared>(kEmptyQuery);
+filter::prepared::ptr Empty::prepare(const PrepareContext& /*ctx*/) const {
+  return memory::to_managed<prepared>(kEmptyQuery);
 }
 
 }  // namespace irs

--- a/core/search/filter.cpp
+++ b/core/search/filter.cpp
@@ -37,6 +37,8 @@ struct EmptyQuery : public filter::prepared {
   void visit(const SubReader&, PreparedStateVisitor&, score_t) const final {
     // No terms to visit
   }
+
+  score_t boost() const noexcept final { return kNoBoost; }
 };
 
 EmptyQuery kEmptyQuery;

--- a/core/search/granular_range_filter.hpp
+++ b/core/search/granular_range_filter.hpp
@@ -91,18 +91,18 @@ void set_granular_term(by_granular_range_options::terms& boundary,
 ///              termA@0 + termA@2 + termA@5 + termA@10
 ///              termB@0 + termB@2 + termB@6 + termB@10
 //////////////////////////////////////////////////////////////////////////////
-class by_granular_range : public filter_base<by_granular_range_options> {
+class by_granular_range : public FilterWithField<by_granular_range_options> {
  public:
-  static filter::prepared::ptr prepare(const PrepareContext& ctx,
-                                       std::string_view field,
-                                       const options_type::range_type& rng,
-                                       size_t scored_terms_limit);
+  static prepared::ptr prepare(const PrepareContext& ctx,
+                               std::string_view field,
+                               const options_type::range_type& rng,
+                               size_t scored_terms_limit);
 
   static void visit(const SubReader& segment, const term_reader& reader,
                     const options_type::range_type& rng,
                     filter_visitor& visitor);
 
-  filter::prepared::ptr prepare(const PrepareContext& ctx) const final {
+  prepared::ptr prepare(const PrepareContext& ctx) const final {
     return prepare(ctx.Boost(boost()), field(), options().range,
                    options().scored_terms_limit);
   }

--- a/core/search/granular_range_filter.hpp
+++ b/core/search/granular_range_filter.hpp
@@ -60,10 +60,6 @@ struct by_granular_range_options {
   bool operator==(const by_granular_range_options& rhs) const noexcept {
     return range == rhs.range && scored_terms_limit == rhs.scored_terms_limit;
   }
-
-  size_t hash() const noexcept {
-    return hash_combine(scored_terms_limit, range.hash());
-  }
 };
 
 //////////////////////////////////////////////////////////////////////////////

--- a/core/search/levenshtein_filter.cpp
+++ b/core/search/levenshtein_filter.cpp
@@ -286,8 +286,8 @@ filter::prepared::ptr by_edit_distance::prepare(
   bool with_transpositions, bytes_view prefix) {
   return executeLevenshtein(
     max_distance, provider, with_transpositions, prefix, term,
-    []() -> filter::prepared::ptr { return prepared::empty(); },
-    [&]() -> filter::prepared::ptr {
+    []() -> prepared::ptr { return prepared::empty(); },
+    [&]() -> prepared::ptr {
       if (!prefix.empty() && !term.empty()) {
         bstring target;
         target.reserve(prefix.size() + term.size());
@@ -300,7 +300,7 @@ filter::prepared::ptr by_edit_distance::prepare(
     },
     [&, scored_terms_limit](const parametric_description& d,
                             const bytes_view prefix,
-                            const bytes_view term) -> filter::prepared::ptr {
+                            const bytes_view term) -> prepared::ptr {
       return prepare_levenshtein_filter(ctx, field, prefix, term,
                                         scored_terms_limit, d);
     });

--- a/core/search/levenshtein_filter.cpp
+++ b/core/search/levenshtein_filter.cpp
@@ -233,7 +233,7 @@ filter::prepared::ptr prepare_levenshtein_filter(
 }  // namespace
 
 field_visitor by_edit_distance::visitor(
-  const options_type::filter_options& opts) {
+  const by_edit_distance_all_options& opts) {
   return executeLevenshtein(
     opts.max_distance, opts.provider, opts.with_transpositions, opts.prefix,
     opts.term,

--- a/core/search/levenshtein_filter.hpp
+++ b/core/search/levenshtein_filter.hpp
@@ -90,7 +90,8 @@ struct by_edit_distance_options : by_edit_distance_all_options {
 /// @class by_edit_distance
 /// @brief user-side levenstein filter
 ////////////////////////////////////////////////////////////////////////////////
-class by_edit_distance final : public filter_base<by_edit_distance_options> {
+class by_edit_distance final
+  : public FilterWithField<by_edit_distance_options> {
  public:
   static prepared::ptr prepare(const PrepareContext& ctx,
                                std::string_view field, bytes_view term,
@@ -100,7 +101,7 @@ class by_edit_distance final : public filter_base<by_edit_distance_options> {
 
   static field_visitor visitor(const by_edit_distance_all_options& options);
 
-  filter::prepared::ptr prepare(const PrepareContext& ctx) const final {
+  prepared::ptr prepare(const PrepareContext& ctx) const final {
     auto sub_ctx = ctx;
     sub_ctx.boost *= boost();
     return prepare(sub_ctx, field(), options().term, options().max_terms,

--- a/core/search/levenshtein_filter.hpp
+++ b/core/search/levenshtein_filter.hpp
@@ -84,14 +84,6 @@ struct by_edit_distance_options : by_edit_distance_all_options {
            with_transpositions == rhs.with_transpositions &&
            max_terms == rhs.max_terms;
   }
-
-  size_t hash() const noexcept {
-    const auto hash0 = hash_combine(std::hash<bool>()(with_transpositions),
-                                    std::hash<bstring>()(term));
-    const auto hash1 = hash_combine(std::hash<uint8_t>()(max_distance),
-                                    std::hash<bstring>()(prefix));
-    return hash_combine(hash_combine(hash0, hash1), max_terms);
-  }
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -118,14 +110,3 @@ class by_edit_distance final : public filter_base<by_edit_distance_options> {
 };
 
 }  // namespace irs
-
-namespace std {
-
-template<>
-struct hash<::irs::by_edit_distance_options> {
-  size_t operator()(const ::irs::by_edit_distance_options& v) const noexcept {
-    return v.hash();
-  }
-};
-
-}  // namespace std

--- a/core/search/multiterm_query.cpp
+++ b/core/search/multiterm_query.cpp
@@ -107,7 +107,7 @@ namespace irs {
 void MultiTermQuery::visit(const SubReader& segment,
                            PreparedStateVisitor& visitor, score_t boost) const {
   if (auto state = states_.find(segment); state) {
-    visitor.Visit(*this, *state, boost * this->boost());
+    visitor.Visit(*this, *state, boost * boost_);
   }
 }
 
@@ -151,7 +151,7 @@ doc_iterator::ptr MultiTermQuery::execute(const ExecutionContext& ctx) const {
       IRS_ASSERT(entry.stat_offset < stats.size());
       auto* stat = stats[entry.stat_offset].c_str();
       CompileScore(*score, ord.buckets(), segment, *state->reader, stat, *docs,
-                   entry.boost * boost());
+                   entry.boost * boost_);
     }
 
     IRS_ASSERT(it != std::end(itrs));

--- a/core/search/multiterm_query.hpp
+++ b/core/search/multiterm_query.hpp
@@ -37,9 +37,9 @@ class MultiTermQuery : public filter::prepared {
 
   explicit MultiTermQuery(States&& states, Stats&& stats, score_t boost,
                           ScoreMergeType merge_type, size_t min_match)
-    : prepared{boost},
-      states_{std::move(states)},
+    : states_{std::move(states)},
       stats_{std::move(stats)},
+      boost_{boost},
       merge_type_{merge_type},
       min_match_{min_match} {}
 
@@ -48,9 +48,12 @@ class MultiTermQuery : public filter::prepared {
   void visit(const SubReader& segment, PreparedStateVisitor& visitor,
              score_t boost) const final;
 
+  score_t boost() const noexcept final { return boost_; }
+
  private:
   States states_;
   Stats stats_;
+  score_t boost_;
   ScoreMergeType merge_type_;
   size_t min_match_;
 };

--- a/core/search/nested_filter.cpp
+++ b/core/search/nested_filter.cpp
@@ -601,7 +601,8 @@ class ByNestedQuery : public filter::prepared {
 
   void visit(const SubReader& segment, PreparedStateVisitor& visitor,
              score_t boost) const final {
-    boost *= this->boost();
+    // TODO(MBkkt) maybe use none_boost for NoneMatcher?
+    // boost *= this->boost();
 
     if (!visitor.Visit(*this, boost)) {
       return;
@@ -610,6 +611,8 @@ class ByNestedQuery : public filter::prepared {
     IRS_ASSERT(child_);
     child_->visit(segment, visitor, boost);
   }
+
+  score_t boost() const noexcept final { return kNoBoost; }
 
  private:
   DocIteratorProvider parent_;

--- a/core/search/nested_filter.hpp
+++ b/core/search/nested_filter.hpp
@@ -88,22 +88,6 @@ struct ByNestedOptions {
              match) &&
            merge_type == rhs.merge_type && equal(child.get(), rhs.child.get());
   }
-
-  size_t hash() const noexcept {
-    size_t hash = std::visit(
-      []<typename T>(const T& v) noexcept -> size_t {
-        if constexpr (std::is_same_v<T, Match>) {
-          return hash_combine(std::hash<doc_id_t>{}(v.Min),
-                              std::hash<doc_id_t>{}(v.Max));
-        }
-        return 0;
-      },
-      match);
-    if (child) {
-      hash = hash_combine(hash, child->hash());
-    }
-    return hash_combine(hash, merge_type);
-  }
 };
 
 // Filter is capable of finding parents by the corresponding child filter.

--- a/core/search/nested_filter.hpp
+++ b/core/search/nested_filter.hpp
@@ -91,7 +91,7 @@ struct ByNestedOptions {
 };
 
 // Filter is capable of finding parents by the corresponding child filter.
-class ByNestedFilter final : public filter_with_options<ByNestedOptions> {
+class ByNestedFilter final : public FilterWithOptions<ByNestedOptions> {
  public:
   prepared::ptr prepare(const PrepareContext& ctx) const final;
 };

--- a/core/search/ngram_similarity_filter.hpp
+++ b/core/search/ngram_similarity_filter.hpp
@@ -44,14 +44,6 @@ struct by_ngram_similarity_options {
   bool operator==(const by_ngram_similarity_options& rhs) const noexcept {
     return ngrams == rhs.ngrams && threshold == rhs.threshold;
   }
-
-  size_t hash() const noexcept {
-    size_t hash = std::hash<decltype(threshold)>()(threshold);
-    for (const auto& ngram : ngrams) {
-      hash = hash_combine(hash, hash_utils::Hash(ngram));
-    }
-    return hash;
-  }
 };
 
 class by_ngram_similarity : public filter_base<by_ngram_similarity_options> {

--- a/core/search/ngram_similarity_filter.hpp
+++ b/core/search/ngram_similarity_filter.hpp
@@ -46,7 +46,8 @@ struct by_ngram_similarity_options {
   }
 };
 
-class by_ngram_similarity : public filter_base<by_ngram_similarity_options> {
+class by_ngram_similarity
+  : public FilterWithField<by_ngram_similarity_options> {
  public:
   static prepared::ptr Prepare(const PrepareContext& ctx,
                                std::string_view field_name,

--- a/core/search/ngram_similarity_query.cpp
+++ b/core/search/ngram_similarity_query.cpp
@@ -582,14 +582,14 @@ doc_iterator::ptr NGramSimilarityQuery::execute(
   if (itrs.size() == min_match_count_) {
     return memory::make_managed<NGramSimilarityDocIterator<
       NGramApprox<true>, SerialPositionsChecker<Dummy>>>(
-      std::move(itrs), segment, *query_state->field, boost(), stats_.c_str(),
+      std::move(itrs), segment, *query_state->field, boost_, stats_.c_str(),
       query_state->terms.size(), min_match_count_, ord);
   }
   // TODO(MBkkt) min_match_count_ == 1: disjunction for approx,
   // optimization for low threshold case
   return memory::make_managed<NGramSimilarityDocIterator<
     NGramApprox<false>, SerialPositionsChecker<Dummy>>>(
-    std::move(itrs), segment, *query_state->field, boost(), stats_.c_str(),
+    std::move(itrs), segment, *query_state->field, boost_, stats_.c_str(),
     query_state->terms.size(), min_match_count_, ord);
 }
 

--- a/core/search/ngram_similarity_query.hpp
+++ b/core/search/ngram_similarity_query.hpp
@@ -41,19 +41,21 @@ class NGramSimilarityQuery : public filter::prepared {
 
   NGramSimilarityQuery(size_t min_match_count, NGramStates&& states,
                        bstring&& stats, score_t boost = kNoBoost)
-    : prepared{boost},
-      min_match_count_{min_match_count},
+    : min_match_count_{min_match_count},
       states_{std::move(states)},
-      stats_{std::move(stats)} {}
+      stats_{std::move(stats)},
+      boost_{boost} {}
 
   doc_iterator::ptr execute(const ExecutionContext& ctx) const final;
 
   void visit(const SubReader& segment, PreparedStateVisitor& visitor,
              score_t boost) const final {
     if (const auto* state = states_.find(segment); state) {
-      visitor.Visit(*this, *state, boost * this->boost());
+      visitor.Visit(*this, *state, boost * boost_);
     }
   }
+
+  score_t boost() const noexcept final { return boost_; }
 
   doc_iterator::ptr ExecuteWithOffsets(const SubReader& rdr) const;
 
@@ -61,6 +63,7 @@ class NGramSimilarityQuery : public filter::prepared {
   size_t min_match_count_;
   NGramStates states_;
   bstring stats_;
+  score_t boost_;
 };
 
 }  // namespace irs

--- a/core/search/phrase_filter.cpp
+++ b/core/search/phrase_filter.cpp
@@ -444,9 +444,8 @@ filter::prepared::ptr by_phrase::Prepare(const PrepareContext& ctx,
   if (1 == options.size()) {
     auto query =
       std::visit(PrepareVisitor{ctx, field}, options.begin()->second);
-    if (query) {
-      return query;
-    }
+    IRS_ASSERT(query);
+    return query;
   }
 
   // prepare phrase stats (collector for each term)

--- a/core/search/phrase_filter.cpp
+++ b/core/search/phrase_filter.cpp
@@ -127,9 +127,7 @@ struct PrepareVisitor : util::noncopyable {
                                      part.with_transpositions, part.prefix);
   }
 
-  auto operator()(const by_terms_options& part) const {
-    return filter::prepared::ptr{};
-  }
+  filter::prepared::ptr operator()(const by_terms_options&) const { return {}; }
 
   auto operator()(const by_range_options& part) const {
     return by_range::prepare(ctx, field, part.range, part.scored_terms_limit);

--- a/core/search/phrase_filter.cpp
+++ b/core/search/phrase_filter.cpp
@@ -30,14 +30,41 @@
 #include "search/prepared_state_visitor.hpp"
 #include "search/states/phrase_state.hpp"
 #include "search/states_cache.hpp"
+#include "search/top_terms_collector.hpp"
 
 namespace irs {
 namespace {
 
-struct GetVisitor {
-  using result_type = field_visitor;
+struct TopTermsCollector final : filter_visitor {
+  explicit TopTermsCollector(size_t size) : impl_{size} { IRS_ASSERT(size); }
 
-  result_type operator()(const by_term_options& part) const {
+  void prepare(const SubReader& segment, const term_reader& field,
+               const seek_term_iterator& terms) final {
+    impl_.prepare(segment, field, terms);
+  }
+
+  void visit(score_t boost) final { impl_.visit(boost); }
+
+  field_visitor ToVisitor() {
+    // TODO(MBkkt) we can avoid by_terms, but needs to change
+    // top_terms_collector, to make it able keep equal elements
+    irs::by_terms_options::search_terms terms;
+    impl_.visit([&](top_term<score_t>& term) {
+      terms.emplace(std::move(term.term), term.key);
+    });
+    return [terms = std::move(terms)](const SubReader& segment,
+                                      const term_reader& field,
+                                      filter_visitor& visitor) {
+      return by_terms::visit(segment, field, terms, visitor);
+    };
+  }
+
+ private:
+  top_terms_collector<top_term<score_t>> impl_;
+};
+
+struct GetVisitor {
+  field_visitor operator()(const by_term_options& part) const {
     return [term = bytes_view(part.term)](const SubReader& segment,
                                           const term_reader& field,
                                           filter_visitor& visitor) {
@@ -45,7 +72,7 @@ struct GetVisitor {
     };
   }
 
-  result_type operator()(const by_prefix_options& part) const {
+  field_visitor operator()(const by_prefix_options& part) const {
     return [term = bytes_view(part.term)](const SubReader& segment,
                                           const term_reader& field,
                                           filter_visitor& visitor) {
@@ -53,15 +80,18 @@ struct GetVisitor {
     };
   }
 
-  result_type operator()(const by_wildcard_options& part) const {
+  field_visitor operator()(const by_wildcard_options& part) const {
     return by_wildcard::visitor(part.term);
   }
 
-  result_type operator()(const by_edit_distance_filter_options& part) const {
+  field_visitor operator()(const by_edit_distance_options& part) const {
+    if (part.max_terms != 0) {
+      return {};
+    }
     return by_edit_distance::visitor(part);
   }
 
-  result_type operator()(const by_terms_options& part) const {
+  field_visitor operator()(const by_terms_options& part) const {
     return
       [terms = &part.terms](const SubReader& segment, const term_reader& field,
                             filter_visitor& visitor) {
@@ -69,7 +99,7 @@ struct GetVisitor {
       };
   }
 
-  result_type operator()(const by_range_options& part) const {
+  field_visitor operator()(const by_range_options& part) const {
     return
       [range = &part.range](const SubReader& segment, const term_reader& field,
                             filter_visitor& visitor) {
@@ -79,32 +109,29 @@ struct GetVisitor {
 };
 
 struct PrepareVisitor : util::noncopyable {
-  using result_type = filter::prepared::ptr;
-
-  result_type operator()(const by_term_options& opts) const {
+  auto operator()(const by_term_options& opts) const {
     return by_term::prepare(ctx, field, opts.term);
   }
 
-  result_type operator()(const by_prefix_options& part) const {
+  auto operator()(const by_prefix_options& part) const {
     return by_prefix::prepare(ctx, field, part.term, part.scored_terms_limit);
   }
 
-  result_type operator()(const by_wildcard_options& part) const {
+  auto operator()(const by_wildcard_options& part) const {
     return by_wildcard::prepare(ctx, field, part.term, part.scored_terms_limit);
   }
 
-  result_type operator()(const by_edit_distance_filter_options& part) const {
-    return by_edit_distance::prepare(ctx, field, part.term,
-                                     0,  // collect all terms
+  auto operator()(const by_edit_distance_options& part) const {
+    return by_edit_distance::prepare(ctx, field, part.term, part.max_terms,
                                      part.max_distance, part.provider,
                                      part.with_transpositions, part.prefix);
   }
 
-  result_type operator()(const by_terms_options&) const {
-    return nullptr;  // TODO(MBkkt) Some tests doesn't work for by_terms :(
+  auto operator()(const by_terms_options& part) const {
+    return by_terms::Prepare(ctx, field, part);
   }
 
-  result_type operator()(const by_range_options& part) const {
+  auto operator()(const by_range_options& part) const {
     return by_range::prepare(ctx, field, part.range, part.scored_terms_limit);
   }
 
@@ -175,6 +202,15 @@ class phrase_term_visitor final : public filter_visitor,
   bool volatile_boost_ = false;
 };
 
+bool Valid(const term_reader* reader) noexcept {
+  static_assert(FixedPhraseQuery::kRequiredFeatures ==
+                VariadicPhraseQuery::kRequiredFeatures);
+  // check field reader exists with required features
+  return reader != nullptr && (reader->meta().index_features &
+                               FixedPhraseQuery::kRequiredFeatures) ==
+                                FixedPhraseQuery::kRequiredFeatures;
+}
+
 filter::prepared::ptr FixedPrepareCollect(const PrepareContext& ctx,
                                           std::string_view field,
                                           const by_phrase_options& options) {
@@ -198,31 +234,20 @@ filter::prepared::ptr FixedPrepareCollect(const PrepareContext& ctx,
   for (const auto& segment : ctx.index) {
     // get term dictionary for field
     const auto* reader = segment.field(field);
-
-    if (reader == nullptr) {
+    if (!Valid(reader)) {
       continue;
     }
 
-    // check required features
-    if (FixedPhraseQuery::kRequiredFeatures !=
-        (reader->meta().index_features & FixedPhraseQuery::kRequiredFeatures)) {
-      continue;
-    }
-
-    field_stats.collect(segment,
-                        *reader);  // collect field statistics once per segment
+    // collect field statistics once per segment
+    field_stats.collect(segment, *reader);
     ptv.reset(term_stats);
 
     for (const auto& word : options) {
       IRS_ASSERT(std::get_if<by_term_options>(&word.second));
       by_term::visit(segment, *reader,
                      std::get<by_term_options>(word.second).term, ptv);
-      if (!ptv.found()) {
-        if (is_ord_empty) {
-          break;
-        }
-        // continue here because we should collect
-        // stats for other terms in phrase
+      if (!ptv.found() && is_ord_empty) {
+        break;
       }
     }
 
@@ -281,9 +306,40 @@ filter::prepared::ptr VariadicPrepareCollect(const PrepareContext& ctx,
   phrase_part_visitors.reserve(phrase_size);
   std::vector<term_collectors> phrase_part_stats;
   phrase_part_stats.reserve(phrase_size);
+
+  std::vector<field_visitor*> all_terms_visitors;
+  std::vector<TopTermsCollector> top_terms_collectors;
+
   for (const auto& word : options) {
     phrase_part_stats.emplace_back(ctx.scorers, 0);
-    phrase_part_visitors.emplace_back(std::visit(GetVisitor{}, word.second));
+    auto& visitor =
+      phrase_part_visitors.emplace_back(std::visit(GetVisitor{}, word.second));
+    if (!visitor) {
+      auto& opts = std::get<by_edit_distance_options>(word.second);
+      visitor = irs::by_edit_distance::visitor(opts);
+      all_terms_visitors.push_back(&visitor);
+      top_terms_collectors.emplace_back(opts.max_terms);
+    }
+  }
+
+  if (!all_terms_visitors.empty()) {
+    // TODO(MBkkt) we should move all terms search to here
+    // And make second loop for index only to make correct order of terms
+    for (const auto& segment : ctx.index) {
+      // get term dictionary for field
+      const auto* reader = segment.field(field);
+      if (!Valid(reader)) {
+        continue;
+      }
+      auto it = top_terms_collectors.begin();
+      for (auto* visitor : all_terms_visitors) {
+        (*visitor)(segment, *reader, *it++);
+      }
+    }
+    auto it = top_terms_collectors.begin();
+    for (auto* visitor : all_terms_visitors) {
+      *visitor = it++->ToVisitor();
+    }
   }
 
   // per segment phrase states
@@ -303,46 +359,30 @@ filter::prepared::ptr VariadicPrepareCollect(const PrepareContext& ctx,
   for (const auto& segment : ctx.index) {
     // get term dictionary for field
     const auto* reader = segment.field(field);
-
-    if (reader == nullptr) {
+    if (!Valid(reader)) {
       continue;
     }
 
-    // check required features
-    if (FixedPhraseQuery::kRequiredFeatures !=
-        (reader->meta().index_features & FixedPhraseQuery::kRequiredFeatures)) {
-      continue;
-    }
-
-    ptv.reset();  // reset boost volaitility mark
-    field_stats.collect(segment, *reader);
     // collect field statistics once per segment
+    field_stats.collect(segment, *reader);
+    ptv.reset();  // reset boost volaitility mark
 
-    size_t part_offset = 0;
-    size_t found_words_count = 0;
-
+    size_t found_parts = 0;
     for (const auto& visitor : phrase_part_visitors) {
-      const auto terms_count = phrase_terms.size();
-
-      ptv.reset(phrase_part_stats[part_offset]);
+      const auto was_terms_count = phrase_terms.size();
+      ptv.reset(phrase_part_stats[found_parts]);
       visitor(segment, *reader, ptv);
-      if (!ptv.found()) {
-        if (is_ord_empty) {
-          break;
-        }
-        // continue here because we should collect
-        // stats for other terms in phrase
-      } else {
-        ++found_words_count;
+      const auto new_terms_count = phrase_terms.size() - was_terms_count;
+      // TODO(MBkkt) Avoid unnecessary work for min_match > 1 queries
+      if (new_terms_count != 0) {
+        num_terms[found_parts++] = new_terms_count;
+      } else if (is_ord_empty) {
+        break;
       }
-
-      // number of terms per phrase part
-      num_terms[part_offset] = phrase_terms.size() - terms_count;
-      ++part_offset;
     }
 
     // we have not found all needed terms
-    if (found_words_count != phrase_size) {
+    if (found_parts != phrase_size) {
       phrase_terms.clear();
       continue;
     }
@@ -367,7 +407,7 @@ filter::prepared::ptr VariadicPrepareCollect(const PrepareContext& ctx,
 
   // offset of the first term in a phrase
   IRS_ASSERT(!options.empty());
-  const size_t base_offset = options.begin()->first;
+  const auto base_offset = options.begin()->first;
 
   // finish stats
   IRS_ASSERT(phrase_size == phrase_part_stats.size());
@@ -376,15 +416,13 @@ filter::prepared::ptr VariadicPrepareCollect(const PrepareContext& ctx,
   auto collector = phrase_part_stats.begin();
 
   VariadicPhraseQuery::positions_t positions(phrase_size);
-  auto pos_itr = positions.begin();
+  auto position = positions.begin();
 
   for (const auto& term : options) {
-    *pos_itr = static_cast<position::value_t>(term.first - base_offset);
-    for (size_t term_idx = 0, size = collector->size(); term_idx < size;
-         ++term_idx) {
-      collector->finish(stats_buf, term_idx, field_stats, ctx.index);
+    *position++ = static_cast<position::value_t>(term.first - base_offset);
+    for (size_t i = 0, size = collector->size(); i < size; ++i) {
+      collector->finish(stats_buf, i, field_stats, ctx.index);
     }
-    ++pos_itr;
     ++collector;
   }
 

--- a/core/search/phrase_filter.cpp
+++ b/core/search/phrase_filter.cpp
@@ -128,7 +128,7 @@ struct PrepareVisitor : util::noncopyable {
   }
 
   auto operator()(const by_terms_options& part) const {
-    return by_terms::Prepare(ctx, field, part);
+    return filter::prepared::ptr{};
   }
 
   auto operator()(const by_range_options& part) const {
@@ -444,8 +444,9 @@ filter::prepared::ptr by_phrase::Prepare(const PrepareContext& ctx,
   if (1 == options.size()) {
     auto query =
       std::visit(PrepareVisitor{ctx, field}, options.begin()->second);
-    IRS_ASSERT(query);
-    return query;
+    if (query) {
+      return query;
+    }
   }
 
   // prepare phrase stats (collector for each term)

--- a/core/search/phrase_filter.hpp
+++ b/core/search/phrase_filter.hpp
@@ -132,7 +132,7 @@ class by_phrase_options {
   bool is_simple_term_only_{true};
 };
 
-class by_phrase : public filter_base<by_phrase_options> {
+class by_phrase : public FilterWithField<by_phrase_options> {
  public:
   static prepared::ptr Prepare(const PrepareContext& ctx,
                                std::string_view field,

--- a/core/search/phrase_filter.hpp
+++ b/core/search/phrase_filter.hpp
@@ -102,16 +102,6 @@ class by_phrase_options {
     return phrase_ == rhs.phrase_;
   }
 
-  // Returns hash value
-  size_t hash() const noexcept {
-    size_t hash = 0;
-    for (auto& part : phrase_) {
-      hash = hash_combine(hash, part.first);
-      hash = hash_combine(hash, part.second);
-    }
-    return hash;
-  }
-
   // Clear phrase contents
   void clear() noexcept {
     phrase_.clear();

--- a/core/search/phrase_filter.hpp
+++ b/core/search/phrase_filter.hpp
@@ -42,8 +42,7 @@ class by_phrase_options {
  private:
   using phrase_part =
     std::variant<by_term_options, by_prefix_options, by_wildcard_options,
-                 by_edit_distance_filter_options, by_terms_options,
-                 by_range_options>;
+                 by_edit_distance_options, by_terms_options, by_range_options>;
 
   using phrase_type = std::map<size_t, phrase_part>;
 

--- a/core/search/phrase_query.cpp
+++ b/core/search/phrase_query.cpp
@@ -107,7 +107,7 @@ doc_iterator::ptr FixedPhraseQuery::execute(const ExecutionContext& ctx) const {
 
   return memory::make_managed<FixedPhraseIterator<false, true>>(
     std::move(itrs), std::move(positions), rdr, *phrase_state->reader,
-    stats_.c_str(), ord, boost());
+    stats_.c_str(), ord, boost_);
 }
 
 doc_iterator::ptr FixedPhraseQuery::ExecuteWithOffsets(
@@ -284,13 +284,13 @@ doc_iterator::ptr VariadicPhraseQuery::execute(
     return memory::make_managed<
       VariadicPhraseIterator<Adapter, true, false, true>>(
       std::move(conj_itrs), std::move(positions), rdr, *phrase_state->reader,
-      stats_.c_str(), ord, boost());
+      stats_.c_str(), ord, boost_);
   }
 
   return memory::make_managed<
     VariadicPhraseIterator<Adapter, false, false, true>>(
     std::move(conj_itrs), std::move(positions), rdr, *phrase_state->reader,
-    stats_.c_str(), ord, boost());
+    stats_.c_str(), ord, boost_);
 }
 
 doc_iterator::ptr VariadicPhraseQuery::ExecuteWithOffsets(

--- a/core/search/prefix_filter.hpp
+++ b/core/search/prefix_filter.hpp
@@ -64,7 +64,7 @@ struct by_prefix_options : by_prefix_filter_options {
 /// @class by_prefix
 /// @brief user-side prefix filter
 ////////////////////////////////////////////////////////////////////////////////
-class by_prefix : public filter_base<by_prefix_options> {
+class by_prefix : public FilterWithField<by_prefix_options> {
  public:
   static prepared::ptr prepare(const PrepareContext& ctx,
                                std::string_view field, bytes_view prefix,
@@ -73,7 +73,7 @@ class by_prefix : public filter_base<by_prefix_options> {
   static void visit(const SubReader& segment, const term_reader& reader,
                     bytes_view prefix, filter_visitor& visitor);
 
-  filter::prepared::ptr prepare(const PrepareContext& ctx) const final {
+  prepared::ptr prepare(const PrepareContext& ctx) const final {
     auto sub_ctx = ctx;
     sub_ctx.boost *= boost();
     return prepare(sub_ctx, field(), options().term,

--- a/core/search/prefix_filter.hpp
+++ b/core/search/prefix_filter.hpp
@@ -39,8 +39,6 @@ struct by_prefix_filter_options {
   bool operator==(const by_prefix_filter_options& rhs) const noexcept {
     return term == rhs.term;
   }
-
-  size_t hash() const noexcept { return hash_utils::Hash(term); }
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -59,10 +57,6 @@ struct by_prefix_options : by_prefix_filter_options {
   bool operator==(const by_prefix_options& rhs) const noexcept {
     return filter_options::operator==(rhs) &&
            scored_terms_limit == rhs.scored_terms_limit;
-  }
-
-  size_t hash() const noexcept {
-    return hash_combine(filter_options::hash(), scored_terms_limit);
   }
 };
 
@@ -88,14 +82,3 @@ class by_prefix : public filter_base<by_prefix_options> {
 };
 
 }  // namespace irs
-
-namespace std {
-
-template<>
-struct hash<::irs::by_prefix_options> {
-  size_t operator()(const ::irs::by_prefix_options& v) const noexcept {
-    return v.hash();
-  }
-};
-
-}  // namespace std

--- a/core/search/proxy_filter.cpp
+++ b/core/search/proxy_filter.cpp
@@ -197,6 +197,7 @@ struct proxy_query_cache {
 class proxy_query : public filter::prepared {
  public:
   explicit proxy_query(proxy_filter::cache_ptr cache) : cache_{cache} {
+    IRS_ASSERT(cache_);
     IRS_ASSERT(cache_->real_filter_prepared_);
   }
 
@@ -224,6 +225,8 @@ class proxy_query : public filter::prepared {
   void visit(const SubReader&, PreparedStateVisitor&, score_t) const final {
     // No terms to visit
   }
+
+  score_t boost() const noexcept final { return kNoBoost; }
 
  private:
   proxy_filter::cache_ptr cache_;

--- a/core/search/proxy_filter.hpp
+++ b/core/search/proxy_filter.hpp
@@ -42,7 +42,7 @@ class proxy_filter final : public filter {
  public:
   using cache_ptr = std::shared_ptr<proxy_query_cache>;
 
-  filter::prepared::ptr prepare(const PrepareContext& ctx) const final;
+  prepared::ptr prepare(const PrepareContext& ctx) const final;
 
   template<typename Impl, typename Base = Impl, typename... Args>
   std::pair<Base&, cache_ptr> set_filter(IResourceManager& memory,

--- a/core/search/range_filter.hpp
+++ b/core/search/range_filter.hpp
@@ -42,8 +42,6 @@ struct by_range_filter_options {
   bool operator==(const by_range_filter_options& rhs) const noexcept {
     return range == rhs.range;
   }
-
-  size_t hash() const noexcept { return range.hash(); }
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -62,12 +60,6 @@ struct by_range_options : by_range_filter_options {
   bool operator==(const by_range_options& rhs) const noexcept {
     return filter_options::operator==(rhs) &&
            scored_terms_limit == rhs.scored_terms_limit;
-  }
-
-  size_t hash() const noexcept {
-    return hash_combine(
-      filter_options::hash(),
-      std::hash<decltype(scored_terms_limit)>()(scored_terms_limit));
   }
 };
 
@@ -93,14 +85,3 @@ class by_range : public filter_base<by_range_options> {
 };
 
 }  // namespace irs
-
-namespace std {
-
-template<>
-struct hash<::irs::by_range_options> {
-  size_t operator()(const ::irs::by_range_options& v) const noexcept {
-    return v.hash();
-  }
-};
-
-}  // namespace std

--- a/core/search/range_filter.hpp
+++ b/core/search/range_filter.hpp
@@ -67,7 +67,7 @@ struct by_range_options : by_range_filter_options {
 /// @class by_range
 /// @brief user-side term range filter
 //////////////////////////////////////////////////////////////////////////////
-class by_range : public filter_base<by_range_options> {
+class by_range : public FilterWithField<by_range_options> {
  public:
   static prepared::ptr prepare(const PrepareContext& ctx,
                                std::string_view field,
@@ -78,7 +78,7 @@ class by_range : public filter_base<by_range_options> {
                     const options_type::range_type& rng,
                     filter_visitor& visitor);
 
-  filter::prepared::ptr prepare(const PrepareContext& ctx) const final {
+  prepared::ptr prepare(const PrepareContext& ctx) const final {
     return prepare(ctx.Boost(boost()), field(), options().range,
                    options().scored_terms_limit);
   }

--- a/core/search/same_position_filter.cpp
+++ b/core/search/same_position_filter.cpp
@@ -110,7 +110,7 @@ class same_position_query : public filter::prepared {
 
   explicit same_position_query(states_t&& states, stats_t&& stats,
                                score_t boost)
-    : prepared(boost), states_(std::move(states)), stats_(std::move(stats)) {}
+    : states_{std::move(states)}, stats_{std::move(stats)}, boost_{boost} {}
 
   void visit(const SubReader&, PreparedStateVisitor&, score_t) const final {
     // FIXME(gnusi): implement
@@ -162,7 +162,7 @@ class same_position_query : public filter::prepared {
         IRS_ASSERT(score);
 
         CompileScore(*score, ord.buckets(), segment, *term_state.reader,
-                     term_stats->c_str(), *docs, boost());
+                     term_stats->c_str(), *docs, boost_);
       }
 
       // add iterator
@@ -180,9 +180,12 @@ class same_position_query : public filter::prepared {
       });
   }
 
+  score_t boost() const noexcept final { return boost_; }
+
  private:
   states_t states_;
   stats_t stats_;
+  score_t boost_;
 };
 
 }  // namespace

--- a/core/search/same_position_filter.hpp
+++ b/core/search/same_position_filter.hpp
@@ -43,13 +43,13 @@ struct by_same_position_options {
   }
 };
 
-class by_same_position : public filter_with_options<by_same_position_options> {
+class by_same_position : public FilterWithOptions<by_same_position_options> {
  public:
   // Returns features required for the filter
   static constexpr IndexFeatures kRequiredFeatures =
     IndexFeatures::FREQ | IndexFeatures::POS;
 
-  filter::prepared::ptr prepare(const PrepareContext& ctx) const final;
+  prepared::ptr prepare(const PrepareContext& ctx) const final;
 };
 
 }  // namespace irs

--- a/core/search/same_position_filter.hpp
+++ b/core/search/same_position_filter.hpp
@@ -41,15 +41,6 @@ struct by_same_position_options {
   bool operator==(const by_same_position_options& rhs) const noexcept {
     return terms == rhs.terms;
   }
-
-  size_t hash() const noexcept {
-    size_t hash = 0;
-    for (auto& term : terms) {
-      hash = hash_combine(hash, term.first);
-      hash = hash_combine(hash, term.second);
-    }
-    return hash;
-  }
 };
 
 class by_same_position : public filter_with_options<by_same_position_options> {

--- a/core/search/scorers.cpp
+++ b/core/search/scorers.cpp
@@ -47,18 +47,14 @@ struct entry_key_t {
 
 }  // namespace
 
-namespace std {
-
 template<>
-struct hash<entry_key_t> {
+struct std::hash<entry_key_t> {
   size_t operator()(const entry_key_t& value) const {
     return irs::hash_combine(
       std::hash<irs::type_info::type_id>()(value.args_format_.id()),
       irs::hash_utils::Hash(value.name_));
   }
 };
-
-}  // namespace std
 
 namespace {
 

--- a/core/search/search_range.hpp
+++ b/core/search/search_range.hpp
@@ -27,7 +27,11 @@
 
 namespace irs {
 
-enum class BoundType { UNBOUNDED, INCLUSIVE, EXCLUSIVE };
+enum class BoundType {
+  UNBOUNDED,
+  INCLUSIVE,
+  EXCLUSIVE,
+};
 
 template<typename T>
 struct search_range {
@@ -35,25 +39,6 @@ struct search_range {
   T max{};
   BoundType min_type = BoundType::UNBOUNDED;
   BoundType max_type = BoundType::UNBOUNDED;
-
-  size_t hash() const noexcept {
-    using bound_type = typename std::underlying_type_t<BoundType>;
-    const auto hash0 = [this]() {
-      size_t min_hash, max_hash;
-      if constexpr (irs::is_vector_v<T>) {
-        min_hash = irs::hash(min.data(), min.size());
-        max_hash = irs::hash(max.data(), max.size());
-      } else {
-        min_hash = std::hash<decltype(min)>()(max);
-        max_hash = std::hash<decltype(min)>()(max);
-      }
-      return hash_combine(min_hash, max_hash);
-    }();
-    const auto hash1 =
-      hash_combine(std::hash<bound_type>()(static_cast<bound_type>(min_type)),
-                   std::hash<bound_type>()(static_cast<bound_type>(max_type)));
-    return hash_combine(hash0, hash1);
-  }
 
   bool operator==(const search_range& rhs) const noexcept {
     return min == rhs.min && min_type == rhs.min_type && max == rhs.max &&

--- a/core/search/term_filter.hpp
+++ b/core/search/term_filter.hpp
@@ -39,8 +39,6 @@ struct by_term_options {
   bool operator==(const by_term_options& rhs) const noexcept {
     return term == rhs.term;
   }
-
-  size_t hash() const noexcept { return hash_utils::Hash(term); }
 };
 
 // User-side term filter
@@ -60,14 +58,3 @@ class by_term : public filter_base<by_term_options> {
 };
 
 }  // namespace irs
-
-namespace std {
-
-template<>
-struct hash<::irs::by_term_options> {
-  size_t operator()(const ::irs::by_term_options& v) const noexcept {
-    return v.hash();
-  }
-};
-
-}  // namespace std

--- a/core/search/term_filter.hpp
+++ b/core/search/term_filter.hpp
@@ -42,7 +42,7 @@ struct by_term_options {
 };
 
 // User-side term filter
-class by_term : public filter_base<by_term_options> {
+class by_term : public FilterWithField<by_term_options> {
  public:
   static prepared::ptr prepare(const PrepareContext& ctx,
                                std::string_view field, bytes_view term);

--- a/core/search/term_query.hpp
+++ b/core/search/term_query.hpp
@@ -40,9 +40,12 @@ class TermQuery : public filter::prepared {
   void visit(const SubReader& segment, PreparedStateVisitor& visitor,
              score_t boost) const final;
 
+  score_t boost() const noexcept final { return boost_; }
+
  private:
   States states_;
   bstring stats_;
+  score_t boost_;
 };
 
 }  // namespace irs

--- a/core/search/terms_filter.cpp
+++ b/core/search/terms_filter.cpp
@@ -155,7 +155,7 @@ filter::prepared::ptr by_terms::Prepare(const PrepareContext& ctx,
 
 filter::prepared::ptr by_terms::prepare(const PrepareContext& ctx) const {
   if (options().terms.empty() || options().min_match != 0) {
-    return Prepare(ctx, field(), options());
+    return Prepare(ctx.Boost(boost()), field(), options());
   }
   if (ctx.scorers.empty()) {
     return MakeAllDocsFilter(kNoBoost)->prepare({
@@ -168,6 +168,7 @@ filter::prepared::ptr by_terms::prepare(const PrepareContext& ctx) const {
   disj.add(MakeAllDocsFilter(0.F));
   // Reset min_match to 1
   auto& terms = disj.add<by_terms>();
+  terms.boost(boost());
   *terms.mutable_field() = field();
   *terms.mutable_options() = options();
   terms.mutable_options()->min_match = 1;

--- a/core/search/terms_filter.hpp
+++ b/core/search/terms_filter.hpp
@@ -70,7 +70,7 @@ struct by_terms_options {
 };
 
 // Filter by a set of terms
-class by_terms final : public filter_base<by_terms_options>,
+class by_terms final : public FilterWithField<by_terms_options>,
                        public AllDocsProvider {
  public:
   static void visit(const SubReader& segment, const term_reader& field,
@@ -79,12 +79,9 @@ class by_terms final : public filter_base<by_terms_options>,
 
   static prepared::ptr Prepare(const PrepareContext& ctx,
                                std::string_view field,
-                               const by_terms_options& options,
-                               const AllDocsProvider& provider = {});
+                               const by_terms_options& options);
 
-  prepared::ptr prepare(const PrepareContext& ctx) const final {
-    return Prepare(ctx.Boost(boost()), field(), options(), *this);
-  }
+  prepared::ptr prepare(const PrepareContext& ctx) const final;
 };
 
 }  // namespace irs

--- a/core/search/terms_filter.hpp
+++ b/core/search/terms_filter.hpp
@@ -54,10 +54,6 @@ struct by_terms_options {
     bool operator<(const search_term& rhs) const noexcept {
       return term < rhs.term;
     }
-
-    size_t hash() const noexcept {
-      return hash_combine(std::hash<decltype(boost)>()(boost), term);
-    }
   };
 
   using filter_type = by_terms;
@@ -70,14 +66,6 @@ struct by_terms_options {
   bool operator==(const by_terms_options& rhs) const noexcept {
     return min_match == rhs.min_match && merge_type == rhs.merge_type &&
            terms == rhs.terms;
-  }
-
-  size_t hash() const noexcept {
-    size_t hash = hash_combine(0, min_match);
-    for (auto& term : terms) {
-      hash = hash_combine(hash, term.hash());
-    }
-    return hash_combine(hash, merge_type);
   }
 };
 
@@ -100,14 +88,3 @@ class by_terms final : public filter_base<by_terms_options>,
 };
 
 }  // namespace irs
-
-namespace std {
-
-template<>
-struct hash<::irs::by_terms_options> {
-  size_t operator()(const ::irs::by_terms_options& v) const noexcept {
-    return v.hash();
-  }
-};
-
-}  // namespace std

--- a/core/search/wildcard_filter.cpp
+++ b/core/search/wildcard_filter.cpp
@@ -129,13 +129,13 @@ filter::prepared::ptr by_wildcard::prepare(const PrepareContext& ctx,
   bstring buf;
   return ExecuteWildcard(
     buf, term,
-    [&](bytes_view term) -> filter::prepared::ptr {
+    [&](bytes_view term) -> prepared::ptr {
       return by_term::prepare(ctx, field, term);
     },
-    [&, scored_terms_limit](bytes_view term) -> filter::prepared::ptr {
+    [&, scored_terms_limit](bytes_view term) -> prepared::ptr {
       return by_prefix::prepare(ctx, field, term, scored_terms_limit);
     },
-    [&, scored_terms_limit](bytes_view term) -> filter::prepared::ptr {
+    [&, scored_terms_limit](bytes_view term) -> prepared::ptr {
       return PrepareAutomatonFilter(ctx, field, FromWildcard(term),
                                     scored_terms_limit);
     });

--- a/core/search/wildcard_filter.hpp
+++ b/core/search/wildcard_filter.hpp
@@ -36,8 +36,6 @@ struct by_wildcard_filter_options {
   bool operator==(const by_wildcard_filter_options& rhs) const noexcept {
     return term == rhs.term;
   }
-
-  size_t hash() const noexcept { return std::hash<bstring>()(term); }
 };
 
 // Options for wildcard filter
@@ -51,10 +49,6 @@ struct by_wildcard_options : by_wildcard_filter_options {
   bool operator==(const by_wildcard_options& rhs) const noexcept {
     return filter_options::operator==(rhs) &&
            scored_terms_limit == rhs.scored_terms_limit;
-  }
-
-  size_t hash() const noexcept {
-    return hash_combine(filter_options::hash(), scored_terms_limit);
   }
 };
 
@@ -74,14 +68,3 @@ class by_wildcard final : public filter_base<by_wildcard_options> {
 };
 
 }  // namespace irs
-
-namespace std {
-
-template<>
-struct hash<::irs::by_wildcard_options> {
-  size_t operator()(const ::irs::by_wildcard_options& v) const noexcept {
-    return v.hash();
-  }
-};
-
-}  // namespace std

--- a/core/search/wildcard_filter.hpp
+++ b/core/search/wildcard_filter.hpp
@@ -53,7 +53,7 @@ struct by_wildcard_options : by_wildcard_filter_options {
 };
 
 // User-side wildcard filter
-class by_wildcard final : public filter_base<by_wildcard_options> {
+class by_wildcard final : public FilterWithField<by_wildcard_options> {
  public:
   static prepared::ptr prepare(const PrepareContext& ctx,
                                std::string_view field, bytes_view term,
@@ -61,7 +61,7 @@ class by_wildcard final : public filter_base<by_wildcard_options> {
 
   static field_visitor visitor(bytes_view term);
 
-  filter::prepared::ptr prepare(const PrepareContext& ctx) const final {
+  prepared::ptr prepare(const PrepareContext& ctx) const final {
     return prepare(ctx.Boost(boost()), field(), options().term,
                    options().scored_terms_limit);
   }

--- a/core/utils/fstext/fst_utils.hpp
+++ b/core/utils/fstext/fst_utils.hpp
@@ -24,8 +24,7 @@
 
 #include <fst/fst.h>
 
-namespace fst {
-namespace fstext {
+namespace fst::fstext {
 
 template<typename Label>
 struct EmptyLabel {
@@ -117,29 +116,22 @@ struct ILabelArc {
     : ilabel(ilabel), nextstate(nextstate) {}
 };
 
-}  // namespace fstext
-}  // namespace fst
-
-namespace std {
-
 template<typename L>
-inline void swap(typename ::fst::fstext::EmptyLabel<L>& /*lhs*/,
-                 L& rhs) noexcept {
+inline void swap(EmptyLabel<L>& /*lhs*/, L& rhs) noexcept {
   rhs = ::fst::kNoLabel;
 }
 
 template<typename L>
-inline void swap(L& lhs,
-                 typename ::fst::fstext::EmptyLabel<L>& /*rhs*/) noexcept {
+inline void swap(L& lhs, EmptyLabel<L>& /*rhs*/) noexcept {
   lhs = ::fst::kNoLabel;
 }
 
+}  // namespace fst::fstext
+
 template<typename L>
-struct hash<typename ::fst::fstext::EmptyLabel<L>> {
+struct std::hash<typename ::fst::fstext::EmptyLabel<L>> {
   constexpr size_t operator()(
     typename ::fst::fstext::EmptyLabel<L>) const noexcept {
     return 0;
   }
 };
-
-}  // namespace std

--- a/core/utils/hash_utils.hpp
+++ b/core/utils/hash_utils.hpp
@@ -91,8 +91,7 @@ struct elsa<std::string_view> {
 
 }  // namespace frozen
 
-namespace absl {
-namespace hash_internal {
+namespace absl::hash_internal {
 
 template<typename Char>
 struct HashImpl<::irs::hashed_basic_string_view<Char>> {
@@ -101,17 +100,12 @@ struct HashImpl<::irs::hashed_basic_string_view<Char>> {
   }
 };
 
-}  // namespace hash_internal
-}  // namespace absl
-
-namespace std {
+}  // namespace absl::hash_internal
 
 template<typename Char>
-struct hash<::irs::hashed_basic_string_view<Char>> {
+struct std::hash<::irs::hashed_basic_string_view<Char>> {
   size_t operator()(
     const ::irs::hashed_basic_string_view<Char>& value) const noexcept {
     return value.hash();
   }
 };
-
-}  // namespace std

--- a/core/utils/string.hpp
+++ b/core/utils/string.hpp
@@ -210,20 +210,16 @@ struct Hasher {
 }  // namespace hash_utils
 }  // namespace irs
 
-namespace std {
-
 template<>
-struct hash<::irs::bstring> {
+struct std::hash<::irs::bstring> {
   size_t operator()(const ::irs::bstring& value) const noexcept {
     return ::irs::hash_utils::Hash(value);
   }
 };
 
 template<>
-struct hash<::irs::bytes_view> {
+struct std::hash<::irs::bytes_view> {
   size_t operator()(::irs::bytes_view value) const noexcept {
     return ::irs::hash_utils::Hash(value);
   }
 };
-
-}  // namespace std

--- a/core/utils/type_info.hpp
+++ b/core/utils/type_info.hpp
@@ -87,13 +87,9 @@ class type_info {
 
 }  // namespace irs
 
-namespace std {
-
 template<>
-struct hash<::irs::type_info> {
+struct std::hash<::irs::type_info> {
   size_t operator()(const ::irs::type_info& key) const {
     return std::hash<decltype(key.id())>()(key.id());
   }
 };
-
-}  // namespace std

--- a/external/openfst/fst/matcher.h
+++ b/external/openfst/fst/matcher.h
@@ -203,7 +203,8 @@ class SortedMatcher : public MatcherBase<typename F::Arc> {
       case MATCH_NONE:
         break;
       case MATCH_OUTPUT:
-        std::swap(loop_.ilabel, loop_.olabel);
+        using std::swap;
+        swap(loop_.ilabel, loop_.olabel);
         break;
       default:
         FSTERROR() << "SortedMatcher: Bad match type";

--- a/tests/search/bm25_test.cpp
+++ b/tests/search/bm25_test.cpp
@@ -469,7 +469,7 @@ TEST_P(bm25_test_case, test_phrase) {
       irs::ViewCast<irs::byte_type>(std::string_view("ca"));
     phrase.push_back<irs::by_wildcard_options>().term =
       irs::ViewCast<irs::byte_type>(std::string_view("p_e"));
-    auto& lt = phrase.push_back<irs::by_edit_distance_filter_options>();
+    auto& lt = phrase.push_back<irs::by_edit_distance_options>();
     lt.max_distance = 1;
     lt.term = irs::ViewCast<irs::byte_type>(std::string_view("biscuit"));
     auto& ct = phrase.push_back<irs::by_terms_options>();

--- a/tests/search/boolean_filter_tests.cpp
+++ b/tests/search/boolean_filter_tests.cpp
@@ -16444,7 +16444,6 @@ TEST(Not_test, equal) {
   {
     irs::Not lhs, rhs;
     ASSERT_EQ(lhs, rhs);
-    ASSERT_EQ(lhs.hash(), rhs.hash());
   }
 
   {
@@ -16454,7 +16453,6 @@ TEST(Not_test, equal) {
     irs::Not rhs;
     rhs.filter<irs::by_term>() = make_filter<irs::by_term>("abc", "def");
     ASSERT_EQ(lhs, rhs);
-    ASSERT_EQ(lhs.hash(), rhs.hash());
   }
 
   {
@@ -16507,7 +16505,6 @@ TEST(And_test, equal) {
     }
 
     ASSERT_EQ(lhs, rhs);
-    ASSERT_EQ(lhs.hash(), rhs.hash());
   }
 
   {
@@ -16691,7 +16688,6 @@ TEST(Or_test, equal) {
     }
 
     ASSERT_EQ(lhs, rhs);
-    ASSERT_EQ(lhs.hash(), rhs.hash());
   }
 
   {

--- a/tests/search/boolean_filter_tests.cpp
+++ b/tests/search/boolean_filter_tests.cpp
@@ -15625,7 +15625,7 @@ TEST_P(boolean_filter_test_case, or_sequential) {
   {
     irs::Or root;
     append<irs::by_term>(root, "name", "A");  // 1
-    root.add<irs::empty>();
+    root.add<irs::Empty>();
 
     CheckQuery(root, Docs{1}, rdr);
   }
@@ -15635,7 +15635,7 @@ TEST_P(boolean_filter_test_case, or_sequential) {
     irs::Or root;
     root.add<irs::Not>().filter<irs::by_term>() =
       make_filter<irs::by_term>("name", "A");  // 1
-    root.add<irs::empty>();
+    root.add<irs::Empty>();
 
     CheckQuery(
       root, Docs{2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17,
@@ -16760,9 +16760,9 @@ TEST(Or_test, optimize_all_unscored) {
     node.docs = {3};
   }
   root.add<irs::all>();
-  root.add<irs::empty>();
+  root.add<irs::Empty>();
   root.add<irs::all>();
-  root.add<irs::empty>();
+  root.add<irs::Empty>();
 
   auto prep = root.prepare({.index = irs::SubReader::empty()});
 
@@ -16787,9 +16787,9 @@ TEST(Or_test, optimize_all_scored) {
     node.docs = {3};
   }
   root.add<irs::all>();
-  root.add<irs::empty>();
+  root.add<irs::Empty>();
   root.add<irs::all>();
-  root.add<irs::empty>();
+  root.add<irs::Empty>();
   tests::sort::boost sort{};
   auto pord = irs::Scorers::Prepare(sort);
   auto prep = root.prepare({.index = irs::SubReader::empty(), .scorers = pord});

--- a/tests/search/column_existence_filter_test.cpp
+++ b/tests/search/column_existence_filter_test.cpp
@@ -1165,7 +1165,6 @@ TEST(by_column_existence, equal) {
     irs::by_column_existence q0 = make_filter("name", false);
     irs::by_column_existence q1 = make_filter("name", false);
     ASSERT_EQ(q0, q1);
-    ASSERT_EQ(q0.hash(), q1.hash());
   }
 
   {

--- a/tests/search/empty_filter_tests.cpp
+++ b/tests/search/empty_filter_tests.cpp
@@ -40,7 +40,7 @@ TEST_P(empty_filter_test_case, empty) {
 
   std::vector<irs::cost::cost_t> cost{0};
 
-  CheckQuery(irs::empty(), Docs{}, cost, rdr);
+  CheckQuery(irs::Empty{}, Docs{}, cost, rdr);
 }
 
 static constexpr auto kTestDirs = tests::getDirectories<tests::kTypesDefault>();

--- a/tests/search/granular_range_filter_tests.cpp
+++ b/tests/search/granular_range_filter_tests.cpp
@@ -1723,7 +1723,6 @@ TEST(by_granular_range_test, equal) {
   q1.mutable_options()->range.max_type = irs::BoundType::INCLUSIVE;
 
   ASSERT_EQ(q0, q1);
-  ASSERT_EQ(q0.hash(), q1.hash());
 
   irs::by_granular_range q2;
   *q2.mutable_field() = "field1";

--- a/tests/search/levenshtein_filter_test.cpp
+++ b/tests/search/levenshtein_filter_test.cpp
@@ -935,7 +935,7 @@ TEST_P(by_edit_distance_test_case, visit) {
   ASSERT_NE(nullptr, reader);
 
   {
-    irs::by_edit_distance_filter_options opts;
+    irs::by_edit_distance_options opts;
     opts.term = term;
     opts.max_distance = 0;
     opts.provider = nullptr;
@@ -954,7 +954,7 @@ TEST_P(by_edit_distance_test_case, visit) {
   }
 
   {
-    irs::by_edit_distance_filter_options opts;
+    irs::by_edit_distance_options opts;
     opts.term = term;
     opts.max_distance = 1;
     opts.provider = irs::default_pdp;
@@ -987,7 +987,7 @@ TEST_P(by_edit_distance_test_case, visit) {
 
   // with prefix
   {
-    irs::by_edit_distance_filter_options opts;
+    irs::by_edit_distance_options opts;
     opts.term = irs::ViewCast<irs::byte_type>(std::string_view("c"));
     opts.max_distance = 2;
     opts.provider = irs::default_pdp;

--- a/tests/search/nested_filter_test.cpp
+++ b/tests/search/nested_filter_test.cpp
@@ -1144,7 +1144,7 @@ TEST_P(NestedFilterTestCase, JoinNone2) {
 
   irs::ByNestedFilter filter;
   auto& opts = *filter.mutable_options();
-  opts.child = std::make_unique<irs::empty>();
+  opts.child = std::make_unique<irs::Empty>();
   opts.parent = MakeParentProvider("customer");
   opts.match = irs::kMatchNone;
   filter.boost(1.f);
@@ -1205,7 +1205,7 @@ TEST_P(NestedFilterTestCase, JoinNone3) {
 
   irs::ByNestedFilter filter;
   auto& opts = *filter.mutable_options();
-  opts.child = std::make_unique<irs::empty>();
+  opts.child = std::make_unique<irs::Empty>();
 
   // Bitset iterator doesn't provide score, check that wrapper works correctly
   opts.parent = [word = irs::bitset::word_t{}](

--- a/tests/search/nested_filter_test.cpp
+++ b/tests/search/nested_filter_test.cpp
@@ -228,19 +228,16 @@ TEST(NestedFilterTest, CheckOptions) {
     ASSERT_NE(nullptr, std::get_if<irs::Match>(&opts.match));
     ASSERT_EQ(irs::kMatchAny, std::get<irs::Match>(opts.match));
     ASSERT_EQ(opts, irs::ByNestedOptions{});
-    ASSERT_EQ(opts.hash(), irs::ByNestedOptions{}.hash());
   }
 
   {
     const auto opts0 = MakeOptions("parent", "child", "442");
     const auto opts1 = MakeOptions("parent", "child", "442");
     ASSERT_EQ(opts0, opts1);
-    ASSERT_EQ(opts0.hash(), opts1.hash());
 
     // We discount parent providers from equality comparison
     const auto opts2 = MakeOptions("parent42", "child", "442");
     ASSERT_EQ(opts0, opts2);
-    ASSERT_EQ(opts0.hash(), opts2.hash());
 
     ASSERT_NE(opts0, MakeOptions("parent", "child", "443"));
     ASSERT_NE(opts0,

--- a/tests/search/phrase_filter_tests.cpp
+++ b/tests/search/phrase_filter_tests.cpp
@@ -8730,7 +8730,6 @@ TEST(by_phrase_test, equal) {
     q1.mutable_options()->push_back<irs::by_term_options>().term =
       irs::ViewCast<irs::byte_type>(std::string_view("brown"));
     ASSERT_EQ(q0, q1);
-    ASSERT_EQ(q0.hash(), q1.hash());
   }
 
   {
@@ -8785,7 +8784,6 @@ TEST(by_phrase_test, equal) {
     }
 
     ASSERT_EQ(q0, q1);
-    ASSERT_EQ(q0.hash(), q1.hash());
   }
 
   {
@@ -8929,11 +8927,9 @@ TEST(by_phrase_test, copy_move) {
 
     irs::by_phrase q1 = q0;
     ASSERT_EQ(q0, q1);
-    ASSERT_EQ(q0.hash(), q1.hash());
     irs::by_phrase q2 = q0;
     irs::by_phrase q3 = std::move(q2);
     ASSERT_EQ(q0, q3);
-    ASSERT_EQ(q0.hash(), q3.hash());
   }
 }
 

--- a/tests/search/phrase_filter_tests.cpp
+++ b/tests/search/phrase_filter_tests.cpp
@@ -1199,8 +1199,7 @@ TEST_P(phrase_filter_test_case, sequential_one_term) {
   {
     irs::by_phrase q;
     *q.mutable_field() = "phrase_anl";
-    auto& lt =
-      q.mutable_options()->push_back<irs::by_edit_distance_filter_options>();
+    auto& lt = q.mutable_options()->push_back<irs::by_edit_distance_options>();
     lt.max_distance = 0;
     lt.term = irs::ViewCast<irs::byte_type>(std::string_view("fox"));
 
@@ -1323,8 +1322,7 @@ TEST_P(phrase_filter_test_case, sequential_one_term) {
   {
     irs::by_phrase q;
     *q.mutable_field() = "phrase_anl";
-    auto& lt =
-      q.mutable_options()->push_back<irs::by_edit_distance_filter_options>();
+    auto& lt = q.mutable_options()->push_back<irs::by_edit_distance_options>();
     lt.max_distance = 1;
     lt.term = irs::ViewCast<irs::byte_type>(std::string_view("fol"));
 
@@ -2424,8 +2422,7 @@ TEST_P(phrase_filter_test_case, sequential_one_term) {
   {
     irs::by_phrase q;
     *q.mutable_field() = "phrase";
-    auto& lt =
-      q.mutable_options()->push_back<irs::by_edit_distance_filter_options>();
+    auto& lt = q.mutable_options()->push_back<irs::by_edit_distance_options>();
     lt.max_distance = 1;
     lt.with_transpositions = true;
     lt.term = irs::ViewCast<irs::byte_type>(std::string_view("fxo"));
@@ -3121,9 +3118,8 @@ TEST_P(phrase_filter_test_case, sequential_one_term) {
   {
     irs::by_phrase q;
     *q.mutable_field() = "phrase_anl";
-    auto& lt =
-      q.mutable_options()->push_back<irs::by_edit_distance_filter_options>(
-        std::numeric_limits<size_t>::max());
+    auto& lt = q.mutable_options()->push_back<irs::by_edit_distance_options>(
+      std::numeric_limits<size_t>::max());
     lt.max_distance = 1;
     lt.term = irs::ViewCast<irs::byte_type>(std::string_view("fkx"));
 
@@ -3598,8 +3594,7 @@ TEST_P(phrase_filter_test_case, sequential_three_terms) {
   {
     irs::by_phrase q;
     *q.mutable_field() = "phrase_anl";
-    auto& lt =
-      q.mutable_options()->push_back<irs::by_edit_distance_filter_options>();
+    auto& lt = q.mutable_options()->push_back<irs::by_edit_distance_options>();
     lt.max_distance = 0;
     lt.term = irs::ViewCast<irs::byte_type>(std::string_view("quick"));
     q.mutable_options()->push_back<irs::by_term_options>().term =
@@ -3662,8 +3657,7 @@ TEST_P(phrase_filter_test_case, sequential_three_terms) {
   {
     irs::by_phrase q;
     *q.mutable_field() = "phrase_anl";
-    auto& lt =
-      q.mutable_options()->push_back<irs::by_edit_distance_filter_options>();
+    auto& lt = q.mutable_options()->push_back<irs::by_edit_distance_options>();
     lt.max_distance = 1;
     lt.term = irs::ViewCast<irs::byte_type>(std::string_view("quck"));
     q.mutable_options()->push_back<irs::by_term_options>().term =
@@ -3974,8 +3968,7 @@ TEST_P(phrase_filter_test_case, sequential_three_terms) {
     *q.mutable_field() = "phrase_anl";
     q.mutable_options()->push_back<irs::by_term_options>().term =
       irs::ViewCast<irs::byte_type>(std::string_view("quick"));
-    auto& lt =
-      q.mutable_options()->push_back<irs::by_edit_distance_filter_options>();
+    auto& lt = q.mutable_options()->push_back<irs::by_edit_distance_options>();
     lt.max_distance = 2;
     lt.term = irs::ViewCast<irs::byte_type>(std::string_view("brkln"));
     q.mutable_options()->push_back<irs::by_term_options>().term =
@@ -4290,8 +4283,7 @@ TEST_P(phrase_filter_test_case, sequential_three_terms) {
       irs::ViewCast<irs::byte_type>(std::string_view("quick"));
     q.mutable_options()->push_back<irs::by_term_options>().term =
       irs::ViewCast<irs::byte_type>(std::string_view("brown"));
-    auto& lt =
-      q.mutable_options()->push_back<irs::by_edit_distance_filter_options>();
+    auto& lt = q.mutable_options()->push_back<irs::by_edit_distance_options>();
     lt.max_distance = 1;
     lt.with_transpositions = true;
     lt.term = irs::ViewCast<irs::byte_type>(std::string_view("fxo"));
@@ -4644,12 +4636,10 @@ TEST_P(phrase_filter_test_case, sequential_three_terms) {
   {
     irs::by_phrase q;
     *q.mutable_field() = "phrase_anl";
-    auto& lt1 =
-      q.mutable_options()->push_back<irs::by_edit_distance_filter_options>();
+    auto& lt1 = q.mutable_options()->push_back<irs::by_edit_distance_options>();
     lt1.max_distance = 2;
     lt1.term = irs::ViewCast<irs::byte_type>(std::string_view("qui"));
-    auto& lt2 =
-      q.mutable_options()->push_back<irs::by_edit_distance_filter_options>();
+    auto& lt2 = q.mutable_options()->push_back<irs::by_edit_distance_options>();
     lt2.max_distance = 1;
     lt2.term = irs::ViewCast<irs::byte_type>(std::string_view("brow"));
     q.mutable_options()->push_back<irs::by_term_options>().term =
@@ -5066,14 +5056,12 @@ TEST_P(phrase_filter_test_case, sequential_three_terms) {
   {
     irs::by_phrase q;
     *q.mutable_field() = "phrase_anl";
-    auto& lt1 =
-      q.mutable_options()->push_back<irs::by_edit_distance_filter_options>();
+    auto& lt1 = q.mutable_options()->push_back<irs::by_edit_distance_options>();
     lt1.max_distance = 1;
     lt1.term = irs::ViewCast<irs::byte_type>(std::string_view("qoick"));
     auto& wt = q.mutable_options()->push_back<irs::by_wildcard_options>();
     wt.term = irs::ViewCast<irs::byte_type>(std::string_view("br__n"));
-    auto& lt2 =
-      q.mutable_options()->push_back<irs::by_edit_distance_filter_options>();
+    auto& lt2 = q.mutable_options()->push_back<irs::by_edit_distance_options>();
     lt2.max_distance = 1;
     lt2.term = irs::ViewCast<irs::byte_type>(std::string_view("fix"));
 
@@ -6226,8 +6214,7 @@ TEST_P(phrase_filter_test_case, sequential_several_terms) {
   {
     irs::by_phrase q;
     *q.mutable_field() = "phrase_anl";
-    auto& lt =
-      q.mutable_options()->push_back<irs::by_edit_distance_filter_options>();
+    auto& lt = q.mutable_options()->push_back<irs::by_edit_distance_options>();
     lt.max_distance = 1;
     lt.term = irs::ViewCast<irs::byte_type>(std::string_view("fpx"));
     q.mutable_options()->push_back<irs::by_term_options>(1).term =
@@ -6473,10 +6460,9 @@ TEST_P(phrase_filter_test_case, sequential_several_terms) {
   {
     irs::by_phrase q;
     *q.mutable_field() = "phrase_anl";
-    auto& lt1 =
-      q.mutable_options()->push_back<irs::by_edit_distance_filter_options>();
+    auto& lt1 = q.mutable_options()->push_back<irs::by_edit_distance_options>();
     auto& lt2 =
-      q.mutable_options()->push_back<irs::by_edit_distance_filter_options>(1);
+      q.mutable_options()->push_back<irs::by_edit_distance_options>(1);
     lt1.max_distance = 1;
     lt1.term = irs::ViewCast<irs::byte_type>(std::string_view("fx"));
     lt2.max_distance = 1;
@@ -6528,10 +6514,9 @@ TEST_P(phrase_filter_test_case, sequential_several_terms) {
   {
     irs::by_phrase q;
     *q.mutable_field() = "phrase_anl";
-    auto& lt1 =
-      q.mutable_options()->push_back<irs::by_edit_distance_filter_options>();
+    auto& lt1 = q.mutable_options()->push_back<irs::by_edit_distance_options>();
     auto& lt2 =
-      q.mutable_options()->push_back<irs::by_edit_distance_filter_options>(1);
+      q.mutable_options()->push_back<irs::by_edit_distance_options>(1);
     lt1.max_distance = 1;
     lt1.term = irs::ViewCast<irs::byte_type>(std::string_view("fx"));
     lt2.max_distance = 1;
@@ -7641,8 +7626,7 @@ TEST_P(phrase_filter_test_case, sequential_several_terms) {
     *q.mutable_field() = "phrase_anl";
     auto& wt = q.mutable_options()->push_back<irs::by_wildcard_options>(
       std::numeric_limits<size_t>::max());
-    auto& lt =
-      q.mutable_options()->push_back<irs::by_edit_distance_filter_options>(1);
+    auto& lt = q.mutable_options()->push_back<irs::by_edit_distance_options>(1);
     wt.term = irs::ViewCast<irs::byte_type>(std::string_view("fo%"));
     lt.max_distance = 1;
     lt.term = irs::ViewCast<irs::byte_type>(std::string_view("quik"));
@@ -7757,7 +7741,7 @@ TEST_P(phrase_filter_test_case, sequential_several_terms) {
     q.mutable_options()->push_back<irs::by_term_options>().term =
       irs::ViewCast<irs::byte_type>(std::string_view("fox"));
     auto& lt =
-      q.mutable_options()->push_back<irs::by_edit_distance_filter_options>(10);
+      q.mutable_options()->push_back<irs::by_edit_distance_options>(10);
     lt.max_distance = 2;
     lt.term = irs::ViewCast<irs::byte_type>(std::string_view("quc"));
 
@@ -7868,8 +7852,7 @@ TEST_P(phrase_filter_test_case, sequential_several_terms) {
   {
     irs::by_phrase q;
     *q.mutable_field() = "phrase_anl";
-    auto& lt =
-      q.mutable_options()->push_back<irs::by_edit_distance_filter_options>();
+    auto& lt = q.mutable_options()->push_back<irs::by_edit_distance_options>();
     lt.max_distance = 2;
     lt.term = irs::ViewCast<irs::byte_type>(std::string_view("ass"));
     q.mutable_options()->push_back<irs::by_term_options>().term =
@@ -8529,7 +8512,7 @@ TEST(by_phrase_test, boost) {
       auto& wt = q.mutable_options()->push_back<irs::by_wildcard_options>();
       wt.term = irs::ViewCast<irs::byte_type>(std::string_view("qu__k"));
       auto& lt =
-        q.mutable_options()->push_back<irs::by_edit_distance_filter_options>();
+        q.mutable_options()->push_back<irs::by_edit_distance_options>();
       lt.max_distance = 1;
       lt.term = irs::ViewCast<irs::byte_type>(std::string_view("brwn"));
       q.boost(boost);
@@ -8601,11 +8584,11 @@ TEST(by_phrase_test, push_back_insert) {
       ASSERT_TRUE(wt2);
       ASSERT_EQ(wt1, *wt2);
 
-      irs::by_edit_distance_filter_options lt1;
+      irs::by_edit_distance_options lt1;
       lt1.term = irs::ViewCast<irs::byte_type>(std::string_view("whale"));
       q.push_back(lt1, 0);
-      const irs::by_edit_distance_filter_options* lt2 =
-        q.get<irs::by_edit_distance_filter_options>(7);
+      const irs::by_edit_distance_options* lt2 =
+        q.get<irs::by_edit_distance_options>(7);
       ASSERT_TRUE(lt2);
       ASSERT_EQ(lt1, *lt2);
 
@@ -8695,11 +8678,11 @@ TEST(by_phrase_test, push_back_insert) {
       ASSERT_EQ(wt1, *wt2);
       ASSERT_EQ(10, q.size());
 
-      irs::by_edit_distance_filter_options lt1;
+      irs::by_edit_distance_options lt1;
       lt1.term = irs::ViewCast<irs::byte_type>(std::string_view("whale"));
       q.insert(lt1, 29);
-      const irs::by_edit_distance_filter_options* lt2 =
-        q.get<irs::by_edit_distance_filter_options>(29);
+      const irs::by_edit_distance_options* lt2 =
+        q.get<irs::by_edit_distance_options>(29);
       ASSERT_TRUE(lt2);
       ASSERT_EQ(lt1, *lt2);
       ASSERT_EQ(11, q.size());
@@ -8764,7 +8747,7 @@ TEST(by_phrase_test, equal) {
       auto& wt1 = q0.mutable_options()->push_back<irs::by_wildcard_options>();
       wt1.term = irs::ViewCast<irs::byte_type>(std::string_view("br_wn"));
       auto& lt1 =
-        q0.mutable_options()->push_back<irs::by_edit_distance_filter_options>();
+        q0.mutable_options()->push_back<irs::by_edit_distance_options>();
       lt1.max_distance = 2;
       lt1.term = irs::ViewCast<irs::byte_type>(std::string_view("fo"));
       auto& rt1 = q0.mutable_options()->push_back<irs::by_range_options>();
@@ -8789,7 +8772,7 @@ TEST(by_phrase_test, equal) {
       auto& wt1 = q1.mutable_options()->push_back<irs::by_wildcard_options>();
       wt1.term = irs::ViewCast<irs::byte_type>(std::string_view("br_wn"));
       auto& lt1 =
-        q1.mutable_options()->push_back<irs::by_edit_distance_filter_options>();
+        q1.mutable_options()->push_back<irs::by_edit_distance_options>();
       lt1.max_distance = 2;
       lt1.term = irs::ViewCast<irs::byte_type>(std::string_view("fo"));
       auto& rt1 = q1.mutable_options()->push_back<irs::by_range_options>();
@@ -8868,7 +8851,7 @@ TEST(by_phrase_test, equal) {
       auto& wt1 = q0.mutable_options()->push_back<irs::by_wildcard_options>();
       wt1.term = irs::ViewCast<irs::byte_type>(std::string_view("br_wn"));
       auto& lt1 =
-        q0.mutable_options()->push_back<irs::by_edit_distance_filter_options>();
+        q0.mutable_options()->push_back<irs::by_edit_distance_options>();
       lt1.max_distance = 2;
       lt1.term = irs::ViewCast<irs::byte_type>(std::string_view("fo"));
       auto& rt1 = q0.mutable_options()->push_back<irs::by_range_options>();
@@ -8893,7 +8876,7 @@ TEST(by_phrase_test, equal) {
       auto& wt1 = q1.mutable_options()->push_back<irs::by_wildcard_options>();
       wt1.term = irs::ViewCast<irs::byte_type>(std::string_view("br_wn"));
       auto& lt1 =
-        q1.mutable_options()->push_back<irs::by_edit_distance_filter_options>();
+        q1.mutable_options()->push_back<irs::by_edit_distance_options>();
       lt1.max_distance = 2;
       lt1.term = irs::ViewCast<irs::byte_type>(std::string_view("fo"));
       auto& rt1 = q1.mutable_options()->push_back<irs::by_range_options>();
@@ -8920,7 +8903,7 @@ TEST(by_phrase_test, copy_move) {
     ct.terms.emplace(irs::ViewCast<irs::byte_type>(std::string_view("dark")));
     irs::by_wildcard_options wt;
     wt.term = irs::ViewCast<irs::byte_type>(std::string_view("br_wn"));
-    irs::by_edit_distance_filter_options lt;
+    irs::by_edit_distance_options lt;
     lt.max_distance = 2;
     lt.term = irs::ViewCast<irs::byte_type>(std::string_view("fo"));
     irs::by_range_options rt;

--- a/tests/search/prefix_filter_test.cpp
+++ b/tests/search/prefix_filter_test.cpp
@@ -284,7 +284,6 @@ TEST(by_prefix_test, equal) {
     irs::by_prefix q = make_filter("field", "term");
 
     ASSERT_EQ(q, make_filter("field", "term"));
-    ASSERT_EQ(q.hash(), make_filter("field", "term").hash());
     ASSERT_NE(q, make_filter("field1", "term"));
     ASSERT_NE(q, make_filter("field", "term", 100));
   }
@@ -293,7 +292,6 @@ TEST(by_prefix_test, equal) {
     irs::by_prefix q = make_filter("field", "term", 100);
 
     ASSERT_EQ(q, make_filter("field", "term", 100));
-    ASSERT_EQ(q.hash(), make_filter("field", "term", 100).hash());
     ASSERT_NE(q, make_filter("field1", "term", 100));
     ASSERT_NE(q, make_filter("field", "term"));
   }

--- a/tests/search/proxy_filter_test.cpp
+++ b/tests/search/proxy_filter_test.cpp
@@ -95,7 +95,7 @@ class doclist_test_iterator : public doc_iterator, private util::noncopyable {
 class doclist_test_query : public filter::prepared {
  public:
   doclist_test_query(const std::vector<doc_id_t>& documents, score_t)
-    : documents_(documents){};
+    : documents_(documents) {}
 
   doc_iterator::ptr execute(const ExecutionContext&) const final {
     ++executes_;
@@ -105,6 +105,8 @@ class doclist_test_query : public filter::prepared {
   void visit(const SubReader&, PreparedStateVisitor&, score_t) const final {
     // No terms to visit
   }
+
+  irs::score_t boost() const noexcept final { return kNoBoost; }
 
   static size_t get_execs() noexcept { return executes_; }
 

--- a/tests/search/range_filter_test.cpp
+++ b/tests/search/range_filter_test.cpp
@@ -1167,7 +1167,6 @@ TEST(by_range_test, equal) {
   q1.mutable_options()->range.max_type = irs::BoundType::INCLUSIVE;
 
   ASSERT_EQ(q0, q1);
-  ASSERT_EQ(q0.hash(), q1.hash());
 
   irs::by_range q2;
   *q2.mutable_field() = "field1";

--- a/tests/search/terms_filter_test.cpp
+++ b/tests/search/terms_filter_test.cpp
@@ -64,7 +64,6 @@ TEST(by_terms_test, equal) {
   const irs::by_terms q1 =
     make_filter("field", {{"bar", 0.5f}, {"baz", 0.25f}});
   ASSERT_EQ(q0, q1);
-  ASSERT_EQ(q0.hash(), q1.hash());
 
   const irs::by_terms q2 =
     make_filter("field1", {{"bar", 0.5f}, {"baz", 0.25f}});
@@ -80,7 +79,6 @@ TEST(by_terms_test, equal) {
   irs::by_terms q5 = make_filter("field", {{"bar", 0.5f}, {"baz", 0.25f}});
   q5.mutable_options()->min_match = 2;
   ASSERT_NE(q0, q5);
-  ASSERT_NE(q0.hash(), q5.hash());
 }
 
 class terms_filter_test_case : public tests::FilterTestCaseBase {};

--- a/tests/search/tfidf_test.cpp
+++ b/tests/search/tfidf_test.cpp
@@ -467,7 +467,7 @@ TEST_P(tfidf_test_case, test_phrase) {
       irs::ViewCast<irs::byte_type>(std::string_view("ca"));
     phrase.push_back<irs::by_wildcard_options>().term =
       irs::ViewCast<irs::byte_type>(std::string_view("p_e"));
-    auto& lt = phrase.push_back<irs::by_edit_distance_filter_options>();
+    auto& lt = phrase.push_back<irs::by_edit_distance_options>();
     lt.max_distance = 1;
     lt.term = irs::ViewCast<irs::byte_type>(std::string_view("biscuit"));
     auto& ct = phrase.push_back<irs::by_terms_options>();


### PR DESCRIPTION
* Phrase with levenshtein couldn't account terms_limit
* filter hash was very bad and unnecessary
* Formal UB with define swap in std-namespace
* Avoid boost in base classes: filter/prepared (they're unnecessary in this place and their moving out allow to decrease sizeof of removes in arangodb, which is important)
* phrase allow by_terms only with min_match >= 1