### PR TITLE
fix compile warning

### DIFF
--- a/core/analysis/multi_delimited_token_stream.cpp
+++ b/core/analysis/multi_delimited_token_stream.cpp
@@ -85,7 +85,7 @@ class MultiDelimitedTokenStreamSingleCharsBase
  public:
   auto FindNextDelim() {
     auto where = static_cast<Derived*>(this)->FindNextDelim();
-    return std::make_pair(where, 1);
+    return std::make_pair(where, size_t{1});
   }
 };
 


### PR DESCRIPTION
core/analysis/multi_delimited_token_stream.cpp:58:25: warning: comparison of integers of different signs: 'std::tuple_element<1, std::pair<const unsigned char *, int>>::type' (aka 'int') and 'size_type' (aka 'unsigned long') [-Wsign-compare]
        IRS_ASSERT(skip <= data.size());